### PR TITLE
chore(release): v0.108.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.108.0] - 2026-08-22
 
 ### Added
 - **A bundled catalog of public AMIs, so an AMI discovered through SSM is an AMI that
@@ -9053,7 +9053,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.107.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.108.0...HEAD
+[v0.108.0]: https://github.com/scttfrdmn/substrate/compare/v0.107.0...v0.108.0
 [v0.107.0]: https://github.com/scttfrdmn/substrate/compare/v0.106.0...v0.107.0
 [v0.106.0]: https://github.com/scttfrdmn/substrate/compare/v0.105.0...v0.106.0
 [v0.105.0]: https://github.com/scttfrdmn/substrate/compare/v0.104.0...v0.105.0


### PR DESCRIPTION
Dates the `## [Unreleased]` section as `## [v0.108.0] - 2026-08-22` and adds its comparison
link. No code changes.

Milestone 93 held five issues, all filed from the live SDK runs that closed v0.107.0 — real
`aws` CLI calls against a built binary — and all five are resolved:

- #734 — one server serves one account, resolved from one place, configurable (#740)
- #733 — a bundled AMI catalog, and a launch refuses an AMI that is malformed or names nothing (#741)
- #731 — a volume or AMI ID that names nothing is an error (#742)
- #732 — a block device mapping can only name a completed snapshot (#743)
- #730 — the bundled policies' condition keys (#751)

Closes #730, closes #731, closes #732, closes #733, closes #734.