### PR TITLE
docs(changelog): the account compatibility note belongs to #734, not #731

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   switches SigV4 enforcement on and would 403 substrate's own documented credentials — the
   decoupling is #630.
 
+  **Compatibility.** Every ARN returned to an unsigned or non-`AKIA` caller changes account, so
+  a fixture asserting on `000000000000` now sees `123456789012`. Several plugins prefix their
+  state keys with the account (`table:{account}/{name}`, `instance:{account}/{id}`), so
+  **persisted SQLite state written under the old account is unreachable** after upgrading:
+  re-seed it, or set `account.default: "000000000000"` to read it back.
+
 - **EventBridge is reachable from a real SDK** (#734). Found while verifying the above with the
   `aws` CLI: **every** EventBridge call answered `ServiceNotAvailable: service not emulated:
   awsevents`. The target prefix in EventBridge's model is `AWSEvents`, not `AmazonEventBridge`,
@@ -241,12 +247,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reason — `DescribeFleets`' `FleetId.N` and `DescribeRegions`' `RegionName.N` are permanent
   declines (AWS publishes no `InvalidFleetId.NotFound`, and `RegionName.N` explicitly permits
   naming any Region), while the other five are unimplemented rather than declined.
-
-  **Compatibility.** Every ARN returned to an unsigned or non-`AKIA` caller changes account, so
-  a fixture asserting on `000000000000` now sees `123456789012`. Several plugins prefix their
-  state keys with the account (`table:{account}/{name}`, `instance:{account}/{id}`), so
-  **persisted SQLite state written under the old account is unreachable** after upgrading:
-  re-seed it, or set `account.default: "000000000000"` to read it back.
 
 - **A grant written about `ec2:ResourceTag/<key>` no longer silently fails** (#730). Two of the
   bundled AWS-authored managed policies scope an EC2 delete by tag under EC2's own prefix


### PR DESCRIPTION
Noticed while drafting the v0.108.0 release notes from the merged CHANGELOG.

The Compatibility paragraph about every ARN changing account — and about persisted SQLite state
written under the old account becoming unreachable — was nested under the **#731**
"Two documentation claims that were wrong" bullet, three entries below the **#734** entry it
actually describes. It reads as guidance about a doc-comment fix, which is the one thing it is
not.

It landed there because #734's PR and #731's PR each appended to the same `### Fixed` section
and the paragraph ended up after the wrong bullet. Moved to the end of the #734 entry, directly
after the deliberately-not-covered list. No wording change; nothing else in the section moves.

The v0.108.0 tag and Release are untouched — the Release notes were drafted with the paragraph
attributed correctly, so this only fixes the CHANGELOG a reader following the Release's anchor
link lands on.