### PR TITLE
fix(dynamodb,eventbridge,lambda,cloudtrail,wafv2): publish the member names AWS publishes (#738)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Nine response members were published under a name no AWS SDK reads** (#738). A Go `json`
+  tag is only a bug when three things hold at once — the plugin's protocol serializes Go tags,
+  the struct actually reaches a response body, and AWS spells the member differently — so every
+  one of these was checked against the member name in the official API reference rather than
+  swept mechanically. Of 158 candidate tag lines, 24 turned out to be cases where AWS really
+  does publish the capitalized form: the bare spelling `ARN` appears on 16 lines and is correct
+  on 15 of them (Secrets Manager, SSM, WAFv2's Web ACL, CloudFront and ElastiCache all publish
+  `ARN`), and FSx genuinely publishes `ResourceARN` and `DNSName`. A blanket `ARN` → `Arn`
+  rename would have broken six correct fields to fix one.
+
+  The nine that were wrong, per service:
+  - DynamoDB — `TableArn`, `LatestStreamArn`, and `IndexArn` on both the global and the local
+    secondary-index descriptor. A real SDK decoded all four as nil, so a consumer reading
+    `TableArn` got an empty string and no error. `StackDeployer`'s own decode of substrate's
+    `CreateTable` response is fixed in the same commit, or it would have stopped recording table
+    ARNs the moment the tag changed.
+  - EventBridge — a rule's `Arn`. `PutRule`, which wraps the same value under `RuleArn`, was
+    already correct and is unchanged.
+  - Lambda — an event-source mapping's `FunctionArn` and `EventSourceArn`. The lowercase
+    `eventSourceARN` inside a stream-record event payload is a different and correct spelling,
+    and is untouched.
+  - CloudTrail — `KmsKeyId`, and the log-file-validation flag, which every response publishes as
+    `LogFileValidationEnabled`; `EnableLogFileValidation` is `CreateTrail`'s and `UpdateTrail`'s
+    *input* name, and the input parsing still reads it. A trail's own `TrailARN` is correct.
+  - WAFv2 — an IP set's `IPAddressVersion`.
+
+- **`CreateIPSet` honors the IP address version the caller asked for** (#738). WAFv2's wrong
+  member name was used to *parse* the request as well as to render the response, so a typed
+  SDK — which can only send `IPAddressVersion` — had its `IPV6` request read as absent and
+  silently replaced by substrate's `IPV4` default. The set was created successfully holding the
+  wrong address family, so a consumer's error branch never ran. This is why the fix is a
+  behaviour change and not only a rendering one.
+
+  The real-SDK tier had no DynamoDB or WAFv2 client at all, which is exactly how both defects
+  stayed green through every release: the unit tier asserts on substrate's own spelling, and only
+  a typed SDK can decide whether a member decodes. `test/e2e` gains a journey that creates a
+  table with a stream and a GSI and reads all three ARNs off the SDK's `TableDescription`, plus a
+  `CreateIPSet`/`GetIPSet` round-trip asserting an IPv6 set stays IPv6; both fail against the
+  previous code. The e2e module gains the `dynamodb` and `wafv2` clients, which requires
+  `aws-sdk-go-v2` v1.43.7 there.
+
 ## [v0.108.0] - 2026-08-22
 
 ### Added

--- a/emulator/cfn_deployer.go
+++ b/emulator/cfn_deployer.go
@@ -3090,7 +3090,9 @@ func (d *StackDeployer) deployDynamoDBTable(
 	} else if resp != nil {
 		var result struct {
 			TableDescription struct {
-				TableARN string `json:"TableARN"`
+				// TableArn is DynamoDB's published member name, and must track the
+				// tag on DynamoDBTable.TableARN or this decode silently reads empty.
+				TableARN string `json:"TableArn"`
 			} `json:"TableDescription"`
 		}
 		if jsonErr := json.Unmarshal(resp.Body, &result); jsonErr == nil {

--- a/emulator/cloudtrail_plugin.go
+++ b/emulator/cloudtrail_plugin.go
@@ -108,7 +108,7 @@ func (p *CloudTrailPlugin) createTrail(reqCtx *RequestContext, req *AWSRequest) 
 		S3KeyPrefix:                input.S3KeyPrefix,
 		IncludeGlobalServiceEvents: input.IncludeGlobalServiceEvents,
 		IsMultiRegionTrail:         input.IsMultiRegionTrail,
-		EnableLogFileValidation:    input.EnableLogFileValidation,
+		LogFileValidationEnabled:   input.EnableLogFileValidation,
 		CloudWatchLogsLogGroupArn:  input.CloudWatchLogsLogGroupArn,
 		CloudWatchLogsRoleArn:      input.CloudWatchLogsRoleArn,
 		KMSKeyID:                   input.KMSKeyID,
@@ -216,7 +216,7 @@ func (p *CloudTrailPlugin) updateTrail(reqCtx *RequestContext, req *AWSRequest) 
 		trail.IsMultiRegionTrail = *input.IsMultiRegionTrail
 	}
 	if input.EnableLogFileValidation != nil {
-		trail.EnableLogFileValidation = *input.EnableLogFileValidation
+		trail.LogFileValidationEnabled = *input.EnableLogFileValidation
 	}
 	if input.CloudWatchLogsLogGroupArn != "" {
 		trail.CloudWatchLogsLogGroupArn = input.CloudWatchLogsLogGroupArn

--- a/emulator/cloudtrail_types.go
+++ b/emulator/cloudtrail_types.go
@@ -17,14 +17,17 @@ type CloudTrailTrail struct {
 	IncludeGlobalServiceEvents bool `json:"IncludeGlobalServiceEvents"`
 	// IsMultiRegionTrail specifies whether the trail is multi-region.
 	IsMultiRegionTrail bool `json:"IsMultiRegionTrail"`
-	// EnableLogFileValidation specifies whether log file validation is enabled.
-	EnableLogFileValidation bool `json:"EnableLogFileValidation"`
+	// LogFileValidationEnabled specifies whether log file validation is enabled.
+	// EnableLogFileValidation is CreateTrail's and UpdateTrail's *input* name; every
+	// response publishes the setting as LogFileValidationEnabled.
+	LogFileValidationEnabled bool `json:"LogFileValidationEnabled"`
 	// CloudWatchLogsLogGroupArn is the ARN of the CloudWatch Logs log group.
 	CloudWatchLogsLogGroupArn string `json:"CloudWatchLogsLogGroupArn,omitempty"`
 	// CloudWatchLogsRoleArn is the ARN of the IAM role for CloudWatch Logs delivery.
 	CloudWatchLogsRoleArn string `json:"CloudWatchLogsRoleArn,omitempty"`
-	// KMSKeyID is the ARN or alias of the KMS key used for encryption.
-	KMSKeyID string `json:"KMSKeyId,omitempty"`
+	// KMSKeyID is the ARN or alias of the KMS key used for encryption. CloudTrail
+	// publishes it as KmsKeyId, while the trail's own ARN really is TrailARN.
+	KMSKeyID string `json:"KmsKeyId,omitempty"`
 	// TrailARN is the Amazon Resource Name of the trail.
 	TrailARN string `json:"TrailARN"`
 	// HomeRegion is the region where the trail was originally created.

--- a/emulator/dynamodb_plugin_test.go
+++ b/emulator/dynamodb_plugin_test.go
@@ -98,7 +98,7 @@ func TestDynamoDB_TableLifecycle(t *testing.T) {
 	desc := createResult["TableDescription"].(map[string]any)
 	assert.Equal(t, "Users", desc["TableName"])
 	assert.Equal(t, "ACTIVE", desc["TableStatus"])
-	assert.Contains(t, desc["TableARN"].(string), "arn:aws:dynamodb")
+	assert.Contains(t, desc["TableArn"].(string), "arn:aws:dynamodb")
 
 	// Describe table.
 	resp = dynamodbRequest(t, srv, "DescribeTable", map[string]any{
@@ -745,8 +745,8 @@ func TestDynamoDB_Streams(t *testing.T) {
 	var createResult map[string]any
 	decodeDynamoJSON(t, resp, &createResult)
 	desc := createResult["TableDescription"].(map[string]any)
-	assert.NotEmpty(t, desc["LatestStreamARN"])
-	streamARN := desc["LatestStreamARN"].(string)
+	assert.NotEmpty(t, desc["LatestStreamArn"])
+	streamARN := desc["LatestStreamArn"].(string)
 
 	// ListStreams — should include our table's stream.
 	resp = dynamodbRequest(t, srv, "ListStreams", map[string]any{

--- a/emulator/dynamodb_streams_test.go
+++ b/emulator/dynamodb_streams_test.go
@@ -47,7 +47,7 @@ func TestDynamoDBStreams_GetShardIteratorAndRecords(t *testing.T) {
 	var createResult map[string]any
 	decodeDynamoDB(t, createResp, &createResult)
 	tableDesc, _ := createResult["TableDescription"].(map[string]any)
-	streamARN, _ := tableDesc["LatestStreamARN"].(string)
+	streamARN, _ := tableDesc["LatestStreamArn"].(string)
 	if streamARN == "" {
 		t.Skip("stream ARN not set; skipping stream test")
 	}
@@ -165,7 +165,7 @@ func TestDynamoDBStreams_DeleteItemRecord(t *testing.T) {
 	var dtResult map[string]any
 	decodeDynamoDB(t, dtResp, &dtResult)
 	tbl, _ := dtResult["Table"].(map[string]any)
-	streamARN, _ := tbl["LatestStreamARN"].(string)
+	streamARN, _ := tbl["LatestStreamArn"].(string)
 	if streamARN == "" {
 		t.Skip("stream ARN not populated; skipping")
 	}

--- a/emulator/dynamodb_types.go
+++ b/emulator/dynamodb_types.go
@@ -47,8 +47,9 @@ type DynamoDBTable struct {
 	// TableName is the name of the table.
 	TableName string `json:"TableName"`
 
-	// TableARN is the Amazon Resource Name of the table.
-	TableARN string `json:"TableARN"`
+	// TableARN is the Amazon Resource Name of the table. DynamoDB publishes it as
+	// TableArn; see the TableDescription API reference.
+	TableARN string `json:"TableArn"`
 
 	// TableStatus is the current table status (always "ACTIVE" in this emulator).
 	TableStatus string `json:"TableStatus"`
@@ -77,8 +78,9 @@ type DynamoDBTable struct {
 	// StreamSpecification holds the Streams configuration.
 	StreamSpecification *DynamoDBStreamSpecification `json:"StreamSpecification,omitempty"`
 
-	// LatestStreamARN is the ARN of the latest stream, if enabled.
-	LatestStreamARN string `json:"LatestStreamARN,omitempty"`
+	// LatestStreamARN is the ARN of the latest stream, if enabled. DynamoDB publishes
+	// it as LatestStreamArn.
+	LatestStreamARN string `json:"LatestStreamArn,omitempty"`
 
 	// TableSizeBytes is estimated as ItemCount×100.
 	TableSizeBytes int64 `json:"TableSizeBytes"`
@@ -152,8 +154,8 @@ type DynamoDBGlobalSecondaryIndexDesc struct {
 	// ProvisionedThroughput holds read/write capacity for this GSI.
 	ProvisionedThroughput DynamoDBProvisionedThroughputDesc `json:"ProvisionedThroughput"`
 
-	// IndexARN is the Amazon Resource Name of the GSI.
-	IndexARN string `json:"IndexARN,omitempty"`
+	// IndexARN is the Amazon Resource Name of the GSI. DynamoDB publishes it as IndexArn.
+	IndexARN string `json:"IndexArn,omitempty"`
 }
 
 // DynamoDBLocalSecondaryIndexDesc describes a local secondary index on a table.
@@ -167,8 +169,8 @@ type DynamoDBLocalSecondaryIndexDesc struct {
 	// Projection describes which attributes are projected into the index.
 	Projection DynamoDBProjection `json:"Projection"`
 
-	// IndexARN is the Amazon Resource Name of the LSI.
-	IndexARN string `json:"IndexARN,omitempty"`
+	// IndexARN is the Amazon Resource Name of the LSI. DynamoDB publishes it as IndexArn.
+	IndexARN string `json:"IndexArn,omitempty"`
 }
 
 // DynamoDBProjection specifies which attributes are projected into an index.

--- a/emulator/eventbridge_types.go
+++ b/emulator/eventbridge_types.go
@@ -8,8 +8,10 @@ type EBRule struct {
 	// Name is the name of the rule.
 	Name string `json:"Name"`
 
-	// ARN is the Amazon Resource Name for the rule.
-	ARN string `json:"ARN,omitempty"`
+	// ARN is the Amazon Resource Name for the rule. EventBridge publishes it as Arn
+	// on the Rule type, which DescribeRule and ListRules render; PutRule wraps the
+	// same value under RuleArn.
+	ARN string `json:"Arn,omitempty"`
 
 	// EventPattern is the JSON event pattern the rule matches.
 	EventPattern string `json:"EventPattern,omitempty"`

--- a/emulator/lambda_plugin.go
+++ b/emulator/lambda_plugin.go
@@ -1095,11 +1095,14 @@ type ESMConfig struct {
 	// UUID is the unique identifier for this event source mapping.
 	UUID string `json:"UUID"`
 
-	// FunctionARN is the Lambda function that will receive events.
-	FunctionARN string `json:"FunctionARN"`
+	// FunctionARN is the Lambda function that will receive events. Lambda publishes it
+	// as FunctionArn on EventSourceMappingConfiguration.
+	FunctionARN string `json:"FunctionArn"`
 
 	// EventSourceARN is the ARN of the event source (DynamoDB stream or Kinesis stream).
-	EventSourceARN string `json:"EventSourceARN"`
+	// Lambda publishes it as EventSourceArn. The lowercase eventSourceARN used in a
+	// stream record's event payload is a different, and correct, spelling.
+	EventSourceARN string `json:"EventSourceArn"`
 
 	// BatchSize is the maximum number of records in each batch.
 	BatchSize int `json:"BatchSize"`

--- a/emulator/v030_coverage_test.go
+++ b/emulator/v030_coverage_test.go
@@ -169,7 +169,7 @@ func TestDynamoDBStreams_UpdateItemRecord(t *testing.T) {
 	var dtResult map[string]any
 	decodeDynamoDB(t, dtResp, &dtResult)
 	tbl, _ := dtResult["Table"].(map[string]any)
-	streamARN, _ := tbl["LatestStreamARN"].(string)
+	streamARN, _ := tbl["LatestStreamArn"].(string)
 	if streamARN == "" {
 		t.Skip("stream ARN not populated; skipping")
 	}

--- a/emulator/wafv2_plugin.go
+++ b/emulator/wafv2_plugin.go
@@ -419,11 +419,11 @@ func (p *WAFv2Plugin) getWebACLForResource(reqCtx *RequestContext, req *AWSReque
 
 func (p *WAFv2Plugin) createIPSet(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	var input struct {
-		Name        string   `json:"Name"`
-		Scope       string   `json:"Scope"`
-		Description string   `json:"Description"`
-		IPVersion   string   `json:"IPVersion"`
-		Addresses   []string `json:"Addresses"`
+		Name             string   `json:"Name"`
+		Scope            string   `json:"Scope"`
+		Description      string   `json:"Description"`
+		IPAddressVersion string   `json:"IPAddressVersion"`
+		Addresses        []string `json:"Addresses"`
 	}
 	if len(req.Body) > 0 {
 		if err := json.Unmarshal(req.Body, &input); err != nil {
@@ -436,8 +436,8 @@ func (p *WAFv2Plugin) createIPSet(reqCtx *RequestContext, req *AWSRequest) (*AWS
 	if input.Scope == "" {
 		input.Scope = "REGIONAL"
 	}
-	if input.IPVersion == "" {
-		input.IPVersion = "IPV4"
+	if input.IPAddressVersion == "" {
+		input.IPAddressVersion = "IPV4"
 	}
 	if input.Addresses == nil {
 		input.Addresses = []string{}
@@ -448,16 +448,16 @@ func (p *WAFv2Plugin) createIPSet(reqCtx *RequestContext, req *AWSRequest) (*AWS
 	arn := fmt.Sprintf("arn:aws:wafv2:%s:%s:regional/ipset/%s/%s", reqCtx.Region, reqCtx.AccountID, input.Name, id)
 
 	ipset := WAFv2IPSet{
-		ID:          id,
-		Name:        input.Name,
-		ARN:         arn,
-		Description: input.Description,
-		Scope:       input.Scope,
-		LockToken:   lockToken,
-		IPVersion:   input.IPVersion,
-		Addresses:   input.Addresses,
-		AccountID:   reqCtx.AccountID,
-		Region:      reqCtx.Region,
+		ID:               id,
+		Name:             input.Name,
+		ARN:              arn,
+		Description:      input.Description,
+		Scope:            input.Scope,
+		LockToken:        lockToken,
+		IPAddressVersion: input.IPAddressVersion,
+		Addresses:        input.Addresses,
+		AccountID:        reqCtx.AccountID,
+		Region:           reqCtx.Region,
 	}
 
 	data, err := json.Marshal(ipset)

--- a/emulator/wafv2_plugin_test.go
+++ b/emulator/wafv2_plugin_test.go
@@ -359,16 +359,100 @@ func TestWAFv2Plugin_AssociateGetWebACLForResource(t *testing.T) {
 	}
 }
 
+// TestWAFv2Plugin_IPSet_AddressVersionRoundTrips pins the member name WAFv2 actually
+// publishes. CreateIPSet reads IPAddressVersion, not IPVersion; reading the wrong name
+// made an SDK's IPV6 request silently fall through to the IPV4 default (#738).
+func TestWAFv2Plugin_IPSet_AddressVersionRoundTrips(t *testing.T) {
+	tests := []struct {
+		name    string
+		request map[string]any
+		want    string
+	}{
+		{
+			name: "IPV6 is honored",
+			request: map[string]any{
+				"Name":             "v6-set",
+				"Scope":            "REGIONAL",
+				"IPAddressVersion": "IPV6",
+				"Addresses":        []string{"2001:db8::/32"},
+			},
+			want: "IPV6",
+		},
+		{
+			name: "IPV4 is honored",
+			request: map[string]any{
+				"Name":             "v4-set",
+				"Scope":            "REGIONAL",
+				"IPAddressVersion": "IPV4",
+				"Addresses":        []string{"192.0.2.0/24"},
+			},
+			want: "IPV4",
+		},
+		{
+			name: "an omitted version still defaults to IPV4",
+			request: map[string]any{
+				"Name":      "default-set",
+				"Scope":     "REGIONAL",
+				"Addresses": []string{"192.0.2.0/24"},
+			},
+			want: "IPV4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, ctx := setupWAFv2Plugin(t)
+
+			resp, err := p.HandleRequest(ctx, wafv2Request(t, "CreateIPSet", tt.request))
+			if err != nil {
+				t.Fatalf("CreateIPSet: %v", err)
+			}
+			var created struct {
+				Summary struct {
+					Id string `json:"Id"` //nolint:revive
+				} `json:"Summary"`
+			}
+			if err := json.Unmarshal(resp.Body, &created); err != nil {
+				t.Fatalf("unmarshal create: %v", err)
+			}
+
+			resp, err = p.HandleRequest(ctx, wafv2Request(t, "GetIPSet", map[string]any{
+				"Id":    created.Summary.Id,
+				"Name":  tt.request["Name"],
+				"Scope": "REGIONAL",
+			}))
+			if err != nil {
+				t.Fatalf("GetIPSet: %v", err)
+			}
+
+			// Decoded through a raw map so the assertion is against the wire name a
+			// real SDK reads, not against substrate's Go field.
+			var got struct {
+				IPSet map[string]any `json:"IPSet"`
+			}
+			if err := json.Unmarshal(resp.Body, &got); err != nil {
+				t.Fatalf("unmarshal get: %v", err)
+			}
+			if _, ok := got.IPSet["IPVersion"]; ok {
+				t.Error("IPSet renders IPVersion, which WAFv2 does not publish")
+			}
+			if got.IPSet["IPAddressVersion"] != tt.want {
+				t.Errorf("want IPAddressVersion=%q, got %v", tt.want, got.IPSet["IPAddressVersion"])
+			}
+		})
+	}
+}
+
 func TestWAFv2Plugin_IPSet_CRUD(t *testing.T) {
 	p, ctx := setupWAFv2Plugin(t)
 
 	// Create IPSet.
 	resp, err := p.HandleRequest(ctx, wafv2Request(t, "CreateIPSet", map[string]any{
-		"Name":        "my-ipset",
-		"Scope":       "REGIONAL",
-		"Description": "test ip set",
-		"IPVersion":   "IPV4",
-		"Addresses":   []string{"192.168.0.0/16"},
+		"Name":             "my-ipset",
+		"Scope":            "REGIONAL",
+		"Description":      "test ip set",
+		"IPAddressVersion": "IPV4",
+		"Addresses":        []string{"192.168.0.0/16"},
 	}))
 	if err != nil {
 		t.Fatalf("CreateIPSet: %v", err)

--- a/emulator/wafv2_types.go
+++ b/emulator/wafv2_types.go
@@ -47,8 +47,9 @@ type WAFv2IPSet struct {
 	Scope string `json:"Scope"`
 	// LockToken is a CAS token required for update and delete operations.
 	LockToken string `json:"LockToken"`
-	// IPVersion is the IP address version: IPV4 or IPV6.
-	IPVersion string `json:"IPVersion"`
+	// IPAddressVersion is the IP address version: IPV4 or IPV6. WAFv2 publishes and
+	// accepts it under this name; the IPSet type's ARN really is ARN.
+	IPAddressVersion string `json:"IPAddressVersion"`
 	// Addresses is the list of IP addresses or CIDR ranges in the set.
 	Addresses []string `json:"Addresses"`
 	// AccountID is the AWS account that owns this IP set.

--- a/emulator/wire_names_738_test.go
+++ b/emulator/wire_names_738_test.go
@@ -1,0 +1,199 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// requireWireNames asserts that body publishes each wanted member and none of the rejected
+// spellings. Decoding into a raw map is the point: a typed struct would read whatever tag
+// substrate happens to carry, which is exactly how #738's nine wrong names stayed green.
+func requireWireNames(t *testing.T, what string, body map[string]any, want, reject []string) {
+	t.Helper()
+	for _, name := range want {
+		if _, ok := body[name]; !ok {
+			t.Errorf("%s: does not publish %q", what, name)
+		}
+	}
+	for _, name := range reject {
+		if _, ok := body[name]; ok {
+			t.Errorf("%s: publishes %q, which AWS does not", what, name)
+		}
+	}
+}
+
+// TestCloudTrail_WireNames pins the two members CloudTrail spells differently from substrate's
+// Go fields (#738). EnableLogFileValidation is CreateTrail's and UpdateTrail's *input* name —
+// every response publishes the setting as LogFileValidationEnabled — and the key is KmsKeyId,
+// not KMSKeyId. A real SDK read both as absent, so a caller could not tell validation was on.
+func TestCloudTrail_WireNames(t *testing.T) {
+	p, ctx := setupCloudTrailPlugin(t)
+	const kmsKey = "arn:aws:kms:us-east-1:123456789012:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+
+	resp, err := p.HandleRequest(ctx, cloudtrailRequest(t, "CreateTrail", map[string]any{
+		"Name":                    "wire-trail",
+		"S3BucketName":            "wire-bucket",
+		"EnableLogFileValidation": true,
+		"KmsKeyId":                kmsKey,
+	}))
+	if err != nil {
+		t.Fatalf("CreateTrail: %v", err)
+	}
+	var created map[string]any
+	if err := json.Unmarshal(resp.Body, &created); err != nil {
+		t.Fatalf("unmarshal CreateTrail: %v", err)
+	}
+	requireWireNames(t, "CreateTrail",
+		created,
+		[]string{"LogFileValidationEnabled", "KmsKeyId", "TrailARN"},
+		[]string{"EnableLogFileValidation", "KMSKeyId"},
+	)
+	if created["LogFileValidationEnabled"] != true {
+		t.Errorf("CreateTrail: LogFileValidationEnabled = %v, want true — the input was not read",
+			created["LogFileValidationEnabled"])
+	}
+	if created["KmsKeyId"] != kmsKey {
+		t.Errorf("CreateTrail: KmsKeyId = %v, want %q", created["KmsKeyId"], kmsKey)
+	}
+
+	// GetTrail nests the same shape, so the tag has to be right in both places.
+	resp, err = p.HandleRequest(ctx, cloudtrailRequest(t, "GetTrail", map[string]any{
+		"Name": "wire-trail",
+	}))
+	if err != nil {
+		t.Fatalf("GetTrail: %v", err)
+	}
+	var got struct {
+		Trail map[string]any `json:"Trail"`
+	}
+	if err := json.Unmarshal(resp.Body, &got); err != nil {
+		t.Fatalf("unmarshal GetTrail: %v", err)
+	}
+	requireWireNames(t, "GetTrail",
+		got.Trail,
+		[]string{"LogFileValidationEnabled", "KmsKeyId"},
+		[]string{"EnableLogFileValidation", "KMSKeyId"},
+	)
+	if got.Trail["LogFileValidationEnabled"] != true {
+		t.Errorf("GetTrail: LogFileValidationEnabled = %v, want true", got.Trail["LogFileValidationEnabled"])
+	}
+
+	// UpdateTrail still reads the input name, and turning validation off must be observable.
+	resp, err = p.HandleRequest(ctx, cloudtrailRequest(t, "UpdateTrail", map[string]any{
+		"Name":                    "wire-trail",
+		"EnableLogFileValidation": false,
+	}))
+	if err != nil {
+		t.Fatalf("UpdateTrail: %v", err)
+	}
+	var updated map[string]any
+	if err := json.Unmarshal(resp.Body, &updated); err != nil {
+		t.Fatalf("unmarshal UpdateTrail: %v", err)
+	}
+	if updated["LogFileValidationEnabled"] != false {
+		t.Errorf("UpdateTrail: LogFileValidationEnabled = %v, want false",
+			updated["LogFileValidationEnabled"])
+	}
+}
+
+// TestEB_RuleWireNames pins a rule's ARN member (#738). EventBridge publishes it as Arn on the
+// Rule type; PutRule wraps the same value under RuleArn, which was already correct.
+func TestEB_RuleWireNames(t *testing.T) {
+	srv := newEBTestServer(t)
+
+	putResp := ebRequest(t, srv, "PutRule", map[string]string{
+		"Name":               "wire-rule",
+		"ScheduleExpression": "rate(5 minutes)",
+		"State":              "ENABLED",
+	})
+	if putResp.StatusCode != http.StatusOK {
+		t.Fatalf("PutRule: got %d", putResp.StatusCode)
+	}
+	var put map[string]any
+	if err := json.Unmarshal(ebReadBody(t, putResp), &put); err != nil {
+		t.Fatalf("unmarshal PutRule: %v", err)
+	}
+	requireWireNames(t, "PutRule", put, []string{"RuleArn"}, []string{"RuleARN"})
+
+	describeResp := ebRequest(t, srv, "DescribeRule", map[string]string{"Name": "wire-rule"})
+	var described map[string]any
+	if err := json.Unmarshal(ebReadBody(t, describeResp), &described); err != nil {
+		t.Fatalf("unmarshal DescribeRule: %v", err)
+	}
+	requireWireNames(t, "DescribeRule", described, []string{"Arn"}, []string{"ARN"})
+	arn, _ := described["Arn"].(string)
+	if !strings.HasPrefix(arn, "arn:aws:events:") {
+		t.Errorf("DescribeRule: Arn = %q, want an arn:aws:events: prefix", arn)
+	}
+
+	listResp := ebRequest(t, srv, "ListRules", map[string]string{})
+	var listed struct {
+		Rules []map[string]any `json:"Rules"`
+	}
+	if err := json.Unmarshal(ebReadBody(t, listResp), &listed); err != nil {
+		t.Fatalf("unmarshal ListRules: %v", err)
+	}
+	if len(listed.Rules) != 1 {
+		t.Fatalf("ListRules: want 1 rule, got %d", len(listed.Rules))
+	}
+	requireWireNames(t, "ListRules", listed.Rules[0], []string{"Arn"}, []string{"ARN"})
+}
+
+// TestLambdaESM_WireNames pins the two ARN members on an EventSourceMappingConfiguration
+// (#738). Lambda publishes FunctionArn and EventSourceArn; the lowercase eventSourceARN in a
+// stream record's event payload is a different, and correct, spelling and is untouched.
+func TestLambdaESM_WireNames(t *testing.T) {
+	srv := newLambdaTestServer(t)
+
+	createResp := lambdaRequest(t, srv, http.MethodPost, "/2015-03-31/functions", map[string]any{
+		"FunctionName": "wire-fn",
+		"Runtime":      "python3.12",
+		"Role":         "arn:aws:iam::123456789012:role/lambda-role",
+		"Handler":      "index.handler",
+		"Code":         map[string]any{"ZipFile": "Zm9v"},
+	})
+	if createResp.StatusCode != http.StatusCreated {
+		t.Fatalf("CreateFunction: got %d body: %s", createResp.StatusCode, readBody(t, createResp))
+	}
+	createResp.Body.Close() //nolint:errcheck
+
+	const sourceARN = "arn:aws:kinesis:us-east-1:123456789012:stream/wire-stream"
+	esmResp := lambdaRequest(t, srv, http.MethodPost, "/2015-03-31/event-source-mappings/", map[string]any{
+		"FunctionName":     "wire-fn",
+		"EventSourceArn":   sourceARN,
+		"StartingPosition": "TRIM_HORIZON",
+	})
+	if esmResp.StatusCode != http.StatusCreated {
+		t.Fatalf("CreateEventSourceMapping: got %d body: %s", esmResp.StatusCode, readBody(t, esmResp))
+	}
+	var created map[string]any
+	decodeLambdaJSON(t, esmResp, &created)
+	requireWireNames(t, "CreateEventSourceMapping",
+		created,
+		[]string{"UUID", "FunctionArn", "EventSourceArn"},
+		[]string{"FunctionARN", "EventSourceARN"},
+	)
+	if created["EventSourceArn"] != sourceARN {
+		t.Errorf("CreateEventSourceMapping: EventSourceArn = %v, want %q",
+			created["EventSourceArn"], sourceARN)
+	}
+	fnARN, _ := created["FunctionArn"].(string)
+	if !strings.HasPrefix(fnARN, "arn:aws:lambda:") {
+		t.Errorf("CreateEventSourceMapping: FunctionArn = %q, want an arn:aws:lambda: prefix", fnARN)
+	}
+
+	uuid, _ := created["UUID"].(string)
+	getResp := lambdaRequest(t, srv, http.MethodGet, "/2015-03-31/event-source-mappings/"+uuid, nil)
+	if getResp.StatusCode != http.StatusOK {
+		t.Fatalf("GetEventSourceMapping: got %d body: %s", getResp.StatusCode, readBody(t, getResp))
+	}
+	var got map[string]any
+	decodeLambdaJSON(t, getResp, &got)
+	requireWireNames(t, "GetEventSourceMapping",
+		got,
+		[]string{"FunctionArn", "EventSourceArn"},
+		[]string{"FunctionARN", "EventSourceARN"},
+	)
+}

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -5,18 +5,20 @@ go 1.26
 toolchain go1.26.6
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.43.6
+	github.com/aws/aws-sdk-go-v2 v1.43.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.37
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.36
 	github.com/aws/aws-sdk-go-v2/service/account v1.35.6
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.76.3
 	github.com/aws/aws-sdk-go-v2/service/configservice v1.68.6
+	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.63.4
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.321.2
 	github.com/aws/aws-sdk-go-v2/service/iam v1.59.1
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.53.8
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.2
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.37.6
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.6
+	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.77.7
 	github.com/aws/smithy-go v1.27.8
 	github.com/scttfrdmn/substrate v0.0.0
 	github.com/spf13/afero v1.15.0
@@ -26,11 +28,12 @@ require (
 require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.18 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.37 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.37 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.37 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.38 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.38 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.38 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.30 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.37 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.38 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.5.6 // indirect

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -1,5 +1,5 @@
-github.com/aws/aws-sdk-go-v2 v1.43.6 h1:RrmFcqCBxkJuf7g1axVo5krB4jM/AO8r5e5oujrgdoQ=
-github.com/aws/aws-sdk-go-v2 v1.43.6/go.mod h1:tXpPM+v0D1lndmga+HqqLDIzUFJlEeR21aspVklHF00=
+github.com/aws/aws-sdk-go-v2 v1.43.7 h1:msCzvkeYJA9ehbV8mRRmkZLo/zJg/+yDVLNtflg83hQ=
+github.com/aws/aws-sdk-go-v2 v1.43.7/go.mod h1:tXpPM+v0D1lndmga+HqqLDIzUFJlEeR21aspVklHF00=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.18 h1:LAfOuhAH331fmOjTQpAaOlH+Ftn7RzSDJ2VFwjdMMy4=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.18/go.mod h1:4e5xhuXHx1e4U9EthvbPP1r/DIMp5c2823OL8karzcM=
 github.com/aws/aws-sdk-go-v2/config v1.32.37 h1:Ljl7LOJB6ym0liuEl0+TZ3d7f5I8MEZN1Cj9PINlj/g=
@@ -8,10 +8,10 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.36 h1:84s5xMme6ENYEdKG8rsbSFFg/8+
 github.com/aws/aws-sdk-go-v2/credentials v1.19.36/go.mod h1:c46BLdagDLIswjgt+GeQOslXgeS0E6wCacs5yZbxPGk=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.37 h1:b5tb+CZItBkydC7r3hTNdSO3pszG1R2EtnA+7TePQPk=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.37/go.mod h1:ZQ+6SU9X0oz6+7MUCSswv9Mjci4eaqZr21HI2RVy/yA=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.37 h1:lznzIOvvbqjfe8UAaciCRJgBgJsxuTROKlhZuXQWfv8=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.37/go.mod h1:otfkzyfQeMMLZAqX59GSXTL3o22BR/l6HFaRzzbWSqA=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.37 h1:zCEORWo0eU0gDjG+IyApE/2B+ZGG1m+GU7B263XV8ds=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.37/go.mod h1:i6c0PEl3TNOWxRbQ++KQcVenPWS/GoQeiklKhNuqzJ8=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.38 h1:MBMg0zJ6i4TkAJ0dVFLKKn2cOkY6FkicmUDM67BRr6g=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.38/go.mod h1:9MWuJbyiUyj6eA7W1/zm1zuePDPSB3g+xcgRQeMWsXc=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.38 h1:lHm4jPf3k1Lz5ZWc+Vcn3MKVwym+26kWCba9FkJ4f0Y=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.38/go.mod h1:Rn+P2XR+FbyZzjmWKjg/KUZNxmGfr5oZwh5jQiE+CzI=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.38 h1:A3UAuCmx7LyUcrixBTzKJYYIUZ2yTvn6ZhT8PB+7APk=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.38/go.mod h1:1PDUYG9Z+JrbbsobsAZHjWOm9QBT/djiK3QbykTL5Z4=
 github.com/aws/aws-sdk-go-v2/service/account v1.35.6 h1:mObt+amlHneRU0jyyCIRb6vyV3kjLqhUMKbFveX365g=
@@ -20,6 +20,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudformation v1.76.3 h1:FjNSXIPC9bbvVRh67
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.76.3/go.mod h1:yQcvrM5JfBihExrlz+2k7W6mBEM6xexhWT8eHr0akzs=
 github.com/aws/aws-sdk-go-v2/service/configservice v1.68.6 h1:8xf8QK6jZ5K/qvmHYUyRYuPVwMPR0FfGXMbtfn5hQqA=
 github.com/aws/aws-sdk-go-v2/service/configservice v1.68.6/go.mod h1:z2ZuTbi9wofbMt8Fy6y2De9+4xoghaKeV2XDyYoKIVs=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.63.4 h1:po1aTwrJKV0sLaPzvOmHlW9J9VL/4Z3M2gZFbH8t9cY=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.63.4/go.mod h1:zLWRn5gabNbj8VT59XrgICjxlCtKeb8XUx4KrLhV01M=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.321.2 h1:jcHDG5dFHYfpGUfEKmBbG8XtJHcJinqLpiIsjz2c4Uw=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.321.2/go.mod h1:0YYJ+4BAgeIkRucGTesOdWnVnxhodrwWo6+lJ6Wmndg=
 github.com/aws/aws-sdk-go-v2/service/iam v1.59.1 h1:Dr7wQQgyc9YVkIR6AWIOSWuOFZ6A0K2jFL6Ld6uJQ1E=
@@ -28,6 +30,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.17 h1:OvYZOB
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.17/go.mod h1:JgR/2Ew50ACfIWau1oeMRX59tMtC0kM+PYQGEaT04cY=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.30 h1:5437eMoOwqqQpZn2XJy74mlDCuPYL81texMT3mXqgtU=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.30/go.mod h1:xfu2m3dOpvW8lj98wQYa8V9ku/Rta59hsbireGzhh3A=
+github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.15 h1:I8tIqh7tQ5GxYwgEsN57V/dYNCDr/2u9a77nE3htie4=
+github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.15/go.mod h1:cIYnGuVFa0DBY0Mq4/VPPcD9GdvYHBdMwHK3HE5RDRc=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.37 h1:a3D4AjrOrTrP8+d9ILBthqrElf0z1JNol09Xvnwcys8=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.37/go.mod h1:ky0gTu+ukvUTuUKFIpp6Wid4oninrkCyvbFkVs0kpHM=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.38 h1:gX8B8y3Ho30B1LPxefDKMi/HZqWEb47U9ogs3DtSG0M=
@@ -46,6 +50,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.6 h1:49BBtY68A+KJCQ3a2F3eUe6R
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.6/go.mod h1:ptG2hbs7QltE1GcQY0MpS4bfrc51KCnBXUr7OT1EEfE=
 github.com/aws/aws-sdk-go-v2/service/sts v1.45.6 h1:JvExZWabChDM0qJAirQYGfOYo0ndT3edXj+fqSPNjkE=
 github.com/aws/aws-sdk-go-v2/service/sts v1.45.6/go.mod h1:XZcaQkV2cItp6yEkrwljyaPOf22RuX7T43jxap/FOmM=
+github.com/aws/aws-sdk-go-v2/service/wafv2 v1.77.7 h1:aYEubZA71DBiNQ5xiKzaLN6hGSBDY/UTnvVlP/8xr34=
+github.com/aws/aws-sdk-go-v2/service/wafv2 v1.77.7/go.mod h1:PO56Pf1k6JN5JAKnXs7NRkOv9IQNsEHPKY7/t6/Wklg=
 github.com/aws/smithy-go v1.27.8 h1:FR0dxZfIlV7Z8eh2iHfIofdunw382XsDV3Mxt9nUvRY=
 github.com/aws/smithy-go v1.27.8/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=

--- a/test/e2e/journey_wire_names_test.go
+++ b/test/e2e/journey_wire_names_test.go
@@ -1,0 +1,149 @@
+package e2e_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/aws-sdk-go-v2/service/wafv2"
+	wafv2types "github.com/aws/aws-sdk-go-v2/service/wafv2/types"
+
+	emulator "github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestJourney_DynamoDBTableArnDecodes is #738 at the only tier that could have caught it.
+//
+// Substrate published the table's ARN as TableARN, the stream's as LatestStreamARN and an
+// index's as IndexARN. DynamoDB publishes TableArn, LatestStreamArn and IndexArn, so a real
+// SDK decoded all three as nil and a consumer reading TableArn got an empty string with no
+// error — the failure mode this project exists to prevent, and one no hand-built parameter
+// map can expose, because the unit tier asserted on substrate's own spelling.
+//
+// The e2e module had no DynamoDB client at all before this, which is precisely why every
+// release up to v0.108.0 shipped the defect green.
+func TestJourney_DynamoDBTableArnDecodes(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	client := dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) { o.RetryMaxAttempts = 1 })
+
+	const tableName = "wire-names"
+	create, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String(tableName),
+		KeySchema: []ddbtypes.KeySchemaElement{
+			{AttributeName: aws.String("pk"), KeyType: ddbtypes.KeyTypeHash},
+		},
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("pk"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+			{AttributeName: aws.String("gsi"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+		GlobalSecondaryIndexes: []ddbtypes.GlobalSecondaryIndex{{
+			IndexName: aws.String("by-gsi"),
+			KeySchema: []ddbtypes.KeySchemaElement{
+				{AttributeName: aws.String("gsi"), KeyType: ddbtypes.KeyTypeHash},
+			},
+			Projection: &ddbtypes.Projection{ProjectionType: ddbtypes.ProjectionTypeAll},
+		}},
+		StreamSpecification: &ddbtypes.StreamSpecification{
+			StreamEnabled:  aws.Bool(true),
+			StreamViewType: ddbtypes.StreamViewTypeNewAndOldImages,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	// CreateTable's own TableDescription, decoded by the SDK rather than read from a map.
+	assertTableARNs(t, "CreateTable", create.TableDescription)
+
+	describe, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{
+		TableName: aws.String(tableName),
+	})
+	if err != nil {
+		t.Fatalf("DescribeTable: %v", err)
+	}
+	assertTableARNs(t, "DescribeTable", describe.Table)
+}
+
+// assertTableARNs checks the three ARN members a real SDK reads off a TableDescription.
+// aws.ToString turning a nil pointer into "" is exactly how the defect stayed invisible,
+// so each assertion tests the pointer as well as the value.
+func assertTableARNs(t *testing.T, op string, desc *ddbtypes.TableDescription) {
+	t.Helper()
+	if desc == nil {
+		t.Fatalf("%s: TableDescription is nil", op)
+	}
+
+	if desc.TableArn == nil {
+		t.Errorf("%s: TableArn is nil — substrate is publishing the ARN under another name", op)
+	} else if !strings.HasPrefix(*desc.TableArn, "arn:aws:dynamodb:") {
+		t.Errorf("%s: TableArn = %q, want an arn:aws:dynamodb: prefix", op, *desc.TableArn)
+	}
+
+	if desc.LatestStreamArn == nil {
+		t.Errorf("%s: LatestStreamArn is nil although the table has a stream enabled", op)
+	} else if !strings.Contains(*desc.LatestStreamArn, "/stream/") {
+		t.Errorf("%s: LatestStreamArn = %q, want it to name a stream", op, *desc.LatestStreamArn)
+	}
+
+	if len(desc.GlobalSecondaryIndexes) != 1 {
+		t.Fatalf("%s: want 1 GSI, got %d", op, len(desc.GlobalSecondaryIndexes))
+	}
+	gsi := desc.GlobalSecondaryIndexes[0]
+	if gsi.IndexArn == nil {
+		t.Errorf("%s: GSI IndexArn is nil", op)
+	} else if !strings.HasSuffix(*gsi.IndexArn, "/index/by-gsi") {
+		t.Errorf("%s: GSI IndexArn = %q, want it to name the index", op, *gsi.IndexArn)
+	}
+}
+
+// TestJourney_WAFv2IPSetAddressVersion is the half of #738 that was a behaviour bug rather
+// than a rendering one. Substrate read the request's IP version from IPVersion, so a typed
+// SDK — which can only send IPAddressVersion — had its IPV6 request silently replaced by
+// substrate's IPV4 default. The set came back successfully, holding the wrong family, and a
+// consumer's error branch never ran.
+func TestJourney_WAFv2IPSetAddressVersion(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	client := wafv2.NewFromConfig(cfg, func(o *wafv2.Options) { o.RetryMaxAttempts = 1 })
+
+	create, err := client.CreateIPSet(ctx, &wafv2.CreateIPSetInput{
+		Name:             aws.String("v6-only"),
+		Scope:            wafv2types.ScopeRegional,
+		IPAddressVersion: wafv2types.IPAddressVersionIpv6,
+		Addresses:        []string{"2001:db8::/32"},
+	})
+	if err != nil {
+		t.Fatalf("CreateIPSet: %v", err)
+	}
+	if create.Summary == nil || create.Summary.Id == nil {
+		t.Fatal("CreateIPSet returned no summary Id")
+	}
+
+	got, err := client.GetIPSet(ctx, &wafv2.GetIPSetInput{
+		Id:    create.Summary.Id,
+		Name:  aws.String("v6-only"),
+		Scope: wafv2types.ScopeRegional,
+	})
+	if err != nil {
+		t.Fatalf("GetIPSet: %v", err)
+	}
+	if got.IPSet == nil {
+		t.Fatal("GetIPSet returned no IPSet")
+	}
+	if got.IPSet.IPAddressVersion != wafv2types.IPAddressVersionIpv6 {
+		t.Errorf("IPAddressVersion = %q, want IPV6 — the requested family was not read",
+			got.IPSet.IPAddressVersion)
+	}
+}


### PR DESCRIPTION
Nine response members were published under a name no AWS SDK reads. Every one was checked against the member name in the official API reference rather than swept mechanically, because a Go `json` tag is only a bug when three things hold at once — the plugin's protocol serializes Go tags, the struct actually reaches a response body, and AWS spells the member differently.

Of 158 candidate tag lines, 24 turned out to be cases where AWS really does publish the capitalized form: the bare spelling `ARN` appears on 16 lines and is correct on 15 of them (Secrets Manager, SSM, WAFv2's Web ACL, CloudFront and ElastiCache all publish `ARN`), and FSx genuinely publishes `ResourceARN` and `DNSName`. A blanket `ARN` → `Arn` rename would have broken six correct fields to fix one, so this is per-service.

## What was wrong

| Service | Member | Was |
|---|---|---|
| DynamoDB | `TableArn`, `LatestStreamArn`, `IndexArn` (GSI and LSI) | `TableARN`, `LatestStreamARN`, `IndexARN` |
| EventBridge | a rule's `Arn` | `ARN` |
| Lambda | ESM `FunctionArn`, `EventSourceArn` | `FunctionARN`, `EventSourceARN` |
| CloudTrail | `KmsKeyId`, `LogFileValidationEnabled` | `KMSKeyId`, `EnableLogFileValidation` |
| WAFv2 | an IP set's `IPAddressVersion` | `IPVersion` |

`EnableLogFileValidation` is `CreateTrail`'s and `UpdateTrail`'s **input** name — every response publishes the setting as `LogFileValidationEnabled` — so the input parsing still reads it. `PutRule`, which wraps a rule's ARN under `RuleArn`, was already correct. The lowercase `eventSourceARN` inside a Lambda stream-record event payload is a different and correct spelling, and is untouched. A trail's own `TrailARN` is correct.

`StackDeployer` decodes substrate's own `CreateTable` response with an inline tag, so it changes in the same commit — otherwise the deployer would have stopped recording table ARNs the moment the tag was fixed.

## WAFv2 is a behaviour fix

The wrong member name was used to *parse* the request as well as to render the response, so a typed SDK — which can only send `IPAddressVersion` — had its `IPV6` request read as absent and silently replaced by substrate's `IPV4` default. The set was created successfully holding the wrong address family, so a consumer's error branch never ran.

## Why no test caught this

`test/e2e` had no DynamoDB or WAFv2 client at all. The unit tier asserts on substrate's own spelling, and only a typed SDK can decide whether a member decodes — which is exactly how nine wrong names stayed green through every release.

- `test/e2e/journey_wire_names_test.go` creates a table with a stream and a GSI and reads all three ARNs off the SDK's `TableDescription`, then round-trips an IPv6 IP set. Against the previous code: `TableArn is nil`, `LatestStreamArn is nil`, `GSI IndexArn is nil`, `IPAddressVersion = "" want IPV6`.
- `emulator/wire_names_738_test.go` pins CloudTrail's, EventBridge's and Lambda's members through a raw `map[string]any`, asserting both that the published name is present and that the wrong one is absent. All three fail against the previous code.
- `emulator/wafv2_plugin_test.go` gains a table-driven round-trip for the three address-version cases.

Verified live through the AWS CLI against a built binary: `dynamodb create-table` / `describe-table` return all three ARNs, and `wafv2 get-ip-set` reports `IPV6`. (`cloudtrail create-trail` still answers `ServiceNotAvailable: service not emulated: com` through the CLI — that is #739's routing miss, unrelated to this change and confirmed by it.)

The e2e module gains the `dynamodb` and `wafv2` clients, which requires `aws-sdk-go-v2` v1.43.7 there.

## Compatibility

`DynamoDBTable` is both the response shape and the persisted record, so the **state key renames too**: a stream or exported fixture recorded before this change decodes the ARN as empty. Accepted as a fixture break at a minor version rather than carried as a permanent read alias. A fixture asserting that an `IPV6` request produced an `IPV4` set also flips.

Also re-adds the `## [Unreleased]` heading the previous release PR consumed.

Closes #738
