### PR TITLE
fix(routing): every registered plugin is reachable from a real AWS client (#739)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Four plugins were registered, unit-tested, and unreachable from a real AWS client**
+  (#739). Substrate resolves which plugin serves a request by reducing four signals to one
+  service name, and `X-Amz-Target` is checked first — so a namespace it does not recognize
+  short-circuits the `Host` and SigV4 paths that would both have answered correctly. Since
+  substrate is reached with `--endpoint-url`, where the host is `localhost`, the target is
+  effectively the only signal a JSON caller supplies. Every such call then answers
+  `ServiceNotAvailable` while the plugin's own tests stay green. That had already shipped
+  four times (#561, #580, #734); this is the sweep that makes the check systematic instead
+  of incidental. All 67 plugins' identifiers were read from the botocore models bundled in a
+  locally installed AWS CLI v2, and each miss was confirmed against a live `aws` run before
+  and after the fix.
+  - **CloudWatch** (`monitoring`) was unreachable from **every AWS CLI and boto3 caller**.
+    Its model declares `protocols: ['smithy-rpc-v2-cbor','json','query']`; botocore resolves
+    `json` first and sends `X-Amz-Target: GraniteServiceVersion20100801.{Op}`, a name that was
+    present in the Smithy path table (the rpc-v2-cbor transport `aws-sdk-go-v2` takes) and
+    absent from the target table. Substrate's suite and its real-SDK end-to-end tier both
+    drive `aws-sdk-go-v2`, which is why they were green over a dead endpoint.
+  - **Health** was unreachable from every SDK. Its real target prefix is
+    `AWSHealth_20160804`; the alias table held an invented `healthservice` in that slot, and
+    the plugin's own tests sent the invented prefix — so the suite proved only that substrate
+    routes a name substrate made up. Health is also not regionalized, so its partition
+    endpoint `global.health.amazonaws.com` reduced to `global` and missed the host path too.
+  - **CloudTrail** was unreachable from the AWS CLI and boto3, which send the model's
+    fully-qualified `com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.{Op}` — split at
+    the first dot, that reduced to `com`. `aws-sdk-go-v2` sends the terse
+    `CloudTrail_20131101` and always worked. An alias could not fix the long form, because
+    `com` prefixes every fully-qualified namespace; substrate now reduces a dot-qualified
+    namespace to its last segment, mirroring what operation extraction already did. Of the 430
+    botocore models only three carry a dotted prefix and their last segments do not collide.
+  - **Timestream** missed the host path: endpoint discovery hands a client
+    `ingest.timestream.{region}` or `query.timestream.{region}`, whose first label is the
+    operation class rather than the service. A `--endpoint-url` caller was unaffected, which
+    is why the suite never saw it.
+
+  The identifiers now live in a table, `emulator/routing.go`, with a cited source per row —
+  and the citation names *which* SDK, because botocore and `aws-sdk-go-v2` disagree about
+  CloudTrail. Three consumers keep it honest: the generated coverage matrix reads its display
+  names and protocols (replacing a second copy that lived in `cmd/gen-service-reference`),
+  `make docs-reference-check` fails when a registered plugin has no row or a row names no
+  plugin, and a sweep test drives every target prefix, host and signing name through the
+  parser and asserts the result is a **registered** plugin rather than an expected string.
+  `docs/services.md` gains a section on the four signals, the reason the priority order hides
+  a routing bug, the three plugins that legitimately cannot be addressed three ways
+  (`apigatewayv2`, `execute-api`, `opensearch`), and the coverage limit that Java, JavaScript
+  and .NET were not checked. Three target prefixes documented in per-service sections were
+  also wrong — Step Functions' is `AWSStepFunctions` not `AmazonStates`, ECR's is
+  `_V20150921` not `_V1_1_0`, and Organizations' is `AWSOrganizationsV20161128` not
+  `Organizations_20161128`; substrate accepts the old spellings too, so no caller breaks.
+
+  Routing CloudWatch is not the same as serving it: the AWS CLI's JSON body now reaches a
+  handler that reads query-form parameters and answers XML, which is filed as #757 rather
+  than fixed here — a protocol rewrite of `CloudWatchPlugin` is a release of its own. `sso`'s
+  error protocol is classified REST/JSON while the plugin emulates sso-admin (JSON 1.1),
+  filed as #758.
 - **Nine response members were published under a name no AWS SDK reads** (#738). A Go `json`
   tag is only a bug when three things hold at once — the plugin's protocol serializes Go tags,
   the struct actually reaches a response body, and AWS spells the member differently — so every

--- a/cmd/gen-service-reference/main.go
+++ b/cmd/gen-service-reference/main.go
@@ -39,85 +39,14 @@ const (
 	endMarker   = "<!-- END GENERATED COVERAGE MATRIX -->"
 )
 
-// pluginMeta is the maintained per-plugin documentation metadata.
-type pluginMeta struct {
-	// Display is the human-facing AWS service name.
-	Display string
-	// Protocol is the wire protocol the plugin speaks.
-	Protocol string
-}
-
-// meta maps each registered plugin name to its documentation metadata. Adding a
-// plugin to the registry without a matching entry here fails generation (and CI).
-var meta = map[string]pluginMeta{
-	"account":              {"Account Management", "REST/JSON"},
-	"acm":                  {"ACM", "JSON"},
-	"apigateway":           {"API Gateway (REST)", "REST/JSON"},
-	"apigatewayv2":         {"API Gateway (HTTP)", "REST/JSON"},
-	"appsync":              {"AppSync", "REST/JSON"},
-	"athena":               {"Athena", "JSON"},
-	"backup":               {"Backup", "REST/JSON"},
-	"batch":                {"Batch", "REST/JSON"},
-	"bedrock-runtime":      {"Bedrock Runtime", "REST/JSON"},
-	"budgets":              {"Budgets", "JSON"},
-	"ce":                   {"Cost Explorer", "JSON"},
-	"cloudformation":       {"CloudFormation", "Query"},
-	"cloudfront":           {"CloudFront", "REST/XML"},
-	"cloudtrail":           {"CloudTrail", "JSON"},
-	"codebuild":            {"CodeBuild", "JSON"},
-	"codedeploy":           {"CodeDeploy", "JSON"},
-	"codepipeline":         {"CodePipeline", "JSON"},
-	"cognito-identity":     {"Cognito Identity", "JSON"},
-	"cognito-idp":          {"Cognito Identity Provider", "JSON"},
-	"config":               {"Config", "JSON"},
-	"dynamodb":             {"DynamoDB", "JSON"},
-	"ec2":                  {"EC2 / VPC", "Query"},
-	"ecr":                  {"ECR", "JSON"},
-	"ecs":                  {"ECS", "JSON"},
-	"efs":                  {"EFS", "REST/JSON"},
-	"elasticache":          {"ElastiCache", "Query"},
-	"elasticloadbalancing": {"ELBv2", "Query"},
-	"emrserverless":        {"EMR Serverless", "REST/JSON"},
-	"eventbridge":          {"EventBridge", "JSON"},
-	"execute-api":          {"API Gateway (execute-api)", "REST/JSON"},
-	"firehose":             {"Kinesis Data Firehose", "JSON"},
-	"fsx":                  {"FSx", "JSON"},
-	"glue":                 {"Glue", "JSON"},
-	"health":               {"Health", "JSON"},
-	"iam":                  {"IAM", "Query"},
-	"kinesis":              {"Kinesis Data Streams", "JSON"},
-	"kms":                  {"KMS", "JSON"},
-	"lambda":               {"Lambda", "REST/JSON"},
-	"logs":                 {"CloudWatch Logs", "JSON"},
-	"monitoring":           {"CloudWatch", "Query"},
-	"msk":                  {"MSK", "REST/JSON"},
-	"omics":                {"HealthOmics", "REST/JSON"},
-	"opensearch":           {"OpenSearch", "REST/JSON"},
-	"organizations":        {"Organizations", "JSON"},
-	"pricing":              {"Price List Query API", "JSON"},
-	"quicksight":           {"QuickSight", "REST/JSON"},
-	"ram":                  {"RAM", "REST/JSON"},
-	"rds":                  {"RDS", "Query"},
-	"redshift":             {"Redshift", "Query"},
-	"redshift-data":        {"Redshift Data API", "JSON"},
-	"route53":              {"Route 53", "REST/XML"},
-	"s3":                   {"S3", "REST/XML"},
-	"sagemaker":            {"SageMaker", "JSON"},
-	"scheduler":            {"EventBridge Scheduler", "REST/JSON"},
-	"secretsmanager":       {"Secrets Manager", "JSON"},
-	"servicequotas":        {"Service Quotas", "JSON"},
-	"sesv2":                {"SES v2", "REST/JSON"},
-	"sns":                  {"SNS", "Query"},
-	"sqs":                  {"SQS", "JSON"},
-	"ssm":                  {"SSM", "JSON"},
-	"sso":                  {"SSO / Identity Store", "REST/JSON"},
-	"states":               {"Step Functions", "JSON"},
-	"sts":                  {"STS", "Query"},
-	"tagging":              {"Resource Groups Tagging", "JSON"},
-	"timestream":           {"Timestream", "JSON"},
-	"transfer":             {"Transfer Family", "JSON"},
-	"wafv2":                {"WAFv2", "JSON"},
-}
+// routing is the per-plugin routing and documentation metadata, read from the
+// emulator's own table (emulator/routing.go) rather than kept in a second copy
+// here. One table then serves three consumers: this matrix, the drift check
+// below, and the reachability sweep test that asserts every identifier in it
+// resolves to a registered plugin (#739). A duplicate map in cmd/ could agree
+// with the docs while disagreeing with what an SDK actually sends, which is the
+// class of failure #739 exists to close.
+var routing = emu.PluginRoutingCatalog()
 
 func main() {
 	check := flag.Bool("check", false, "exit non-zero if the file is out of date instead of writing it")
@@ -178,13 +107,13 @@ func registeredPlugins() ([]string, error) {
 	registered := make(map[string]bool, len(names))
 	for _, n := range names {
 		registered[n] = true
-		if _, ok := meta[n]; !ok {
-			return nil, fmt.Errorf("plugin %q is registered but has no metadata entry in cmd/gen-service-reference/main.go; add one", n)
+		if _, ok := routing[n]; !ok {
+			return nil, fmt.Errorf("plugin %q is registered but has no entry in emulator/routing.go; add one, citing the source of its target prefix, hosts and signing names", n)
 		}
 	}
-	for n := range meta {
+	for n := range routing {
 		if !registered[n] {
-			return nil, fmt.Errorf("metadata entry %q does not correspond to a registered plugin; remove it from cmd/gen-service-reference/main.go", n)
+			return nil, fmt.Errorf("routing entry %q does not correspond to a registered plugin; remove it from emulator/routing.go", n)
 		}
 	}
 	sort.Strings(names)
@@ -211,7 +140,7 @@ func replaceMatrix(doc []byte, names []string) ([]byte, error) {
 	fmt.Fprintln(&matrix, "| # | Service | Plugin name | Protocol |")
 	fmt.Fprintln(&matrix, "|---|---------|-------------|----------|")
 	for i, n := range names {
-		m := meta[n]
+		m := routing[n]
 		fmt.Fprintf(&matrix, "| %d | %s | `%s` | %s |\n", i+1, m.Display, n, m.Protocol)
 	}
 	fmt.Fprint(&matrix, endMarker)

--- a/cmd/gen-service-reference/main.go
+++ b/cmd/gen-service-reference/main.go
@@ -10,10 +10,10 @@
 //
 // in docs/services.md. Everything outside the markers — including the
 // hand-written per-service operation, CloudFormation, and cost detail — is left
-// untouched. Per-plugin display names and protocols come from the maintained
-// metadata map below; the tool fails if a registered plugin has no metadata
-// entry (or an entry names a plugin that is not registered), which is what a CI
-// drift check enforces.
+// untouched. Per-plugin display names and protocols come from the emulator's own
+// routing table ([emu.PluginRoutingCatalog], emulator/routing.go); the tool fails
+// if a registered plugin has no entry there (or an entry names a plugin that is
+// not registered), which is what a CI drift check enforces.
 //
 // Usage:
 //
@@ -102,22 +102,31 @@ func registeredPlugins() ([]string, error) {
 	if err := emu.RegisterDefaultPlugins(context.Background(), reg, state, tc, logger, store, nil); err != nil {
 		return nil, fmt.Errorf("register default plugins: %w", err)
 	}
-	names := reg.Names()
+	return checkRouting(reg.Names(), routing)
+}
 
+// checkRouting verifies that the routing table and the registered plugin names
+// agree in both directions and returns the names sorted. It takes the table as a
+// parameter rather than reading the package-level [routing] so that both refusals
+// are reachable from a test — the drift check is the whole point of the -check
+// flag, and an untested drift check is one nobody knows still fires (#739).
+func checkRouting(names []string, table map[string]emu.PluginRouting) ([]string, error) {
 	registered := make(map[string]bool, len(names))
 	for _, n := range names {
 		registered[n] = true
-		if _, ok := routing[n]; !ok {
+		if _, ok := table[n]; !ok {
 			return nil, fmt.Errorf("plugin %q is registered but has no entry in emulator/routing.go; add one, citing the source of its target prefix, hosts and signing names", n)
 		}
 	}
-	for n := range routing {
+	for n := range table {
 		if !registered[n] {
 			return nil, fmt.Errorf("routing entry %q does not correspond to a registered plugin; remove it from emulator/routing.go", n)
 		}
 	}
-	sort.Strings(names)
-	return names, nil
+	sorted := make([]string, len(names))
+	copy(sorted, names)
+	sort.Strings(sorted)
+	return sorted, nil
 }
 
 // replaceMatrix swaps the content between the begin/end markers in doc for a

--- a/cmd/gen-service-reference/main_test.go
+++ b/cmd/gen-service-reference/main_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	emu "github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestRegisteredPlugins_AgreesWithTheRoutingTable is the drift check the -check
+// flag runs in CI, exercised directly: the live registry and
+// emulator/routing.go must name the same plugins.
+func TestRegisteredPlugins_AgreesWithTheRoutingTable(t *testing.T) {
+	names, err := registeredPlugins()
+	if err != nil {
+		t.Fatalf("registeredPlugins: %v", err)
+	}
+	if len(names) != len(routing) {
+		t.Errorf("registry has %d plugins, routing table has %d", len(names), len(routing))
+	}
+	for i := 1; i < len(names); i++ {
+		if names[i-1] > names[i] {
+			t.Fatalf("names are not sorted: %q before %q", names[i-1], names[i])
+		}
+	}
+}
+
+// TestCheckRouting_RefusesDriftInBothDirections asserts both halves of the drift
+// check fire. A registered plugin with no routing entry is the failure that let
+// EventBridge ship unreachable; an entry naming no plugin is the invented
+// identifier that hid AWS Health's real target prefix (#739).
+func TestCheckRouting_RefusesDriftInBothDirections(t *testing.T) {
+	row := emu.PluginRouting{Display: "Thing", Protocol: "JSON"}
+
+	tests := []struct {
+		name  string
+		names []string
+		table map[string]emu.PluginRouting
+		want  string
+	}{
+		{
+			name:  "registered plugin with no routing entry",
+			names: []string{"sqs", "brandnew"},
+			table: map[string]emu.PluginRouting{"sqs": row},
+			want:  `plugin "brandnew" is registered but has no entry`,
+		},
+		{
+			name:  "routing entry naming no plugin",
+			names: []string{"sqs"},
+			table: map[string]emu.PluginRouting{"sqs": row, "ghost": row},
+			want:  `routing entry "ghost" does not correspond to a registered plugin`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := checkRouting(tt.names, tt.table)
+			if err == nil {
+				t.Fatalf("want a refusal, got names %v", got)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("want error containing %q, got %q", tt.want, err)
+			}
+		})
+	}
+}
+
+// TestCheckRouting_SortsWithoutMutatingTheInput guards the copy: reg.Names()
+// returns the registry's own slice in registration order, and sorting it in
+// place would reorder a caller's view of the registry as a side effect.
+func TestCheckRouting_SortsWithoutMutatingTheInput(t *testing.T) {
+	row := emu.PluginRouting{Display: "Thing", Protocol: "JSON"}
+	names := []string{"sqs", "ec2", "iam"}
+	table := map[string]emu.PluginRouting{"sqs": row, "ec2": row, "iam": row}
+
+	got, err := checkRouting(names, table)
+	if err != nil {
+		t.Fatalf("checkRouting: %v", err)
+	}
+	if want := []string{"ec2", "iam", "sqs"}; strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("want %v, got %v", want, got)
+	}
+	if want := []string{"sqs", "ec2", "iam"}; strings.Join(names, ",") != strings.Join(want, ",") {
+		t.Errorf("input was mutated: want %v, got %v", want, names)
+	}
+}
+
+// TestReplaceMatrix_RendersFromTheRoutingTable asserts the matrix row carries the
+// Display and Protocol the routing table holds, and that content outside the
+// markers survives untouched.
+func TestReplaceMatrix_RendersFromTheRoutingTable(t *testing.T) {
+	doc := []byte("before\n" + beginMarker + "\nstale\n" + endMarker + "\nafter\n")
+
+	got, err := replaceMatrix(doc, []string{"sqs"})
+	if err != nil {
+		t.Fatalf("replaceMatrix: %v", err)
+	}
+	out := string(got)
+	if strings.Contains(out, "stale") {
+		t.Error("the previous matrix survived the replacement")
+	}
+	if !strings.HasPrefix(out, "before\n") || !strings.HasSuffix(out, "\nafter\n") {
+		t.Errorf("content outside the markers changed: %q", out)
+	}
+	want := "| 1 | " + routing["sqs"].Display + " | `sqs` | " + routing["sqs"].Protocol + " |"
+	if !strings.Contains(out, want) {
+		t.Errorf("want a row %q in:\n%s", want, out)
+	}
+	if !strings.Contains(out, "**1 built-in service plugins**") {
+		t.Error("want the count to come from the name list")
+	}
+}
+
+// TestReplaceMatrix_RefusesADocumentWithoutMarkers keeps the tool from silently
+// rewriting a file whose shape it does not know.
+func TestReplaceMatrix_RefusesADocumentWithoutMarkers(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+	}{
+		{name: "no markers at all", doc: "nothing here\n"},
+		{name: "begin only", doc: beginMarker + "\n"},
+		{name: "end only", doc: endMarker + "\n"},
+		{name: "end before begin", doc: endMarker + "\n" + beginMarker + "\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := replaceMatrix([]byte(tt.doc), []string{"sqs"}); err == nil {
+				t.Fatal("want a refusal, got nil")
+			}
+		})
+	}
+}

--- a/docs/services.md
+++ b/docs/services.md
@@ -90,6 +90,108 @@ here.
 
 ---
 
+## How a request reaches a plugin
+
+A plugin that is registered is not necessarily reachable. Substrate resolves which
+plugin serves a request by reducing what the client sent to one lowercase service
+name, using four signals in priority order:
+
+| # | Signal | Example | Notes |
+|---|--------|---------|-------|
+| 1 | `X-Amz-Target` namespace | `DynamoDB_20120810.GetItem` | The only signal a `--endpoint-url` caller supplies beyond the credential scope |
+| 2 | `Host` | `dynamodb.us-east-1.amazonaws.com` | Useless against substrate, where the host is `localhost` |
+| 3 | URL path | `/service/GraniteServiceVersion20100801/operation/GetMetricData` | Smithy RPC v2 CBOR transport |
+| 4 | SigV4 credential scope | `…/us-east-1/dynamodb/aws4_request` | The signing name, which is not always the endpoint prefix |
+
+The order is what makes a routing bug hard to see. The target is checked first, so an
+unrecognized namespace **short-circuits** signals 2 and 4, both of which would often
+have answered correctly. Substrate is reached by pointing a client at
+`--endpoint-url http://localhost:4566`, where signal 2 is `localhost` and signal 3 is
+absent — so for a JSON service the target is effectively the only signal, and a
+namespace substrate does not recognize answers `ServiceNotAvailable` for every
+operation of that service while the plugin's own tests stay green.
+
+That has happened repeatedly: `sso` (#561), `organizations` and `config` (#580),
+`eventbridge` (#734), and then `monitoring`, `health`, `cloudtrail` and `timestream`
+(#739). Each was found by pointing a real client at a running server, not by the test
+suite.
+
+### The routing table
+
+`emulator/routing.go` records, for every registered plugin, the identifiers a real AWS
+client sends: the target namespace, one example endpoint host per distinct shape, and
+the SigV4 signing names. Every row cites the source it was read from, and the citation
+names *which* source — see CloudTrail below for why that matters.
+
+The table has three consumers, so it cannot rot quietly:
+
+- the generated coverage matrix above reads its display names and protocols;
+- `make docs-reference-check` fails if a registered plugin has no row, or a row names
+  no registered plugin;
+- a sweep test drives every identifier in every row through the parser and asserts the
+  result is a **registered** plugin — not merely the expected string.
+
+Adding a plugin therefore means recording how a client addresses it. That is the check
+whose absence let four plugins ship unreachable.
+
+### The four that were unreachable
+
+| Plugin | What the client sends | What it reduced to | Who saw the failure |
+|---|---|---|---|
+| `monitoring` | `X-Amz-Target: GraniteServiceVersion20100801.{Op}` | nothing — the name was in the Smithy path table and absent from the target table | every AWS CLI and boto3 caller |
+| `health` | `X-Amz-Target: AWSHealth_20160804.{Op}` | nothing — the table held an invented `healthservice` instead | every SDK |
+| `health` | `Host: global.health.amazonaws.com` | `global` | a caller using the real endpoint |
+| `cloudtrail` | `X-Amz-Target: com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.{Op}` | `com` | the AWS CLI and boto3 only |
+| `timestream` | `Host: ingest.` / `query.timestream.{region}.amazonaws.com` | `ingest` / `query` | a caller using endpoint discovery |
+
+Two of these are worth understanding rather than just recording.
+
+**CloudTrail is why a source citation must name the SDK.** botocore sends the model's
+fully-qualified namespace; `aws-sdk-go-v2` sends the terse `CloudTrail_20131101`. The
+Go SDK's form always worked, so substrate's suite and its real-SDK end-to-end tier —
+both of which drive `aws-sdk-go-v2` — were green while every CLI and boto3 CloudTrail
+call answered `ServiceNotAvailable`. An alias could not fix the long form, because its
+first label is `com`, which prefixes every fully-qualified namespace and would hijack
+any other service that adopted one. Substrate now reduces a dot-qualified namespace to
+its **last** segment, mirroring what operation extraction already did. Of the 430
+botocore models only three carry a dotted prefix — `cloudtrail`, `codeconnections` and
+`codestar-connections`, the latter two not substrate plugins — and their last segments
+do not collide.
+
+**CloudWatch's fix is routing only, and the gap behind it is real.** `monitoring` now
+receives the AWS CLI's request, but `CloudWatchPlugin` reads query-form parameters and
+answers XML, so a JSON-RPC client gets HTTP 200 with a body it cannot parse, and its
+refusals arrive as `<ErrorResponse>` rather than a JSON error code. Do not read
+"CloudWatch is routed" as "the AWS CLI can drive CloudWatch": it cannot yet. That is
+tracked as #757. Similarly, `sso` is classified as REST/JSON for error shaping while
+the plugin emulates sso-admin, which is JSON 1.1 — #758.
+
+### Plugins that are deliberately not addressable three ways
+
+Three rows cannot assert all three signals, and say so in prose rather than being
+skipped:
+
+- **`apigatewayv2`** shares `apigateway`'s endpoint host *and* signing name, and neither
+  client sends a target. The two are separated by the `/v2/` path segment instead (#529).
+- **`execute-api`** is addressed by a host whose first label is the API's ID — data, not
+  a service name — so the match is on the `execute-api` label. There is no service model;
+  this is the runtime endpoint, which no SDK-generated client calls.
+- **`opensearch`** is data-plane only. A managed domain's host and a Serverless
+  collection's host both carry the resource name ahead of the `es`/`aoss` label, and the
+  OpenSearch Serverless control-plane target prefix names operations substrate does not
+  implement, so it is absent on purpose.
+
+### Coverage limits
+
+All 67 rows were read from the botocore models bundled in a locally installed AWS CLI
+v2. The JSON ones were cross-checked against `aws-sdk-go-v2` serializers. The Java,
+JavaScript and .NET SDKs were **not** checked, so a namespace only they send would not
+have been caught here. Where a per-service section below states a target prefix, that
+prefix is what the model declares; substrate also accepts the older spellings it used
+to document, so correcting one of them cannot break a caller.
+
+---
+
 ## An operation substrate does not implement
 
 No plugin covers its whole service, so every one of the 67 has an answer for a call it
@@ -6304,7 +6406,11 @@ API Gateway HTTP API calls: $1.00 per million calls.
 ## Step Functions
 
 **Endpoint:** `states.{region}.amazonaws.com`
-**Protocol:** JSON (`X-Amz-Target: AmazonStates.{Op}`)
+**Protocol:** JSON (`X-Amz-Target: AWSStepFunctions.{Op}`)
+
+`AmazonStates` was documented here previously and is not what any client sends;
+the Step Functions model's target prefix is `AWSStepFunctions` (#739). Substrate
+routes both.
 
 ### Supported operations
 
@@ -6333,7 +6439,10 @@ Step Functions state transitions: $0.025 per 1,000 transitions.
 ## ECR
 
 **Endpoint:** `ecr.{region}.amazonaws.com`
-**Protocol:** JSON (`X-Amz-Target: AmazonEC2ContainerRegistry_V1_1_0.{Op}`)
+**Protocol:** JSON (`X-Amz-Target: AmazonEC2ContainerRegistry_V20150921.{Op}`)
+
+`_V1_1_0` was documented here previously; `_V20150921` is what the ECR model
+declares (#739). Both reduce to `ec2containerregistry`, so substrate routes either.
 
 ### Supported operations
 
@@ -6838,7 +6947,12 @@ Price List API calls are free.
 ## Organizations
 
 **Endpoint:** `organizations.us-east-1.amazonaws.com`
-**Protocol:** JSON (`X-Amz-Target: Organizations_20161128.{Op}`)
+**Protocol:** JSON (`X-Amz-Target: AWSOrganizationsV20161128.{Op}`)
+
+`Organizations_20161128` was documented here previously and reduces to
+`organizations` by the generic version strip; the prefix every SDK actually sends is
+`AWSOrganizationsV20161128`, which carries its version inline and needed an explicit
+alias (#739).
 
 On the first call, the plugin auto-creates an organization, its management
 account, and its root. All three are persisted, so the root's ID and ARN are

--- a/emulator/health_plugin_test.go
+++ b/emulator/health_plugin_test.go
@@ -42,7 +42,12 @@ func healthRequest(t *testing.T, ts *httptest.Server, op string, body string) *h
 	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/",
 		strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
-	req.Header.Set("X-Amz-Target", "AmazonHealthService."+op)
+	// AWSHealth_20160804 is the target prefix AWS Health's model declares and every
+	// SDK sends. These tests previously sent "AmazonHealthService", a name invented
+	// here, and targetServiceAliases carried a matching "healthservice" entry — so
+	// the suite proved only that substrate routes a prefix substrate made up, while
+	// every real client's call answered ServiceNotAvailable (#739).
+	req.Header.Set("X-Amz-Target", "AWSHealth_20160804."+op)
 	req.Host = "health.us-east-1.amazonaws.com"
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/emulator/parser.go
+++ b/emulator/parser.go
@@ -259,16 +259,37 @@ var targetServiceAliases = map[string]string{
 	"ec2containerregistry": "ecr",
 	// "elasticfilesystem" is the subdomain name for Amazon EFS.
 	"elasticfilesystem": "efs",
-	// "AWSGlue" → strip "AWS" → "glue".
+	// "AWSGlue" → no strip → "awsglue".
 	"awsglue": "glue",
-	// "AWSInsightsIndexService" → strip "AWS" → "insightsindexservice" → "ce".
+	// "AWSInsightsIndexService" → no strip → "awsinsightsindexservice" → "ce".
 	"awsinsightsindexservice": "ce",
 	// "AmazonBudgetServiceGateway" → strip "Amazon" → "budgetservicegateway" → "budgets".
-	// "AWSBudgetServiceGateway" → strip "AWS" → "budgetservicegateway" → "budgets".
+	// "AWSBudgetServiceGateway" → no strip → "awsbudgetservicegateway", which is
+	// the prefix the model actually declares and every client sends.
 	"budgetservicegateway":    "budgets",
 	"awsbudgetservicegateway": "budgets",
-	// "AmazonHealthService" → strip "Amazon" → "healthservice" → "health".
-	"healthservice": "health",
+	// "AWSHealth_20160804" → no strip → strip version → "awshealth". The table
+	// held an invented "healthservice" in this slot instead — a guessed prefix no
+	// client sends, sitting exactly where the real one was needed, which is the
+	// #561 failure repeated and is what hid HealthPlugin's unreachability until
+	// the sweep in #739. AWS Health is also not regionalized, so its partition
+	// endpoint "global.health.amazonaws.com" missed the host path as well.
+	"awshealth": "health",
+	// "GraniteServiceVersion20100801" → no strip, no "_" version suffix →
+	// "graniteserviceversion20100801". Granite is the internal code-name for
+	// CloudWatch, the way Trent is for KMS. The name was already in
+	// smithyServiceAliases for the rpc-v2-cbor URL path but absent here, and
+	// CloudWatch's model declares protocols ['smithy-rpc-v2-cbor','json','query']:
+	// botocore resolves "json" first and sends this target, while aws-sdk-go-v2
+	// takes the CBOR path that substrate already routed. So substrate's own suite
+	// and test/e2e were green over an endpoint no AWS CLI or boto3 caller could
+	// reach — every such call answered ServiceNotAvailable (#739).
+	//
+	// Routing the target is not the whole story: the CLI then sends
+	// application/x-amz-json-1.0 to a handler that reads query-form parameters and
+	// answers XML. That is a protocol gap in CloudWatchPlugin, filed separately;
+	// this alias only makes the request arrive.
+	"graniteserviceversion20100801": "monitoring",
 	// "email" is the subdomain name for Amazon SES v2.
 	"email": "sesv2",
 	// "Kafka_20181101" → strip version → "Kafka" → lowercase → "kafka" → "msk".
@@ -348,17 +369,36 @@ var targetServiceAliases = map[string]string{
 }
 
 // extractServiceFromTarget parses an X-Amz-Target value such as
-// "AmazonDynamoDB.GetItem" or "DynamoDB_20120810.GetItem" into a lowercase
-// service name.
+// "AmazonDynamoDB.GetItem", "DynamoDB_20120810.GetItem" or
+// "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.DescribeTrails" into a
+// lowercase service name.
 func extractServiceFromTarget(target string) string {
-	// Split on "." to get the namespace part.
-	dot := strings.IndexByte(target, '.')
+	// The operation is whatever follows the final dot, which is where
+	// extractOperation splits too, so the namespace is everything before it.
+	dot := strings.LastIndexByte(target, '.')
 	if dot < 0 {
 		return ""
 	}
 	ns := target[:dot]
 
-	// Strip known prefixes: "Amazon" prefix (AmazonDynamoDB → dynamodb).
+	// A namespace may itself be dot-qualified, and only its final segment names
+	// the service: botocore sends CloudTrail's as
+	// "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101", which splitting at
+	// the *first* dot reduced to "com", so every AWS CLI and boto3 CloudTrail call
+	// answered ServiceNotAvailable while aws-sdk-go-v2's terser
+	// "CloudTrail_20131101" resolved (#739). An alias could not fix it: "com"
+	// prefixes every fully-qualified namespace, so aliasing it would hijack any
+	// other service that sends the long form. Of the 430 botocore models only
+	// three carry a dotted prefix — cloudtrail, codeconnections and
+	// codestar-connections, the latter two not substrate plugins — and their final
+	// segments do not collide, so the reduction is safe.
+	if seg := strings.LastIndexByte(ns, '.'); seg >= 0 {
+		ns = ns[seg+1:]
+	}
+
+	// Strip known prefixes: "Amazon" prefix (AmazonDynamoDB → dynamodb). Note
+	// that "AWS" is *not* stripped — an "AWS…" namespace resolves through
+	// targetServiceAliases with the prefix intact.
 	ns = strings.TrimPrefix(ns, "Amazon")
 
 	// Strip version suffix: "DynamoDB_20120810" → "DynamoDB".
@@ -404,6 +444,23 @@ func extractServiceFromHost(host string) string {
 	// API Gateway runtime endpoint: {apiId}.execute-api.{region}
 	if strings.Contains(host, ".execute-api.") {
 		return "execute-api"
+	}
+
+	// Timestream endpoint discovery hands a client a host whose first label is the
+	// operation class rather than the service: "ingest.timestream.{region}" for
+	// writes, "query.timestream.{region}" for queries. Both reduced to "ingest" or
+	// "query" and reached no plugin (#739). A caller passing --endpoint-url was
+	// unaffected, which is why the suite never saw it.
+	if strings.HasPrefix(host, "ingest.timestream.") || strings.HasPrefix(host, "query.timestream.") {
+		return "timestream"
+	}
+
+	// "global.<service>": a non-regionalized service's partition endpoint carries
+	// a literal "global" label ahead of the service name — AWS Health's is
+	// "global.health.amazonaws.com" (endpoints.json, partitionEndpoint
+	// "aws-global"). Taking the first label routed it to a service named "global".
+	if rest, ok := strings.CutPrefix(host, "global."); ok && rest != "" {
+		host = rest
 	}
 
 	// "api.<service>.<region>": several services front their endpoint with a

--- a/emulator/routing.go
+++ b/emulator/routing.go
@@ -1,0 +1,626 @@
+package emulator
+
+// PluginRouting records how a real AWS client addresses one plugin: the
+// X-Amz-Target namespace it sends, the endpoint hosts it dials, and the SigV4
+// signing names it puts in the credential scope. Substrate resolves a request's
+// service from those three signals in that order (see extractServiceSignals), so
+// a plugin whose real identifiers reduce to nothing substrate recognizes is
+// registered, initialized, unit-tested — and unreachable from every SDK.
+//
+// That failure has shipped three times: SSOPlugin (#561), OrganizationsPlugin and
+// ConfigServicePlugin (#580), and EventBridgePlugin (#734), each found by a live
+// run rather than by the suite. The reason it hides is that the target is signal
+// #1: an unrecognized namespace short-circuits the host and signing-name paths
+// that would both have answered correctly, and substrate is always reached with
+// --endpoint-url, where the host is localhost and the target is the only signal.
+//
+// This table exists so the check is systematic rather than incidental (#739). It
+// is the single source for the docs coverage matrix, the drift check that fails
+// when a plugin is registered without routing, and the sweep test that asserts
+// every identifier here resolves to a registered plugin.
+type PluginRouting struct {
+	// Display is the human-facing AWS service name.
+	Display string
+	// Protocol is the wire protocol the substrate plugin speaks, which is not always
+	// the protocol the service model declares; where they differ, Why says so.
+	Protocol string
+	// TargetPrefix is the X-Amz-Target namespace a client sends, empty for a service
+	// whose protocol carries no target (Query, EC2, REST/JSON, REST/XML).
+	TargetPrefix string
+	// Hosts are complete example endpoint hosts, one per distinct shape a client dials.
+	Hosts []string
+	// SigningNames are the SigV4 credential-scope service names a client may sign with.
+	SigningNames []string
+	// RoutesTo names the plugin that Hosts and SigningNames resolve to when it is
+	// deliberately not this one. Empty means they resolve to this plugin.
+	RoutesTo string
+	// Why explains a RoutesTo, an identifier that is data rather than a service name,
+	// or a divergence between the model and the plugin. Empty when there is nothing
+	// to explain.
+	Why string
+	// Source names where the identifiers were read from. It names *which* source,
+	// because botocore and aws-sdk-go-v2 do not always agree — CloudTrail is the
+	// case in point.
+	Source string
+}
+
+// pluginRouting maps each registered plugin name to its routing identifiers.
+// Every entry was read from the service model bundled in the locally installed
+// AWS CLI v2 (metadata.targetPrefix / endpointPrefix / signingName, plus
+// endpoints.json for a non-regionalized host), not from recollection.
+//
+// Coverage limits worth stating rather than implying: all 67 entries were checked
+// against botocore, 53 of the JSON ones were cross-checked against aws-sdk-go-v2
+// serializers, and the Java, JavaScript and .NET SDKs were not checked. CloudTrail
+// proves the cross-check matters — botocore sends a fully-qualified namespace where
+// aws-sdk-go-v2 sends a terse one, so a table citing only one source would have
+// recorded a prefix that half the world's clients do not send.
+var pluginRouting = map[string]PluginRouting{
+	"account": {
+		Display:      "Account Management",
+		Protocol:     "REST/JSON",
+		Hosts:        []string{"account.us-east-1.amazonaws.com"},
+		SigningNames: []string{"account"},
+		Source:       "botocore account service-2.json",
+	},
+	"acm": {
+		Display:      "ACM",
+		Protocol:     "JSON",
+		TargetPrefix: "CertificateManager",
+		Hosts:        []string{"acm.us-east-1.amazonaws.com"},
+		SigningNames: []string{"acm"},
+		Source:       "botocore acm service-2.json",
+	},
+	"apigateway": {
+		Display:      "API Gateway (REST)",
+		Protocol:     "REST/JSON",
+		Hosts:        []string{"apigateway.us-east-1.amazonaws.com"},
+		SigningNames: []string{"apigateway"},
+		Source:       "botocore apigateway service-2.json",
+	},
+	"apigatewayv2": {
+		Display:      "API Gateway (HTTP)",
+		Protocol:     "REST/JSON",
+		Hosts:        []string{"apigateway.us-east-1.amazonaws.com"},
+		SigningNames: []string{"apigateway"},
+		RoutesTo:     "apigateway",
+		Why: "The v2 model shares the v1 endpoint prefix and signing name, so no " +
+			"routing signal distinguishes them. refineAPIGatewayVersion separates the " +
+			"two on the /v2/ path segment instead (#529), which is what a client actually " +
+			"sends.",
+		Source: "botocore apigatewayv2 service-2.json",
+	},
+	"appsync": {
+		Display:      "AppSync",
+		Protocol:     "REST/JSON",
+		Hosts:        []string{"appsync.us-east-1.amazonaws.com", "myapi.appsync-api.us-east-1.amazonaws.com"},
+		SigningNames: []string{"appsync"},
+		Source:       "botocore appsync service-2.json; AppSync developer guide for the execution host",
+	},
+	"athena": {
+		Display:      "Athena",
+		Protocol:     "JSON",
+		TargetPrefix: "AmazonAthena",
+		Hosts:        []string{"athena.us-east-1.amazonaws.com"},
+		SigningNames: []string{"athena"},
+		Source:       "botocore athena service-2.json",
+	},
+	"backup": {
+		Display:      "Backup",
+		Protocol:     "REST/JSON",
+		Hosts:        []string{"backup.us-east-1.amazonaws.com"},
+		SigningNames: []string{"backup"},
+		Source:       "botocore backup service-2.json",
+	},
+	"batch": {
+		Display:      "Batch",
+		Protocol:     "REST/JSON",
+		Hosts:        []string{"batch.us-east-1.amazonaws.com"},
+		SigningNames: []string{"batch"},
+		Source:       "botocore batch service-2.json",
+	},
+	"bedrock-runtime": {
+		Display:      "Bedrock Runtime",
+		Protocol:     "REST/JSON",
+		Hosts:        []string{"bedrock-runtime.us-east-1.amazonaws.com"},
+		SigningNames: []string{"bedrock"},
+		Why:          "The runtime's signing name is the control plane's, so boto3 signs with bedrock.",
+		Source:       "botocore bedrock-runtime service-2.json",
+	},
+	"budgets": {
+		Display:      "Budgets",
+		Protocol:     "JSON",
+		TargetPrefix: "AWSBudgetServiceGateway",
+		Hosts:        []string{"budgets.amazonaws.com"},
+		SigningNames: []string{"budgets"},
+		Why:          "Not regionalized: the partition endpoint carries no region label.",
+		Source:       "botocore budgets service-2.json; botocore endpoints.json aws-global",
+	},
+	"ce": {
+		Display:      "Cost Explorer",
+		Protocol:     "JSON",
+		TargetPrefix: "AWSInsightsIndexService",
+		Hosts:        []string{"ce.us-east-1.amazonaws.com"},
+		SigningNames: []string{"ce"},
+		Source:       "botocore ce service-2.json",
+	},
+	"cloudformation": {
+		Display:      "CloudFormation",
+		Protocol:     "Query",
+		Hosts:        []string{"cloudformation.us-east-1.amazonaws.com"},
+		SigningNames: []string{"cloudformation"},
+		Source:       "botocore cloudformation service-2.json",
+	},
+	"cloudfront": {
+		Display:      "CloudFront",
+		Protocol:     "REST/XML",
+		Hosts:        []string{"cloudfront.amazonaws.com"},
+		SigningNames: []string{"cloudfront"},
+		Why:          "Not regionalized: the partition endpoint carries no region label.",
+		Source:       "botocore cloudfront service-2.json; botocore endpoints.json aws-global",
+	},
+	"cloudtrail": {
+		Display:      "CloudTrail",
+		Protocol:     "JSON",
+		TargetPrefix: "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101",
+		Hosts:        []string{"cloudtrail.us-east-1.amazonaws.com"},
+		SigningNames: []string{"cloudtrail"},
+		Why: "The only plugin whose two SDKs disagree: botocore sends the model's " +
+			"fully-qualified namespace, aws-sdk-go-v2 sends the terse CloudTrail_20131101. " +
+			"An alias cannot fix the long form — the first label is com, which would hijack " +
+			"every fully-qualified prefix — so extractServiceFromTarget reduces a dotted " +
+			"namespace to its last segment instead.",
+		Source: "botocore cloudtrail service-2.json (long form); aws-sdk-go-v2 cloudtrail serializers (terse form)",
+	},
+	"codebuild": {
+		Display:      "CodeBuild",
+		Protocol:     "JSON",
+		TargetPrefix: "CodeBuild_20161006",
+		Hosts:        []string{"codebuild.us-east-1.amazonaws.com"},
+		SigningNames: []string{"codebuild"},
+		Source:       "botocore codebuild service-2.json",
+	},
+	"codedeploy": {
+		Display:      "CodeDeploy",
+		Protocol:     "JSON",
+		TargetPrefix: "CodeDeploy_20141006",
+		Hosts:        []string{"codedeploy.us-east-1.amazonaws.com"},
+		SigningNames: []string{"codedeploy"},
+		Source:       "botocore codedeploy service-2.json",
+	},
+	"codepipeline": {
+		Display:      "CodePipeline",
+		Protocol:     "JSON",
+		TargetPrefix: "CodePipeline_20150709",
+		Hosts:        []string{"codepipeline.us-east-1.amazonaws.com"},
+		SigningNames: []string{"codepipeline"},
+		Source:       "botocore codepipeline service-2.json",
+	},
+	"cognito-identity": {
+		Display:      "Cognito Identity",
+		Protocol:     "JSON",
+		TargetPrefix: "AWSCognitoIdentityService",
+		Hosts:        []string{"cognito-identity.us-east-1.amazonaws.com"},
+		SigningNames: []string{"cognito-identity"},
+		Source:       "botocore cognito-identity service-2.json",
+	},
+	"cognito-idp": {
+		Display:      "Cognito Identity Provider",
+		Protocol:     "JSON",
+		TargetPrefix: "AWSCognitoIdentityProviderService",
+		Hosts:        []string{"cognito-idp.us-east-1.amazonaws.com"},
+		SigningNames: []string{"cognito-idp"},
+		Source:       "botocore cognito-idp service-2.json",
+	},
+	"config": {
+		Display:      "Config",
+		Protocol:     "JSON",
+		TargetPrefix: "StarlingDoveService",
+		Hosts:        []string{"config.us-east-1.amazonaws.com"},
+		SigningNames: []string{"config"},
+		Why:          "StarlingDove is Config's internal code-name, the way TrentService is KMS's (#580).",
+		Source:       "botocore config service-2.json",
+	},
+	"dynamodb": {
+		Display:      "DynamoDB",
+		Protocol:     "JSON",
+		TargetPrefix: "DynamoDB_20120810",
+		Hosts:        []string{"dynamodb.us-east-1.amazonaws.com"},
+		SigningNames: []string{"dynamodb"},
+		Source:       "botocore dynamodb service-2.json",
+	},
+	"ec2": {
+		Display:      "EC2 / VPC",
+		Protocol:     "Query",
+		Hosts:        []string{"ec2.us-east-1.amazonaws.com"},
+		SigningNames: []string{"ec2"},
+		Source:       "botocore ec2 service-2.json",
+	},
+	"ecr": {
+		Display:      "ECR",
+		Protocol:     "JSON",
+		TargetPrefix: "AmazonEC2ContainerRegistry_V20150921",
+		Hosts:        []string{"api.ecr.us-east-1.amazonaws.com"},
+		SigningNames: []string{"ecr"},
+		Source:       "botocore ecr service-2.json",
+	},
+	"ecs": {
+		Display:      "ECS",
+		Protocol:     "JSON",
+		TargetPrefix: "AmazonEC2ContainerServiceV20141113",
+		Hosts:        []string{"ecs.us-east-1.amazonaws.com"},
+		SigningNames: []string{"ecs"},
+		Source:       "botocore ecs service-2.json",
+	},
+	"efs": {
+		Display:      "EFS",
+		Protocol:     "REST/JSON",
+		Hosts:        []string{"elasticfilesystem.us-east-1.amazonaws.com"},
+		SigningNames: []string{"elasticfilesystem"},
+		Source:       "botocore efs service-2.json",
+	},
+	"elasticache": {
+		Display:      "ElastiCache",
+		Protocol:     "Query",
+		Hosts:        []string{"elasticache.us-east-1.amazonaws.com"},
+		SigningNames: []string{"elasticache"},
+		Source:       "botocore elasticache service-2.json",
+	},
+	"elasticloadbalancing": {
+		Display:      "ELBv2",
+		Protocol:     "Query",
+		Hosts:        []string{"elasticloadbalancing.us-east-1.amazonaws.com"},
+		SigningNames: []string{"elasticloadbalancing"},
+		Source:       "botocore elbv2 service-2.json",
+	},
+	"emrserverless": {
+		Display:      "EMR Serverless",
+		Protocol:     "REST/JSON",
+		Hosts:        []string{"emr-serverless.us-east-1.amazonaws.com"},
+		SigningNames: []string{"emr-serverless"},
+		Source:       "botocore emr-serverless service-2.json",
+	},
+	"eventbridge": {
+		Display:      "EventBridge",
+		Protocol:     "JSON",
+		TargetPrefix: "AWSEvents",
+		Hosts:        []string{"events.us-east-1.amazonaws.com"},
+		SigningNames: []string{"events"},
+		Why:          "The prefix is AWSEvents, not AmazonEventBridge; host routing hid that until #734.",
+		Source:       "botocore events service-2.json",
+	},
+	"execute-api": {
+		Display:      "API Gateway (execute-api)",
+		Protocol:     "REST/JSON",
+		Hosts:        []string{"abc123def4.execute-api.us-east-1.amazonaws.com"},
+		SigningNames: []string{"execute-api"},
+		Why: "The first host label is the API's ID — data, not a service name — so the " +
+			"host path matches on the execute-api label instead. There is no service model: " +
+			"this is the runtime endpoint an SDK-generated client never calls.",
+		Source: "API Gateway developer guide (Invoke an API)",
+	},
+	"firehose": {
+		Display:      "Kinesis Data Firehose",
+		Protocol:     "JSON",
+		TargetPrefix: "Firehose_20150804",
+		Hosts:        []string{"firehose.us-east-1.amazonaws.com"},
+		SigningNames: []string{"firehose"},
+		Source:       "botocore firehose service-2.json",
+	},
+	"fsx": {
+		Display:      "FSx",
+		Protocol:     "JSON",
+		TargetPrefix: "AWSSimbaAPIService_v20180301",
+		Hosts:        []string{"fsx.us-east-1.amazonaws.com"},
+		SigningNames: []string{"fsx"},
+		Source:       "botocore fsx service-2.json",
+	},
+	"glue": {
+		Display:      "Glue",
+		Protocol:     "JSON",
+		TargetPrefix: "AWSGlue",
+		Hosts:        []string{"glue.us-east-1.amazonaws.com"},
+		SigningNames: []string{"glue"},
+		Source:       "botocore glue service-2.json",
+	},
+	"health": {
+		Display:      "Health",
+		Protocol:     "JSON",
+		TargetPrefix: "AWSHealth_20160804",
+		Hosts:        []string{"global.health.amazonaws.com", "health.us-east-1.amazonaws.com"},
+		SigningNames: []string{"health"},
+		Why: "Health is not regionalized: its partition endpoint is global.health, whose " +
+			"first label is not the service. Both this and the real target prefix were " +
+			"missing, while the table held an invented healthservice — the #561 failure " +
+			"repeated, and what hid this one (#739).",
+		Source: "botocore health service-2.json; botocore endpoints.json aws-global",
+	},
+	"iam": {
+		Display:      "IAM",
+		Protocol:     "Query",
+		Hosts:        []string{"iam.amazonaws.com"},
+		SigningNames: []string{"iam"},
+		Source:       "botocore iam service-2.json",
+	},
+	"kinesis": {
+		Display:      "Kinesis Data Streams",
+		Protocol:     "JSON",
+		TargetPrefix: "Kinesis_20131202",
+		Hosts:        []string{"kinesis.us-east-1.amazonaws.com"},
+		SigningNames: []string{"kinesis"},
+		Source:       "botocore kinesis service-2.json",
+	},
+	"kms": {
+		Display:      "KMS",
+		Protocol:     "JSON",
+		TargetPrefix: "TrentService",
+		Hosts:        []string{"kms.us-east-1.amazonaws.com"},
+		SigningNames: []string{"kms"},
+		Why:          "Trent is KMS's internal code-name; the prefix bears no relation to the endpoint.",
+		Source:       "botocore kms service-2.json",
+	},
+	"lambda": {
+		Display:      "Lambda",
+		Protocol:     "REST/JSON",
+		Hosts:        []string{"lambda.us-east-1.amazonaws.com"},
+		SigningNames: []string{"lambda"},
+		Source:       "botocore lambda service-2.json",
+	},
+	"logs": {
+		Display:      "CloudWatch Logs",
+		Protocol:     "JSON",
+		TargetPrefix: "Logs_20140328",
+		Hosts:        []string{"logs.us-east-1.amazonaws.com"},
+		SigningNames: []string{"logs"},
+		Source:       "botocore logs service-2.json",
+	},
+	"monitoring": {
+		Display:      "CloudWatch",
+		Protocol:     "Query",
+		TargetPrefix: "GraniteServiceVersion20100801",
+		Hosts:        []string{"monitoring.us-east-1.amazonaws.com"},
+		SigningNames: []string{"monitoring"},
+		Why: "The model declares three protocols and botocore resolves json first, so the " +
+			"AWS CLI sends this target while aws-sdk-go-v2 takes the rpc-v2-cbor path " +
+			"substrate already routed — green tests over an endpoint no CLI could reach " +
+			"(#739). Routing it does not make the CLI's JSON body parseable by a plugin " +
+			"that reads Query form parameters; that is filed separately.",
+		Source: "botocore cloudwatch service-2.json (metadata.protocols, resolved by botocore's protocol priority)",
+	},
+	"msk": {
+		Display:      "MSK",
+		Protocol:     "REST/JSON",
+		Hosts:        []string{"kafka.us-east-1.amazonaws.com"},
+		SigningNames: []string{"kafka"},
+		Source:       "botocore kafka service-2.json",
+	},
+	"omics": {
+		Display:      "HealthOmics",
+		Protocol:     "REST/JSON",
+		Hosts:        []string{"omics.us-east-1.amazonaws.com"},
+		SigningNames: []string{"omics"},
+		Source:       "botocore omics service-2.json",
+	},
+	"opensearch": {
+		Display:  "OpenSearch",
+		Protocol: "REST/JSON",
+		Hosts: []string{
+			"es.us-east-1.amazonaws.com",
+			"search-mydomain-abc123.us-east-1.es.amazonaws.com",
+			"abc123.us-east-1.aoss.amazonaws.com",
+		},
+		SigningNames: []string{"es", "aoss"},
+		Why: "A managed domain's and a Serverless collection's hosts both carry the name " +
+			"as data ahead of the es/aoss label. The plugin is data-plane only, so the " +
+			"OpenSearchServerless control-plane target prefix names operations substrate " +
+			"does not implement and is deliberately absent.",
+		Source: "botocore opensearch and opensearchserverless service-2.json",
+	},
+	"organizations": {
+		Display:      "Organizations",
+		Protocol:     "JSON",
+		TargetPrefix: "AWSOrganizationsV20161128",
+		Hosts:        []string{"organizations.us-east-1.amazonaws.com"},
+		SigningNames: []string{"organizations"},
+		Why:          "The version rides inside the prefix rather than after an underscore, so it never reduces on its own (#580).",
+		Source:       "botocore organizations service-2.json",
+	},
+	"pricing": {
+		Display:      "Price List Query API",
+		Protocol:     "JSON",
+		TargetPrefix: "AWSPriceListService",
+		Hosts:        []string{"api.pricing.us-east-1.amazonaws.com"},
+		SigningNames: []string{"pricing"},
+		Source:       "botocore pricing service-2.json",
+	},
+	"quicksight": {
+		Display:      "QuickSight",
+		Protocol:     "REST/JSON",
+		Hosts:        []string{"quicksight.us-east-1.amazonaws.com"},
+		SigningNames: []string{"quicksight"},
+		Source:       "botocore quicksight service-2.json",
+	},
+	"ram": {
+		Display:      "RAM",
+		Protocol:     "REST/JSON",
+		Hosts:        []string{"ram.us-east-1.amazonaws.com"},
+		SigningNames: []string{"ram"},
+		Source:       "botocore ram service-2.json",
+	},
+	"rds": {
+		Display:      "RDS",
+		Protocol:     "Query",
+		Hosts:        []string{"rds.us-east-1.amazonaws.com"},
+		SigningNames: []string{"rds"},
+		Source:       "botocore rds service-2.json",
+	},
+	"redshift": {
+		Display:      "Redshift",
+		Protocol:     "Query",
+		Hosts:        []string{"redshift.us-east-1.amazonaws.com"},
+		SigningNames: []string{"redshift"},
+		Source:       "botocore redshift service-2.json",
+	},
+	"redshift-data": {
+		Display:      "Redshift Data API",
+		Protocol:     "JSON",
+		TargetPrefix: "RedshiftData",
+		Hosts:        []string{"redshift-data.us-east-1.amazonaws.com"},
+		SigningNames: []string{"redshift-data"},
+		Source:       "botocore redshift-data service-2.json",
+	},
+	"route53": {
+		Display:      "Route 53",
+		Protocol:     "REST/XML",
+		Hosts:        []string{"route53.amazonaws.com"},
+		SigningNames: []string{"route53"},
+		Source:       "botocore route53 service-2.json",
+	},
+	"s3": {
+		Display:      "S3",
+		Protocol:     "REST/XML",
+		Hosts:        []string{"s3.us-east-1.amazonaws.com"},
+		SigningNames: []string{"s3"},
+		Source:       "botocore s3 service-2.json",
+	},
+	"sagemaker": {
+		Display:      "SageMaker",
+		Protocol:     "JSON",
+		TargetPrefix: "SageMaker",
+		Hosts:        []string{"api.sagemaker.us-east-1.amazonaws.com"},
+		SigningNames: []string{"sagemaker"},
+		Source:       "botocore sagemaker service-2.json",
+	},
+	"scheduler": {
+		Display:      "EventBridge Scheduler",
+		Protocol:     "REST/JSON",
+		Hosts:        []string{"scheduler.us-east-1.amazonaws.com"},
+		SigningNames: []string{"scheduler"},
+		Source:       "botocore scheduler service-2.json",
+	},
+	"secretsmanager": {
+		Display:      "Secrets Manager",
+		Protocol:     "JSON",
+		TargetPrefix: "secretsmanager",
+		Hosts:        []string{"secretsmanager.us-east-1.amazonaws.com"},
+		SigningNames: []string{"secretsmanager"},
+		Source:       "botocore secretsmanager service-2.json",
+	},
+	"servicequotas": {
+		Display:      "Service Quotas",
+		Protocol:     "JSON",
+		TargetPrefix: "ServiceQuotasV20190624",
+		Hosts:        []string{"servicequotas.us-east-1.amazonaws.com"},
+		SigningNames: []string{"servicequotas"},
+		Source:       "botocore service-quotas service-2.json",
+	},
+	"sesv2": {
+		Display:      "SES v2",
+		Protocol:     "REST/JSON",
+		Hosts:        []string{"email.us-east-1.amazonaws.com"},
+		SigningNames: []string{"ses"},
+		Why:          "The v2 API keeps v1's email host and ses signing name.",
+		Source:       "botocore sesv2 service-2.json",
+	},
+	"sns": {
+		Display:      "SNS",
+		Protocol:     "Query",
+		Hosts:        []string{"sns.us-east-1.amazonaws.com"},
+		SigningNames: []string{"sns"},
+		Source:       "botocore sns service-2.json",
+	},
+	"sqs": {
+		Display:      "SQS",
+		Protocol:     "JSON",
+		TargetPrefix: "AmazonSQS",
+		Hosts:        []string{"sqs.us-east-1.amazonaws.com"},
+		SigningNames: []string{"sqs"},
+		Source:       "botocore sqs service-2.json",
+	},
+	"ssm": {
+		Display:      "SSM",
+		Protocol:     "JSON",
+		TargetPrefix: "AmazonSSM",
+		Hosts:        []string{"ssm.us-east-1.amazonaws.com"},
+		SigningNames: []string{"ssm"},
+		Source:       "botocore ssm service-2.json",
+	},
+	"sso": {
+		Display:      "SSO / Identity Store",
+		Protocol:     "REST/JSON",
+		TargetPrefix: "SWBExternalService",
+		Hosts:        []string{"sso.us-east-1.amazonaws.com"},
+		SigningNames: []string{"sso"},
+		Why: "The plugin emulates sso-admin, whose model is JSON 1.1 — substrate answers " +
+			"REST/JSON and classifies its errors that way, which is filed as its own issue. " +
+			"The guessed AWSSSOAdminService prefix that no client sends is what made the " +
+			"plugin unreachable in #561.",
+		Source: "botocore sso-admin service-2.json",
+	},
+	"states": {
+		Display:      "Step Functions",
+		Protocol:     "JSON",
+		TargetPrefix: "AWSStepFunctions",
+		Hosts:        []string{"states.us-east-1.amazonaws.com"},
+		SigningNames: []string{"states"},
+		Source:       "botocore stepfunctions service-2.json",
+	},
+	"sts": {
+		Display:      "STS",
+		Protocol:     "Query",
+		Hosts:        []string{"sts.amazonaws.com", "sts.us-east-1.amazonaws.com"},
+		SigningNames: []string{"sts"},
+		Source:       "botocore sts service-2.json",
+	},
+	"tagging": {
+		Display:      "Resource Groups Tagging",
+		Protocol:     "JSON",
+		TargetPrefix: "ResourceGroupsTaggingAPI_20170126",
+		Hosts:        []string{"tagging.us-east-1.amazonaws.com"},
+		SigningNames: []string{"tagging"},
+		Source:       "botocore resourcegroupstaggingapi service-2.json",
+	},
+	"timestream": {
+		Display:  "Timestream",
+		Protocol: "JSON",
+		// Write and Query share the prefix and the signing name; they differ only in host.
+		TargetPrefix: "Timestream_20181101",
+		Hosts: []string{
+			"ingest.timestream.us-east-1.amazonaws.com",
+			"query.timestream.us-east-1.amazonaws.com",
+		},
+		SigningNames: []string{"timestream"},
+		Why: "Endpoint discovery hands a client an ingest. or query. host whose first label " +
+			"is the operation class, not the service, so both reduced to nothing before #739. " +
+			"A --endpoint-url caller was unaffected, which is why the suite stayed green.",
+		Source: "botocore timestream-write and timestream-query service-2.json",
+	},
+	"transfer": {
+		Display:      "Transfer Family",
+		Protocol:     "JSON",
+		TargetPrefix: "TransferService",
+		Hosts:        []string{"transfer.us-east-1.amazonaws.com"},
+		SigningNames: []string{"transfer"},
+		Source:       "botocore transfer service-2.json",
+	},
+	"wafv2": {
+		Display:      "WAFv2",
+		Protocol:     "JSON",
+		TargetPrefix: "AWSWAF_20190729",
+		Hosts:        []string{"wafv2.us-east-1.amazonaws.com"},
+		SigningNames: []string{"wafv2"},
+		Source:       "botocore wafv2 service-2.json",
+	},
+}
+
+// PluginRoutingCatalog returns a copy of the routing table, keyed by plugin name.
+// Callers outside the package — the documentation generator and its drift check —
+// read display names, protocols and routing identifiers from here, so a plugin
+// cannot be registered without declaring how a client reaches it.
+func PluginRoutingCatalog() map[string]PluginRouting {
+	out := make(map[string]PluginRouting, len(pluginRouting))
+	for name, r := range pluginRouting {
+		out[name] = r
+	}
+	return out
+}

--- a/emulator/routing_test.go
+++ b/emulator/routing_test.go
@@ -1,0 +1,313 @@
+package emulator_test
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	emulator "github.com/scttfrdmn/substrate/emulator"
+)
+
+// routingTestRegistry boots the default plugin registry and returns the set of
+// registered plugin names, so a routing assertion can be made against what is
+// actually reachable rather than against a name written down twice.
+func routingTestRegistry(t *testing.T) map[string]bool {
+	t.Helper()
+
+	state := emulator.NewMemoryStateManager()
+	tc := emulator.NewTimeController(time.Unix(0, 0).UTC())
+	registry := emulator.NewPluginRegistry()
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	store := emulator.NewEventStore(emulator.EventStoreConfig{Enabled: false})
+	require.NoError(t, emulator.RegisterDefaultPlugins(
+		context.Background(), registry, state, tc, logger, store, nil))
+
+	names := registry.Names()
+	require.NotEmpty(t, names, "the registry must hold plugins for this to assert anything")
+	registered := make(map[string]bool, len(names))
+	for _, n := range names {
+		registered[n] = true
+	}
+	return registered
+}
+
+// TestPluginRouting_MatchesTheRegistry pins the routing table to the registry in
+// both directions. The documentation generator enforces the same property, but it
+// runs only under `make docs-reference-check`; a plugin registered without routing
+// is a plugin no SDK can address, which belongs in the test suite.
+func TestPluginRouting_MatchesTheRegistry(t *testing.T) {
+	t.Parallel()
+
+	registered := routingTestRegistry(t)
+	routing := emulator.PluginRoutingCatalog()
+
+	for name := range registered {
+		assert.Contains(t, routing, name,
+			"plugin %q is registered but has no entry in emulator/routing.go, so nothing "+
+				"asserts that a real client can address it", name)
+	}
+	for name := range routing {
+		assert.True(t, registered[name],
+			"routing entry %q names no registered plugin; remove it", name)
+	}
+}
+
+// TestPluginRouting_EveryIdentifierReachesARegisteredPlugin is the sweep #739 asks
+// for: for every plugin, every identifier a real AWS client sends — the X-Amz-Target
+// namespace, each endpoint host, each SigV4 signing name — must resolve to a
+// *registered* plugin.
+//
+// Asserting registration rather than string-comparing the name is the point.
+// Substrate resolves a service by reducing those three signals to a lowercase
+// string, and a reduction that lands on nothing (or on a label like "com",
+// "ingest" or "global") answers ServiceNotAvailable while every unit test over the
+// plugin's own handlers stays green. That is how SSOPlugin (#561),
+// OrganizationsPlugin and ConfigServicePlugin (#580) and EventBridgePlugin (#734)
+// each shipped registered and unreachable, and how CloudWatch, Health, CloudTrail
+// and Timestream were still unreachable at v0.108.0 (#739).
+//
+// The target is signal #1, which is why this hides: an unrecognized namespace
+// short-circuits the host and signing-name paths that would both have answered
+// correctly. And substrate is always reached with --endpoint-url, where the host is
+// localhost, so the target is the only signal a caller actually supplies.
+func TestPluginRouting_EveryIdentifierReachesARegisteredPlugin(t *testing.T) {
+	t.Parallel()
+
+	registered := routingTestRegistry(t)
+
+	for name, route := range emulator.PluginRoutingCatalog() {
+		name, route := name, route
+		want := name
+		if route.RoutesTo != "" {
+			want = route.RoutesTo
+		}
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if route.TargetPrefix != "" {
+				t.Run("target", func(t *testing.T) {
+					t.Parallel()
+					r := httptest.NewRequest(http.MethodPost, "http://localhost:4566/", nil)
+					r.Host = "localhost:4566"
+					r.Header.Set("X-Amz-Target", route.TargetPrefix+".ListSomething")
+
+					req, _, err := emulator.ParseAWSRequest(r)
+					require.NoError(t, err)
+					assert.Equal(t, want, req.Service,
+						"X-Amz-Target %q must route to %q", route.TargetPrefix, want)
+					assert.True(t, registered[req.Service],
+						"X-Amz-Target %q reduces to %q, which is not a registered plugin: "+
+							"every client sending it gets ServiceNotAvailable",
+						route.TargetPrefix, req.Service)
+				})
+			}
+
+			for _, host := range route.Hosts {
+				host := host
+				t.Run("host/"+host, func(t *testing.T) {
+					t.Parallel()
+					r := httptest.NewRequest(http.MethodPost, "http://"+host+"/", nil)
+					r.Host = host
+
+					req, _, err := emulator.ParseAWSRequest(r)
+					require.NoError(t, err)
+					assert.Equal(t, want, req.Service, "host %q must route to %q", host, want)
+					assert.True(t, registered[req.Service],
+						"host %q reduces to %q, which is not a registered plugin", host, req.Service)
+				})
+			}
+
+			for _, signing := range route.SigningNames {
+				signing := signing
+				t.Run("signing/"+signing, func(t *testing.T) {
+					t.Parallel()
+					r := httptest.NewRequest(http.MethodPost, "http://localhost:4566/", nil)
+					r.Host = "localhost:4566"
+					r.Header.Set("Authorization",
+						"AWS4-HMAC-SHA256 Credential=AKIATEST12345678901/20260101/us-east-1/"+
+							signing+"/aws4_request, SignedHeaders=host, Signature=fake")
+
+					req, _, err := emulator.ParseAWSRequest(r)
+					require.NoError(t, err)
+					assert.Equal(t, want, req.Service,
+						"SigV4 signing name %q must route to %q", signing, want)
+					assert.True(t, registered[req.Service],
+						"SigV4 signing name %q reduces to %q, which is not a registered plugin",
+						signing, req.Service)
+				})
+			}
+		})
+	}
+}
+
+// TestPluginRouting_RowsAreComplete asserts the table's own invariants, so a row
+// added without them fails here rather than silently weakening the sweep above.
+//
+// A row with no host and no signing name asserts nothing, and a JSON plugin with
+// no target prefix leaves the one signal a --endpoint-url caller supplies untested
+// — which is exactly the gap CloudWatch sat in, present in smithyServiceAliases
+// and absent from targetServiceAliases. Every row cites a source, and the citation
+// must name *which* source: botocore and aws-sdk-go-v2 disagree about CloudTrail's
+// namespace, so a table citing "the SDK" would have recorded a prefix half the
+// world's clients do not send. A row that deliberately routes elsewhere, or that
+// leaves an identifier out, has to say why in prose.
+func TestPluginRouting_RowsAreComplete(t *testing.T) {
+	t.Parallel()
+
+	routing := emulator.PluginRoutingCatalog()
+	for name, route := range routing {
+		name, route := name, route
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.NotEmpty(t, route.Display, "row must carry a display name for docs/services.md")
+			assert.NotEmpty(t, route.Protocol, "row must name the protocol the plugin speaks")
+			assert.NotEmpty(t, route.Source, "row must cite where its identifiers were read from")
+			assert.NotEmpty(t, route.Hosts, "row must give at least one example endpoint host")
+			assert.NotEmpty(t, route.SigningNames, "row must give at least one SigV4 signing name")
+
+			if route.Protocol == "JSON" {
+				assert.NotEmpty(t, route.TargetPrefix,
+					"a JSON plugin is addressed by X-Amz-Target, which is the only signal a "+
+						"--endpoint-url caller supplies; record the prefix its model declares")
+			}
+			if route.RoutesTo != "" {
+				assert.Contains(t, routing, route.RoutesTo,
+					"RoutesTo must name a plugin in this table")
+				assert.NotEmpty(t, route.Why, "a row that routes elsewhere must explain why")
+			}
+			for _, host := range route.Hosts {
+				assert.True(t, strings.HasSuffix(host, ".amazonaws.com"),
+					"host %q must be a complete example endpoint host", host)
+			}
+		})
+	}
+}
+
+// TestPluginRouting_TheFourMissesFoundBy739 pins each of the four reachability
+// misses the #739 sweep turned up, separately from the table-driven sweep, so the
+// reason each one hid is recorded next to the assertion.
+//
+// Every one of these fails against v0.108.0. Each was confirmed against a real
+// client before the fix — the AWS CLI, not aws-sdk-go-v2, because the Go SDK
+// already routed CloudWatch and CloudTrail correctly, which is precisely why
+// substrate's suite and test/e2e were green over endpoints no CLI could reach.
+func TestPluginRouting_TheFourMissesFoundBy739(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// target and host are the identifier under test; exactly one is set.
+		target string
+		host   string
+		want   string
+		why    string
+	}{
+		{
+			name:   "cloudwatch target prefix",
+			target: "GraniteServiceVersion20100801.ListMetrics",
+			want:   "monitoring",
+			why: "CloudWatch's model declares protocols ['smithy-rpc-v2-cbor','json','query'] " +
+				"and botocore resolves json first, so every AWS CLI and boto3 call sends this " +
+				"target. The name was in smithyServiceAliases for the CBOR URL path — the path " +
+				"aws-sdk-go-v2 takes — and absent from targetServiceAliases.",
+		},
+		{
+			name:   "health target prefix",
+			target: "AWSHealth_20160804.DescribeEvents",
+			want:   "health",
+			why: "The table held an invented \"healthservice\" in the slot the real prefix " +
+				"needed: a guessed name no client sends, which is the #561 failure repeated.",
+		},
+		{
+			name: "health global endpoint",
+			host: "global.health.amazonaws.com",
+			want: "health",
+			why: "Health is not regionalized, so its partition endpoint carries a literal " +
+				"\"global\" label ahead of the service name and reduced to \"global\".",
+		},
+		{
+			name:   "cloudtrail fully-qualified target prefix",
+			target: "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.DescribeTrails",
+			want:   "cloudtrail",
+			why: "botocore sends the model's fully-qualified namespace, which splitting at the " +
+				"first dot reduced to \"com\". aws-sdk-go-v2 sends the terse CloudTrail_20131101 " +
+				"and always worked, so only a CLI or boto3 caller saw the failure. An alias " +
+				"cannot fix it — \"com\" prefixes every fully-qualified namespace.",
+		},
+		{
+			name:   "cloudtrail terse target prefix still resolves",
+			target: "CloudTrail_20131101.DescribeTrails",
+			want:   "cloudtrail",
+			why:    "The reduction must not break the form aws-sdk-go-v2 sends.",
+		},
+		{
+			name: "timestream ingest endpoint",
+			host: "ingest.timestream.us-east-1.amazonaws.com",
+			want: "timestream",
+			why: "Endpoint discovery hands a client a host whose first label is the operation " +
+				"class, so it reduced to \"ingest\". A --endpoint-url caller was unaffected, " +
+				"which is why the suite never saw it.",
+		},
+		{
+			name: "timestream query endpoint",
+			host: "query.timestream.us-east-1.amazonaws.com",
+			want: "timestream",
+			why:  "The query endpoint reduced to \"query\" for the same reason.",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			host := tt.host
+			if host == "" {
+				host = "localhost:4566"
+			}
+			r := httptest.NewRequest(http.MethodPost, "http://"+host+"/", nil)
+			r.Host = host
+			if tt.target != "" {
+				r.Header.Set("X-Amz-Target", tt.target)
+			}
+
+			req, _, err := emulator.ParseAWSRequest(r)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, req.Service, tt.why)
+		})
+	}
+}
+
+// TestPluginRouting_DottedTargetKeepsTheOperation guards the other half of the
+// CloudTrail change: reducing a dot-qualified namespace must not disturb the
+// operation, which is still whatever follows the final dot.
+func TestPluginRouting_DottedTargetKeepsTheOperation(t *testing.T) {
+	t.Parallel()
+
+	for target, want := range map[string]string{
+		"com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.DescribeTrails": "DescribeTrails",
+		"CloudTrail_20131101.CreateTrail":                                       "CreateTrail",
+		"DynamoDB_20120810.GetItem":                                             "GetItem",
+	} {
+		target, want := target, want
+		t.Run(want, func(t *testing.T) {
+			t.Parallel()
+			r := httptest.NewRequest(http.MethodPost, "http://localhost:4566/", nil)
+			r.Host = "localhost:4566"
+			r.Header.Set("X-Amz-Target", target)
+
+			req, _, err := emulator.ParseAWSRequest(r)
+			require.NoError(t, err)
+			assert.Equal(t, want, req.Operation)
+		})
+	}
+}


### PR DESCRIPTION
Closes #739

## The failure mode

Substrate resolves which plugin serves a request by reducing four signals to one lowercase
service name, in priority order: `X-Amz-Target` namespace, `Host`, Smithy URL path, SigV4
credential scope. The target is checked **first**, so an unrecognized namespace
short-circuits the `Host` and signing-name paths that would both have answered correctly.

And substrate is reached with `--endpoint-url http://localhost:4566`, where the host is
`localhost` and there is no Smithy path — so for a JSON service the target is effectively
the only signal a caller supplies. An unrecognized one answers `ServiceNotAvailable` for
**every operation of that service**, while every unit test over the plugin's own handlers
stays green.

That has shipped four times: `sso` (#561), `organizations` and `config` (#580), `eventbridge`
(#734). Each was found by pointing a real client at a running server. This PR is the sweep
that makes the check systematic.

## The four it found

All 67 plugins' identifiers were read from the botocore models bundled in the locally
installed AWS CLI v2 — `metadata.targetPrefix` / `endpointPrefix` / `signingName`, plus
`endpoints.json` for a non-regionalized host — and the JSON ones were cross-checked against
`aws-sdk-go-v2` serializers.

| Plugin | What a client sends | Reduced to | Who saw it |
|---|---|---|---|
| `monitoring` | `GraniteServiceVersion20100801.{Op}` | nothing | **every AWS CLI and boto3 caller** |
| `health` | `AWSHealth_20160804.{Op}` | nothing (table held an invented `healthservice`) | every SDK |
| `health` | `Host: global.health.amazonaws.com` | `global` | a real-endpoint caller |
| `cloudtrail` | `com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.{Op}` | `com` | the CLI and boto3 only |
| `timestream` | `Host: ingest.`/`query.timestream.{region}` | `ingest` / `query` | an endpoint-discovery caller |

**CloudWatch is the headline.** Its model declares `protocols:
['smithy-rpc-v2-cbor','json','query']`; botocore resolves `json` first, so the CLI sends that
target. The name was already in `smithyServiceAliases` — the CBOR path `aws-sdk-go-v2` takes
— and absent from `targetServiceAliases`. Both substrate's suite and `test/e2e` drive
`aws-sdk-go-v2`, which is exactly why they were green over a dead endpoint.

**Health is the #561 failure repeated verbatim.** A guessed prefix (`healthservice`) sat in
the slot the real one needed — and `health_plugin_test.go` *sent the guessed prefix*, so the
suite proved only that substrate routes a name substrate invented. That test now sends what
the model declares.

**CloudTrail is why a source citation must name the SDK.** botocore sends the
fully-qualified namespace; `aws-sdk-go-v2` sends the terse `CloudTrail_20131101` and always
worked. An alias cannot fix the long form — its first label is `com`, which prefixes every
fully-qualified namespace and would hijack any other service that adopted one. A dotted
namespace now reduces to its **last** segment, mirroring what `extractOperation` already did.
Of the 430 botocore models only three carry a dotted prefix (`cloudtrail`,
`codeconnections`, `codestar-connections` — the latter two not substrate plugins) and their
last segments do not collide.

## Where the table lives

`emulator/routing.go` records, per plugin, the target prefix, one example endpoint host per
distinct shape, the signing names, and a cited source. Three consumers keep it honest:

1. the generated coverage matrix in `docs/services.md` reads its display names and protocols
   — replacing the duplicate `meta` map that lived in `cmd/gen-service-reference`, which
   could have agreed with the docs while disagreeing with what an SDK sends;
2. `make docs-reference-check` fails when a registered plugin has no row, or a row names no
   registered plugin (#739's fourth acceptance criterion, already enforced there);
3. `TestPluginRouting_EveryIdentifierReachesARegisteredPlugin` drives every identifier
   through `ParseAWSRequest` and asserts the answer is a **registered** plugin — not a
   matching string, which is what actually encodes "no plugin is unreachable".

Three plugins legitimately cannot be addressed three ways and declare it in prose rather
than being skipped: `apigatewayv2` (shares `apigateway`'s host *and* signing name;
disambiguated by `/v2/`, #529), `execute-api` (the host's first label is the API ID — data),
and `opensearch` (data-plane only, so the Serverless control-plane prefix is absent on
purpose).

## Fail-first evidence

Against a build of `main`:

```
service not emulated: graniteserviceversion20100801
service not emulated: com
service not emulated: awshealth
```

and `timestream-write list-databases` succeeded, confirming Timestream is host-path-only.

The new tests, run against the pre-fix `parser.go`, fail on exactly those four and nothing
else:

```
--- FAIL: …/monitoring/target
--- FAIL: …/cloudtrail/target
--- FAIL: …/health/target
--- FAIL: …/health/host/global.health.amazonaws.com
--- FAIL: …/timestream/host/ingest.timestream.us-east-1.amazonaws.com
--- FAIL: …/timestream/host/query.timestream.us-east-1.amazonaws.com
```

After the fix, against the built binary with the **AWS CLI** (not `aws-sdk-go-v2`, which
already routed CloudWatch and CloudTrail correctly):

```
$ aws --endpoint-url http://localhost:4678 cloudtrail describe-trails
{ "trailList": [] }
$ curl -sX POST http://localhost:4678/ -H 'X-Amz-Target: AWSHealth_20160804.DescribeEvents' \
    -H 'Content-Type: application/x-amz-json-1.1' -d '{}'
{"Events":[],"NextToken":""}
$ curl -sX POST http://localhost:4678/ -H 'X-Amz-Target: GraniteServiceVersion20100801.ListMetrics' \
    -H 'Content-Type: application/x-amz-json-1.0' -d '{}'
HTTP 200 … <ListMetricsResponse xmlns="http://monitoring.amazonaws.com/doc/2010-08-01/"> …
```

The last one is the honest limit: **routing CloudWatch is not serving it.** The CLI's JSON
body now reaches a handler that reads query-form parameters and answers XML, so the client
gets a 200 it cannot parse. That is stated in `docs/services.md` and filed as #757; a
protocol rewrite of `CloudWatchPlugin` is a release of its own, not a rider on a routing
sweep. `sso`'s error protocol — classified REST/JSON while the plugin emulates sso-admin,
which is JSON 1.1 — is #758.

## Docs

`docs/services.md` gains a "How a request reaches a plugin" section: the four signals, why
the priority order hides a routing bug, the routing table and its three consumers, the four
misses with the reason each hid, the three deliberately non-three-path plugins, and the
coverage limit that Java/JavaScript/.NET were not checked. Three per-service `X-Amz-Target`
lines were also wrong and are corrected — Step Functions' is `AWSStepFunctions` not
`AmazonStates`, ECR's is `_V20150921` not `_V1_1_0`, Organizations' is
`AWSOrganizationsV20161128` not `Organizations_20161128`. Substrate accepts the old spellings
too, so no caller breaks.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint` (0 issues), `make test` (race), `make coverage`
(emulator **83.3%**, total **82.7%** — the pre-PR baseline exactly), `make docs-reference
docs-reference-check docs-versions`, `npm --prefix docs run build` with no dangling anchors,
and `go vet -C test/e2e ./... && go test -C test/e2e ./...`.