### PR TITLE
feat(ec2): an AMI reports its architecture, platform and root device (#750)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **An AMI reports its architecture, platform and root device** (#750). `DescribeImages`
+  rendered six members — ID, name, description, state, owner and creation date — and nothing
+  about the image itself, so a caller that branched on architecture to pick an instance type,
+  on the platform to decide between PowerShell and bash user data, or on the root device name
+  to build a block device mapping read an empty string out of an AMI substrate knew the answer
+  for. Twelve members now render: `architecture`, `platform`, `platformDetails`,
+  `usageOperation`, `rootDeviceName`, `rootDeviceType`, `virtualizationType`, `hypervisor`,
+  `imageType`, `imageOwnerAlias`, `isPublic` and `publicSsmParameterName`.
+
+  Neither `EC2Image` nor the bundled catalog held any of this, so both gained the fields —
+  and because one closure renders both the state walk and the bundled pass, every default is
+  a decision about *both* kinds of AMI. Four came out asymmetric: `imageOwnerAlias` is
+  `amazon` on the seven AWS-published entries and absent on the two Canonical ones, because
+  the alias is "an Amazon-maintained list" and Canonical is not on it; `publicSsmParameterName`
+  is the parameter an image was discovered through and is absent on a caller's own AMI, since
+  no public parameter names one; and `platformDetails`/`usageOperation` are absent on a
+  registered AMI, because AWS derives both from product codes substrate does not model and
+  reporting `Linux/UNIX` would be a guess about what the image contains.
+
+  `RegisterImage` now stores `Architecture`, `VirtualizationType` and `RootDeviceName`, which
+  it previously read and discarded or never read at all, and derives `rootDeviceType` from
+  whether `ImageLocation` was sent — AWS documents that parameter as the S3 manifest path, so
+  its presence is the caller's own signal for the instance-store registration form. Its
+  defaults are **AWS's documented ones**, `i386` and `paravirtual`: no AMI a caller would
+  register today is either and both will look wrong, but inventing `x86_64`/`hvm` would mean a
+  request that omits the parameter reports one thing here and another on AWS. Neither value is
+  validated against AWS's enum, following the reasoning the mapping rules already state — a
+  new refusal on a published path arrives unannounced.
+
+  `CreateImage` inherits architecture, platform, the billing pair, virtualization type and
+  root device name from the AMI its source instance runs, rather than leaving them empty: an
+  image of an arm64 Amazon Linux instance runs arm64 Amazon Linux, and reporting nothing while
+  its parent reported `arm64` would be two of substrate's own answers disagreeing about one
+  lineage. Ownership is not inherited — the new AMI is the caller's private image whatever it
+  was made from — and the fabricated root mapping follows the inherited device name, so an
+  AMI's `rootDeviceName` and its `blockDeviceMapping` cannot disagree.
+
+  Each bundled entry's root device name is **substrate's reading**: AWS's device naming
+  reference says only "Differs by AMI — `/dev/sda1` or `/dev/xvda`" and publishes no per-AMI
+  table, so the split follows each publisher's convention — `/dev/xvda` for Amazon Linux and
+  the ECS-optimized images, `/dev/sda1` for Windows and Ubuntu. Two AWS pages contradict
+  themselves and the side taken is recorded in `docs/services.md`: `platform` renders as the
+  lowercase `windows` (the member's own prose, `DescribeImages`' second example and the
+  `platform` filter, against the type page's Valid Values line), and the members are spelled
+  `imageOwnerId`/`isPublic` per the `Image` type page and Examples 2–3 rather than
+  `ownerId`/`public` per Example 1.
+
 ### Fixed
+- **Fourteen `DescribeImages` filters were accepted and never applied** (#750). `architecture`,
+  `description`, `hypervisor`, `image-type`, `is-public`, `name`, `owner-alias`, `owner-id`,
+  `platform`, `public-ssm-parameter-name`, `root-device-name`, `root-device-type`, `state` and
+  `virtualization-type` were all in the operation's accepted list — named without narrowing —
+  so a request filtering on `architecture` answered with every AMI in the account and a caller
+  read the non-empty result as a match. That is worse than a refusal in both directions, and it
+  is why the filters and the members above are one change: rendering `architecture` while
+  ignoring the `architecture` filter would have made the gap newly visible without closing it.
+  Eighteen of AWS's forty-three names are now evaluated; the remaining twenty-five select on
+  product codes, watermarks, source-image lineage, state reasons and other state substrate does
+  not keep, or on `creation-date`, whose ISO-8601-prefix-with-wildcards rule is its own.
+- **A named bundled AMI answered with an empty `<imageOwnerId>`** (#750). The member carried no
+  `omitempty` while a bundled image has no owner substrate can name, so the element was present
+  and blank — which an SDK decodes as "the owner is the empty string" rather than as "there is
+  no owner". A comment in the catalog claimed nothing rendered the member at all; it did. The
+  owner is now omitted and the alias rendered in its place: Amazon's AMI-owning account varies
+  by Region and AWS publishes no stable mapping, so it is not inventable.
 - **Four plugins were registered, unit-tested, and unreachable from a real AWS client**
   (#739). Substrate resolves which plugin serves a request by reducing four signals to one
   service name, and `X-Amz-Target` is checked first — so a namespace it does not recognize

--- a/docs/services.md
+++ b/docs/services.md
@@ -3272,7 +3272,7 @@ one is refused on its neighbour — `tag:<key>` most conspicuously (see below).
 | Operation | Evaluated | Documented but inert |
 |---|---|---|
 | DescribeInstances | `availability-zone`, `image-id`, `instance-id`, `instance-state-code`, `instance-state-name`, `instance-type`, `key-name`, `subnet-id`, `tag-key`, `tag:<key>`, `vpc-id` | the other 125 — the `network-interface.*`, `block-device-mapping.*`, `metadata-options.*`, `capacity-reservation*`, `private-dns-name-options.*`, `iam-instance-profile.*` and `operator.*` families, plus `architecture`, `platform`, `tenancy`, `root-device-type`, `owner-id` and the rest |
-| DescribeImages | `block-device-mapping.snapshot-id`, `image-id`, `tag-key`, `tag:<key>` | the other 39 — the `block-device-mapping.*` (bar `snapshot-id`), `image-watermark.*`, `product-code*`, `source-image*` and `state-reason-*` families, plus `architecture`, `creation-date`, `description`, `is-public`, `name`, `owner-alias`, `owner-id`, `platform`, `root-device-name`, `root-device-type`, `state` and the rest |
+| DescribeImages | `architecture`, `block-device-mapping.snapshot-id`, `description`, `hypervisor`, `image-id`, `image-type`, `is-public`, `name`, `owner-alias`, `owner-id`, `platform`, `public-ssm-parameter-name`, `root-device-name`, `root-device-type`, `state`, `tag-key`, `tag:<key>`, `virtualization-type` | the other 25 — the `block-device-mapping.*` (bar `snapshot-id`), `image-watermark.*`, `product-code*`, `source-image*` and `state-reason-*` families, plus `creation-date`, the ENA/sriov and kernel/ramdisk names, the Allowed-AMIs and Free-Tier markers and the rest |
 | DescribeVolumes | `attachment.delete-on-termination`, `attachment.device`, `attachment.instance-id`, `availability-zone`, `size`, `snapshot-id`, `status`, `tag-key`, `tag:<key>`, `volume-id`, `volume-type` | `attachment.attach-time`, `attachment.status`, `availability-zone-id`, `create-time`, `encrypted`, `fast-restored`, `multi-attach-enabled`, `operator.managed`, `operator.principal` |
 | DescribeSnapshots | `description`, `encrypted`, `owner-id`, `progress`, `snapshot-id`, `start-time`, `status`, `tag-key`, `tag:<key>`, `volume-id`, `volume-size` | `owner-alias`, `storage-tier`, `transfer-type` |
 | DescribeSubnets | `availability-zone`, `cidr-block`, `default-for-az`, `map-public-ip-on-launch`, `owner-id`, `state`, `subnet-arn`, `subnet-id`, `tag-key`, `tag:<key>`, `vpc-id`, plus AWS's four alias spellings `availabilityZone`, `cidr`, `cidrBlock` and `defaultForAz` | `availability-zone-id`/`availabilityZoneId`, `available-ip-address-count`, `customer-owned-ipv4-pool`, `enable-dns64`, `enable-lni-at-device-index`, `ipv6-native`, `map-customer-owned-ip-on-launch`, `outpost-arn`, and the three `ipv6-cidr-block-association.*` and three `private-dns-name-options-on-launch.*` filters |
@@ -3592,8 +3592,11 @@ Two things follow from bundled images living outside state.
   exist — see [Explicit resource IDs](#explicit-resource-ids), whose rules
   `DescribeImages` follows for every other ID.
 - **They are not the caller's.** A bundled image reports no owner, so it is not
-  taggable and an `Owners=self` describe does not match it. Register your own AMI
-  when the test is about owning one.
+  taggable, an `Owners=self` describe does not match it, and the `owner-id` filter
+  selects nothing for it. It reports `imageOwnerAlias` instead where AWS publishes
+  one — see [An AMI reports its architecture, platform and root
+  device](#an-ami-reports-its-architecture-platform-and-root-device). Register your
+  own AMI when the test is about owning one.
 
 Deliberately **not** bundled: the example IDs AWS's own reference pages use,
 `ami-0abcdef1234567890` and `ami-1234567890abcdef0`. Generated IaC copies them,
@@ -5353,12 +5356,116 @@ predate this change. The `ResourceType` code is **substrate's reading** — AWS 
 "the request fails" — chosen because `InvalidParameterValue` is EC2's gloss for "A value
 specified in a parameter is not valid, is unsupported, or cannot be used".
 
+#### An AMI reports its architecture, platform and root device
+
+`DescribeImages` rendered six members — `imageId`, `name`, `description`, `imageState`,
+`imageOwnerId` and `creationDate` — and nothing about the image itself. So a caller that
+branched on architecture to pick an instance type, or on the platform to decide whether to
+send PowerShell or bash user data, or on the root device name to build a block device
+mapping, read an empty string out of an AMI substrate knew the answer for. Twelve members
+now render ([#750](https://github.com/scttfrdmn/substrate/issues/750)):
+
+| Member | Bundled AMI | Caller's AMI |
+|---|---|---|
+| `architecture` | from the catalog — `x86_64` or `arm64` | `RegisterImage`'s `Architecture`, or inherited by `CreateImage` |
+| `platform` | `windows` on the Windows entry, **omitted** on the eight Linux ones | omitted; `RegisterImage` takes no such parameter |
+| `platformDetails`, `usageOperation` | `Linux/UNIX`+`RunInstances`, or `Windows`+`RunInstances:0002` | omitted, unless inherited by `CreateImage` |
+| `rootDeviceName` | `/dev/xvda` on the Amazon Linux and ECS entries, `/dev/sda1` on Windows and Ubuntu | `RegisterImage`'s `RootDeviceName`, or inherited |
+| `rootDeviceType` | `ebs` | `instance-store` when `ImageLocation` was sent, otherwise `ebs` |
+| `virtualizationType` | `hvm` | `RegisterImage`'s `VirtualizationType`, or inherited |
+| `hypervisor` | `xen` | `xen` |
+| `imageType` | `machine` | `machine` |
+| `imageOwnerAlias` | `amazon` on the seven AWS-published entries, **omitted** on the two Canonical ones | omitted |
+| `isPublic` | `true` | `false` |
+| `publicSsmParameterName` | the parameter the AMI was discovered through | omitted |
+
+Four of those cells are the interesting ones, because they are where a default written for
+the bundled catalog's benefit would have been wrong for a registered image — both passes
+render through one closure, so a value written once attaches to both:
+
+- **`imageOwnerAlias` is not on the Ubuntu entries.** The alias is "an Amazon-maintained
+  list", and Canonical is not on it.
+- **`publicSsmParameterName` is not on a caller's AMI.** No public parameter names it, and
+  the member exists precisely to let a caller round-trip the parameter it resolved an AMI
+  through — which is now assertable in both directions, since substrate's SSM and EC2
+  plugins answer from the same catalog key.
+- **`platformDetails` and `usageOperation` are absent on a registered AMI.** Both are billing
+  facts AWS derives from the image's product codes, which substrate does not model, so
+  reporting `Linux/UNIX` for an AMI a caller registered would be a guess about what it
+  contains. `CreateImage` inherits them, because an image of a running instance runs the same
+  operating system its parent AMI does.
+- **`imageOwnerId` is now omitted rather than rendered empty** for a bundled AMI. The member
+  had no `omitempty`, so a named bundled image answered with an empty `<imageOwnerId>` — a
+  member present and blank, which an SDK reads as "the owner is the empty string" rather than
+  as "there is no owner". Amazon's AMI-owning account varies by Region and AWS publishes no
+  stable mapping, so the alias is rendered and the account is left out.
+
+`RegisterImage`'s defaults are **AWS's documented ones**: `Architecture` defaults to `i386`
+("Default: For Amazon EBS-backed AMIs, i386") and `VirtualizationType` to `paravirtual`. No
+AMI a caller would register today is either, and both will look wrong. They are used anyway,
+because inventing `x86_64`/`hvm` would mean a request that omits the parameter reports one
+thing here and another on AWS — a divergence in the direction that makes a passing test
+meaningless. Neither parameter's value is validated against AWS's enum, following the same
+reasoning the mapping rules do: a new refusal on a published path arrives unannounced.
+
+Each entry's root device name is **substrate's reading**, not AWS's published text. AWS's
+device naming reference says only "Differs by AMI — `/dev/sda1` or `/dev/xvda`" and publishes
+no per-AMI table, so the split above follows each publisher's own convention: Amazon Linux
+and the ECS-optimized AMIs use `/dev/xvda`, Windows and Canonical's Ubuntu images use
+`/dev/sda1`. The launch path still accepts either spelling as a root device, as it did before.
+
+Two places where AWS contradicts itself, and the side substrate took:
+
+- **`platform`'s casing.** The `Image` type page lists the valid value as `Windows` and in
+  the same entry says the member "is set to `windows` for Windows AMIs"; `DescribeImages`'
+  second example response renders `<platform>windows</platform>` and its `platform` filter
+  says "The only supported value is `windows`". Substrate renders lowercase — three
+  statements against one.
+- **`imageOwnerId`/`isPublic` against `ownerId`/`public`.** `DescribeImages`' first example
+  uses the short spellings; its second and third examples and the `Image` type page use the
+  long ones. Substrate follows the type page, which is the spelling it already used for the
+  owner.
+
+`CreateImage` inherits `architecture`, `platform`, `platformDetails`, `usageOperation`,
+`virtualizationType` and `rootDeviceName` from the AMI its source instance runs, rather than
+leaving them empty: an AMI made from an arm64 Amazon Linux instance runs arm64 Amazon Linux,
+and reporting nothing while its parent reported `arm64` would be two of substrate's own
+answers disagreeing about one lineage. What it does **not** inherit is ownership —
+`imageOwnerAlias`, `publicSsmParameterName` and `isPublic` are the new AMI's own, and it is
+the caller's private image whatever it was made from. The fabricated root mapping follows the
+inherited device name, so an AMI's `rootDeviceName` and its `blockDeviceMapping` cannot
+disagree.
+
+One thing this makes newly visible rather than fixes: a bundled AMI now names a
+`rootDeviceName` while its `blockDeviceMapping` stays empty. Bundled images live outside
+state, so no snapshot backs one, and fabricating a mapping would mean rendering an `ebs`
+element naming a snapshot ID that resolves to nothing — a worse answer than none. A caller
+that needs a mapping to read should register or image its own AMI.
+
 #### `DescribeImages` filters
 
-Four filter names are applied: `image-id`, `block-device-mapping.snapshot-id`,
-`tag:<key>` and `tag-key`. AWS documents thirty-nine more, which need state substrate
+Eighteen filter names are applied: `image-id`, `block-device-mapping.snapshot-id`,
+`tag:<key>`, `tag-key`, and — with the members above, because a rendered member a caller
+cannot filter on is half an answer — `architecture`, `description`, `hypervisor`,
+`image-type`, `is-public`, `name`, `owner-alias`, `owner-id`, `platform`,
+`public-ssm-parameter-name`, `root-device-name`, `root-device-type`, `state` and
+`virtualization-type`. Fourteen of those were previously *accepted and inert*, which is worse
+than the alternatives in both directions: a filter on `architecture` returned every AMI in
+the account, and a caller reads a non-empty answer as a match.
+
+AWS documents twenty-five more, which need state substrate
 does not keep: those are accepted and inert, and anything outside AWS's list is refused —
 see [One rule for an unrecognized filter name](#one-rule-for-an-unrecognized-filter-name).
+The remainder are the `product-code*`, `image-watermark.*`, `source-image*` and
+`state-reason-*` families, the `block-device-mapping.*` names other than `snapshot-id`, the
+ENA/sriov and kernel/ramdisk names, `manifest-location`, the Allowed-AMIs and Free-Tier
+markers, and `creation-date`, whose documented rule is an ISO-8601 prefix match with
+wildcards rather than the equality the others use.
+
+`owner-id` compares against the account that owns the AMI, so it matches nothing for a
+bundled image — which reports no owner — exactly as `Owners=self` does not. `is-public` is
+compared as the rendered `true`/`false`, so `is-public=false` selects the caller's own AMIs
+and excludes every bundled one.
 
 Two behaviour changes came with `tag-key`, both of which bring this operation into line
 with `DescribeInstances` and `DescribeVolumes` rather than leaving it with its own rules:

--- a/emulator/ec2_block_devices.go
+++ b/emulator/ec2_block_devices.go
@@ -10,8 +10,12 @@ import (
 )
 
 // Root device names. Substrate recognizes a mapping as configuring the root volume
-// by device name, because it has no per-AMI root device to compare against:
-// EC2Image records none, and DescribeImages fabricates /dev/sda1 for every AMI.
+// by device name rather than by comparing it against the AMI's own root device.
+// [EC2Image.RootDeviceName] records one as of #750 — RegisterImage stores what the
+// caller sent and a bundled descriptor names its publisher's convention — but the
+// launch path still accepts either spelling, because an AMI minted by CreateImage or
+// registered before #750 has none to compare against and refusing those launches
+// would be a regression a caller cannot act on.
 //
 // Both spellings are AWS's own. Its device naming reference gives the HVM root
 // device as "Differs by AMI — /dev/sda1 or /dev/xvda" and the paravirtual one as

--- a/emulator/ec2_bundled_images.go
+++ b/emulator/ec2_bundled_images.go
@@ -30,7 +30,59 @@ type bundledImage struct {
 
 	// Description is the human-readable description AWS renders for the image family.
 	Description string
+
+	// Architecture is the AMI's architecture, read from the parameter path's own
+	// x86_64/arm64/amd64 suffix rather than guessed: the path is the publisher's
+	// statement of what the image is.
+	Architecture string
+
+	// Platform is "windows" for the Windows entry and empty for every other one, which
+	// is the distinction AWS's platform member draws. PlatformDetails and
+	// UsageOperation are the billing pair from AWS's "usage operation by platform"
+	// table: Windows is "Windows" / "RunInstances:0002" and everything else here is
+	// "Linux/UNIX" / "RunInstances".
+	//
+	// The Ubuntu entries are plain Ubuntu Server rather than Ubuntu Pro, so they bill as
+	// Linux/UNIX; the Pro row's "RunInstances:0g00" would name a subscription these
+	// parameters do not resolve to.
+	Platform        string
+	PlatformDetails string
+	UsageOperation  string
+
+	// RootDeviceName is the device name of the image's root volume.
+	//
+	// AWS's device naming reference gives an HVM AMI's root device as "Differs by AMI —
+	// /dev/sda1 or /dev/xvda" and publishes no per-AMI table, so the assignment here is
+	// substrate's reading of each publisher's convention: Amazon Linux uses /dev/xvda,
+	// Windows Server and Canonical's Ubuntu images use /dev/sda1. Both spellings are
+	// AWS's own (see ec2_block_devices.go's constants) and a launch naming either still
+	// configures the root volume, so a caller that branches on this member gets a real
+	// answer while a caller that ignores it is unaffected.
+	RootDeviceName string
+
+	// OwnerAlias is the AWS-maintained owner alias the image is published under.
+	//
+	// "amazon" for the AWS-published parameters, and deliberately empty for the two
+	// Canonical Ubuntu entries: the aliases are "defined in an Amazon-maintained list"
+	// of which Canonical is not a member, so aliasing them would be an observation
+	// nothing backs (#750).
+	OwnerAlias string
 }
+
+// Values every bundled image shares, named rather than repeated ten times.
+//
+// Each is invariant across the catalog for a reason a reader can check rather than by
+// coincidence: every bundled parameter names an EBS-backed HVM machine image (AWS
+// publishes no paravirtual public parameter, and instance-store AMIs are registered from
+// an S3 manifest, which no parameter resolves to), and AWS documents xen as the only
+// supported hypervisor value. A future entry that breaks one of these belongs on
+// [bundledImage] as a field, not here.
+const (
+	bundledImageRootDeviceType     = "ebs"
+	bundledImageVirtualizationType = "hvm"
+	bundledImageHypervisor         = "xen"
+	bundledImageType               = "machine"
+)
 
 // bundledImages is the catalog, with every parameter name taken verbatim from AWS's own
 // documentation:
@@ -52,49 +104,93 @@ type bundledImage struct {
 // to an ID nothing backs.
 var bundledImages = []bundledImage{
 	{
-		Parameter:   "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64",
-		Name:        "al2023-ami-kernel-default-x86_64",
-		Description: "Amazon Linux 2023 AMI, kernel default, x86_64",
+		Parameter:       "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64",
+		Name:            "al2023-ami-kernel-default-x86_64",
+		Description:     "Amazon Linux 2023 AMI, kernel default, x86_64",
+		Architecture:    "x86_64",
+		PlatformDetails: "Linux/UNIX",
+		UsageOperation:  "RunInstances",
+		RootDeviceName:  ec2RootDeviceXVDA,
+		OwnerAlias:      "amazon",
 	},
 	{
-		Parameter:   "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64",
-		Name:        "al2023-ami-kernel-default-arm64",
-		Description: "Amazon Linux 2023 AMI, kernel default, arm64",
+		Parameter:       "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64",
+		Name:            "al2023-ami-kernel-default-arm64",
+		Description:     "Amazon Linux 2023 AMI, kernel default, arm64",
+		Architecture:    "arm64",
+		PlatformDetails: "Linux/UNIX",
+		UsageOperation:  "RunInstances",
+		RootDeviceName:  ec2RootDeviceXVDA,
+		OwnerAlias:      "amazon",
 	},
 	{
-		Parameter:   "/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-x86_64",
-		Name:        "al2023-ami-minimal-kernel-default-x86_64",
-		Description: "Amazon Linux 2023 minimal AMI, kernel default, x86_64",
+		Parameter:       "/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-x86_64",
+		Name:            "al2023-ami-minimal-kernel-default-x86_64",
+		Description:     "Amazon Linux 2023 minimal AMI, kernel default, x86_64",
+		Architecture:    "x86_64",
+		PlatformDetails: "Linux/UNIX",
+		UsageOperation:  "RunInstances",
+		RootDeviceName:  ec2RootDeviceXVDA,
+		OwnerAlias:      "amazon",
 	},
 	{
-		Parameter:   "/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-arm64",
-		Name:        "al2023-ami-minimal-kernel-default-arm64",
-		Description: "Amazon Linux 2023 minimal AMI, kernel default, arm64",
+		Parameter:       "/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-arm64",
+		Name:            "al2023-ami-minimal-kernel-default-arm64",
+		Description:     "Amazon Linux 2023 minimal AMI, kernel default, arm64",
+		Architecture:    "arm64",
+		PlatformDetails: "Linux/UNIX",
+		UsageOperation:  "RunInstances",
+		RootDeviceName:  ec2RootDeviceXVDA,
+		OwnerAlias:      "amazon",
 	},
 	{
-		Parameter:   "/aws/service/ami-windows-latest/Windows_Server-2022-English-Full-Base",
-		Name:        "Windows_Server-2022-English-Full-Base",
-		Description: "Microsoft Windows Server 2022 Full Locale English AMI",
+		Parameter:       "/aws/service/ami-windows-latest/Windows_Server-2022-English-Full-Base",
+		Name:            "Windows_Server-2022-English-Full-Base",
+		Description:     "Microsoft Windows Server 2022 Full Locale English AMI",
+		Architecture:    "x86_64",
+		Platform:        "windows",
+		PlatformDetails: "Windows",
+		UsageOperation:  "RunInstances:0002",
+		RootDeviceName:  ec2RootDeviceSDA1,
+		OwnerAlias:      "amazon",
 	},
 	{
-		Parameter:   "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id",
-		Name:        "amazon-linux-2023-ecs-optimized",
-		Description: "Amazon ECS-optimized Amazon Linux 2023 AMI",
+		Parameter:       "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id",
+		Name:            "amazon-linux-2023-ecs-optimized",
+		Description:     "Amazon ECS-optimized Amazon Linux 2023 AMI",
+		Architecture:    "x86_64",
+		PlatformDetails: "Linux/UNIX",
+		UsageOperation:  "RunInstances",
+		RootDeviceName:  ec2RootDeviceXVDA,
+		OwnerAlias:      "amazon",
 	},
 	{
-		Parameter:   "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id",
-		Name:        "amazon-linux-2-ecs-optimized",
-		Description: "Amazon ECS-optimized Amazon Linux 2 AMI",
+		Parameter:       "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id",
+		Name:            "amazon-linux-2-ecs-optimized",
+		Description:     "Amazon ECS-optimized Amazon Linux 2 AMI",
+		Architecture:    "x86_64",
+		PlatformDetails: "Linux/UNIX",
+		UsageOperation:  "RunInstances",
+		RootDeviceName:  ec2RootDeviceXVDA,
+		OwnerAlias:      "amazon",
 	},
 	{
-		Parameter:   "/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id",
-		Name:        "ubuntu-noble-24.04-amd64-server",
-		Description: "Canonical Ubuntu Server 24.04 LTS, amd64",
+		Parameter:       "/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id",
+		Name:            "ubuntu-noble-24.04-amd64-server",
+		Description:     "Canonical Ubuntu Server 24.04 LTS, amd64",
+		Architecture:    "x86_64",
+		PlatformDetails: "Linux/UNIX",
+		UsageOperation:  "RunInstances",
+		RootDeviceName:  ec2RootDeviceSDA1,
 	},
 	{
-		Parameter:   "/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id",
-		Name:        "ubuntu-jammy-22.04-amd64-server",
-		Description: "Canonical Ubuntu Server 22.04 LTS, amd64",
+		Parameter:       "/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id",
+		Name:            "ubuntu-jammy-22.04-amd64-server",
+		Description:     "Canonical Ubuntu Server 22.04 LTS, amd64",
+		Architecture:    "x86_64",
+		PlatformDetails: "Linux/UNIX",
+		UsageOperation:  "RunInstances",
+		RootDeviceName:  ec2RootDeviceSDA1,
 	},
 }
 
@@ -156,15 +252,33 @@ func (b bundledImage) idIn(region string) string {
 // AccountID is deliberately empty. A public AWS-owned AMI is not owned by the caller, and
 // substrate holds no account for the "amazon" owner alias — so attributing it to the
 // requesting account would be a claim nothing backs and would make an Owners=self
-// DescribeImages match an image the caller does not own. Nothing renders the member for a
-// bundled image yet; DescribeImages lists state, which holds no record for these.
+// DescribeImages match an image the caller does not own. DescribeImages renders
+// imageOwnerId omitted rather than empty for exactly that reason (#750); through v0.108.0
+// it rendered an empty element, because the member had no omitempty and this comment
+// claimed nothing rendered it at all.
+//
+// The invariants come from the consts above and the varying members from the descriptor,
+// so a caller reading a bundled AMI and a caller reading a registered one read the same
+// shape — [EC2Plugin.describeImages] renders both through one function for the same reason.
 func (b bundledImage) image(region string) EC2Image {
 	return EC2Image{
-		ImageID:     b.idIn(region),
-		Name:        b.Name,
-		Description: b.Description,
-		State:       "available",
-		Region:      region,
+		ImageID:                b.idIn(region),
+		Name:                   b.Name,
+		Description:            b.Description,
+		State:                  "available",
+		Region:                 region,
+		Architecture:           b.Architecture,
+		Platform:               b.Platform,
+		PlatformDetails:        b.PlatformDetails,
+		UsageOperation:         b.UsageOperation,
+		RootDeviceName:         b.RootDeviceName,
+		RootDeviceType:         bundledImageRootDeviceType,
+		VirtualizationType:     bundledImageVirtualizationType,
+		Hypervisor:             bundledImageHypervisor,
+		ImageType:              bundledImageType,
+		OwnerAlias:             b.OwnerAlias,
+		Public:                 true,
+		PublicSsmParameterName: b.Parameter,
 	}
 }
 

--- a/emulator/ec2_filters.go
+++ b/emulator/ec2_filters.go
@@ -248,27 +248,40 @@ func ec2InstanceFilterSpec() ec2FilterSpec {
 //
 // tag-key joined the evaluated list in #686, which also stopped a valueless tag:<key>
 // filter from standing in for it.
+//
+// Fourteen more joined it in #750, when [EC2Image] gained the members they select on. Every
+// one of them was already *accepted* — named without narrowing — so a caller filtering on
+// architecture got every AMI back and read it as a match. That is the failure mode an
+// accepted-but-unevaluated filter always has, and it is why the members and the filters
+// belong in one change: rendering architecture while ignoring the architecture filter would
+// have made the gap newly visible without closing it.
+//
+// The ones still merely accepted select on state substrate does not model at all — product
+// codes, watermarks, ENA/sriov support, kernel and RAM disk IDs, the S3 manifest location,
+// the Allowed-AMIs and Free-Tier flags, source-image lineage, state reasons — or on
+// creation-date, whose ISO-8601-with-wildcard matching is its own rule rather than a string
+// compare.
 func ec2ImageFilterSpec() ec2FilterSpec {
 	return ec2FilterSpec{
 		tagValueFilter: true,
 		evaluated: []string{
-			"block-device-mapping.snapshot-id", "image-id", "tag-key",
+			"architecture", "block-device-mapping.snapshot-id", "description",
+			"hypervisor", "image-id", "image-type", "is-public", "name", "owner-alias",
+			"owner-id", "platform", "public-ssm-parameter-name", "root-device-name",
+			"root-device-type", "state", "tag-key", "virtualization-type",
 		},
 		accepted: []string{
-			"architecture", "block-device-mapping.delete-on-termination",
+			"block-device-mapping.delete-on-termination",
 			"block-device-mapping.device-name", "block-device-mapping.encrypted",
 			"block-device-mapping.volume-size", "block-device-mapping.volume-type",
-			"creation-date", "description", "ena-support", "free-tier-eligible",
-			"hypervisor", "image-allowed", "image-type",
+			"creation-date", "ena-support", "free-tier-eligible", "image-allowed",
 			"image-watermark.source-image-creation-time",
 			"image-watermark.source-image-id", "image-watermark.source-image-region",
 			"image-watermark.watermark-creation-time", "image-watermark.watermark-key",
-			"is-public", "kernel-id", "manifest-location", "name", "owner-alias",
-			"owner-id", "platform", "product-code", "product-code.type",
-			"public-ssm-parameter-name", "ramdisk-id", "root-device-name",
-			"root-device-type", "source-image-id", "source-image-region",
-			"source-instance-id", "sriov-net-support", "state", "state-reason-code",
-			"state-reason-message", "virtualization-type",
+			"kernel-id", "manifest-location", "product-code", "product-code.type",
+			"ramdisk-id", "source-image-id", "source-image-region",
+			"source-instance-id", "sriov-net-support", "state-reason-code",
+			"state-reason-message",
 		},
 	}
 }

--- a/emulator/ec2_image_members_test.go
+++ b/emulator/ec2_image_members_test.go
@@ -1,0 +1,563 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// The Image members DescribeImages renders, and where each one's value comes from (#750).
+//
+// Through v0.108.0 the operation rendered identity, name, description, state, owner and
+// creation date and nothing else, so a caller that branched on architecture, platform or the
+// root device — which CDK and userdata-selection logic routinely do — read an empty string
+// from an AMI substrate knew the answer for. Ten filters were accepted and never evaluated
+// on top of that, so filtering on architecture returned every AMI and looked like a match.
+//
+// Provenance, because two AWS pages disagree with themselves and this file takes a side:
+//
+//   - platform's casing. API_Image.html lists the valid value as "Windows" and in the same
+//     entry says the member "is set to windows for Windows AMIs"; DescribeImages' Example 2
+//     response renders <platform>windows</platform> and its platform filter says "The only
+//     supported value is windows". Substrate renders lowercase — three statements against
+//     one.
+//   - the element names. DescribeImages' Example 1 uses <ownerId> and <public> while
+//     Examples 2 and 3 and API_Image.html use <imageOwnerId> and <isPublic>. Substrate
+//     follows the type page, which is the spelling it already used for imageOwnerId.
+//
+// And two values are substrate's reading rather than AWS's published text: each bundled
+// image's root device name (AWS's device naming reference says only "Differs by AMI —
+// /dev/sda1 or /dev/xvda"), and RegisterImage's i386/paravirtual defaults, which are AWS's
+// own documented defaults and will look wrong to a modern caller — see
+// TestEC2_RegisterImage_UsesAWSDocumentedDefaults for why substrate keeps them anyway.
+
+// ec2DescribedImage is one item of a DescribeImages imagesSet, with every member this file
+// asserts on. It is deliberately a separate shape from the plugin's own imageItem: a test
+// that reused the production struct would pass on a member whose XML name was wrong in both
+// places, which is exactly the class of bug #738 found.
+type ec2DescribedImage struct {
+	ImageID                string `xml:"imageId"`
+	Name                   string `xml:"name"`
+	Description            string `xml:"description"`
+	State                  string `xml:"imageState"`
+	OwnerID                string `xml:"imageOwnerId"`
+	OwnerAlias             string `xml:"imageOwnerAlias"`
+	Public                 bool   `xml:"isPublic"`
+	Architecture           string `xml:"architecture"`
+	Platform               string `xml:"platform"`
+	PlatformDetails        string `xml:"platformDetails"`
+	UsageOperation         string `xml:"usageOperation"`
+	ImageType              string `xml:"imageType"`
+	RootDeviceType         string `xml:"rootDeviceType"`
+	RootDeviceName         string `xml:"rootDeviceName"`
+	VirtualizationType     string `xml:"virtualizationType"`
+	Hypervisor             string `xml:"hypervisor"`
+	PublicSsmParameterName string `xml:"publicSsmParameterName"`
+}
+
+// ec2DescribeImagesRaw returns the DescribeImages response body verbatim, so a test can
+// assert an element is *absent* rather than decoded-to-empty. Those are different answers
+// and unmarshalling cannot tell them apart, which is the whole point of platform's
+// optionality.
+func ec2DescribeImagesRaw(t *testing.T, ts *httptest.Server, params map[string]string) string {
+	t.Helper()
+	req := map[string]string{"Action": "DescribeImages"}
+	for k, v := range params {
+		req[k] = v
+	}
+	resp := ec2Request(t, ts, req)
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body was %s", body)
+	return string(body)
+}
+
+// ec2DescribeImages decodes the imagesSet a DescribeImages request answers with.
+func ec2DescribeImages(t *testing.T, ts *httptest.Server, params map[string]string) []ec2DescribedImage {
+	t.Helper()
+	var doc struct {
+		Images []ec2DescribedImage `xml:"imagesSet>item"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(ec2DescribeImagesRaw(t, ts, params)), &doc))
+	return doc.Images
+}
+
+// ec2DescribeOneImage is the single-AMI form, which is how a bundled image is reachable at
+// all: they are deliberately absent from state (#733), so an unqualified describe does not
+// list them and naming the ID is the only route.
+func ec2DescribeOneImage(t *testing.T, ts *httptest.Server, imageID string) ec2DescribedImage {
+	t.Helper()
+	images := ec2DescribeImages(t, ts, map[string]string{"ImageId.1": imageID})
+	require.Len(t, images, 1, "DescribeImages %s", imageID)
+	return images[0]
+}
+
+// TestEC2_DescribeImages_BundledMembers asserts every member of every bundled AMI, so the
+// catalog and the renderer cannot drift apart one entry at a time.
+//
+// The interesting rows are the ones that differ: arm64 against x86_64, the Windows entry's
+// platform and billing pair against the Linux ones, Amazon Linux's /dev/xvda against
+// Windows' and Ubuntu's /dev/sda1, and the two Canonical entries carrying no owner alias
+// where the seven AWS-published ones carry "amazon".
+func TestEC2_DescribeImages_BundledMembers(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	tests := []struct {
+		param string
+		want  ec2DescribedImage
+	}{
+		{
+			param: "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64",
+			want: ec2DescribedImage{
+				Name: "al2023-ami-kernel-default-x86_64", Architecture: "x86_64",
+				PlatformDetails: "Linux/UNIX", UsageOperation: "RunInstances",
+				RootDeviceName: "/dev/xvda", OwnerAlias: "amazon",
+			},
+		},
+		{
+			param: "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64",
+			want: ec2DescribedImage{
+				Name: "al2023-ami-kernel-default-arm64", Architecture: "arm64",
+				PlatformDetails: "Linux/UNIX", UsageOperation: "RunInstances",
+				RootDeviceName: "/dev/xvda", OwnerAlias: "amazon",
+			},
+		},
+		{
+			param: "/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-x86_64",
+			want: ec2DescribedImage{
+				Name: "al2023-ami-minimal-kernel-default-x86_64", Architecture: "x86_64",
+				PlatformDetails: "Linux/UNIX", UsageOperation: "RunInstances",
+				RootDeviceName: "/dev/xvda", OwnerAlias: "amazon",
+			},
+		},
+		{
+			param: "/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-arm64",
+			want: ec2DescribedImage{
+				Name: "al2023-ami-minimal-kernel-default-arm64", Architecture: "arm64",
+				PlatformDetails: "Linux/UNIX", UsageOperation: "RunInstances",
+				RootDeviceName: "/dev/xvda", OwnerAlias: "amazon",
+			},
+		},
+		{
+			param: "/aws/service/ami-windows-latest/Windows_Server-2022-English-Full-Base",
+			want: ec2DescribedImage{
+				Name: "Windows_Server-2022-English-Full-Base", Architecture: "x86_64",
+				Platform: "windows", PlatformDetails: "Windows",
+				UsageOperation: "RunInstances:0002",
+				RootDeviceName: "/dev/sda1", OwnerAlias: "amazon",
+			},
+		},
+		{
+			param: "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id",
+			want: ec2DescribedImage{
+				Name: "amazon-linux-2023-ecs-optimized", Architecture: "x86_64",
+				PlatformDetails: "Linux/UNIX", UsageOperation: "RunInstances",
+				RootDeviceName: "/dev/xvda", OwnerAlias: "amazon",
+			},
+		},
+		{
+			param: "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id",
+			want: ec2DescribedImage{
+				Name: "amazon-linux-2-ecs-optimized", Architecture: "x86_64",
+				PlatformDetails: "Linux/UNIX", UsageOperation: "RunInstances",
+				RootDeviceName: "/dev/xvda", OwnerAlias: "amazon",
+			},
+		},
+		{
+			param: "/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id",
+			want: ec2DescribedImage{
+				Name: "ubuntu-noble-24.04-amd64-server", Architecture: "x86_64",
+				PlatformDetails: "Linux/UNIX", UsageOperation: "RunInstances",
+				RootDeviceName: "/dev/sda1",
+			},
+		},
+		{
+			param: "/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id",
+			want: ec2DescribedImage{
+				Name: "ubuntu-jammy-22.04-amd64-server", Architecture: "x86_64",
+				PlatformDetails: "Linux/UNIX", UsageOperation: "RunInstances",
+				RootDeviceName: "/dev/sda1",
+			},
+		},
+	}
+	require.Len(t, tests, len(ec2BundledParameters),
+		"every bundled parameter needs a row here, or a new catalog entry ships unasserted")
+
+	for _, tc := range tests {
+		t.Run(tc.param, func(t *testing.T) {
+			id := emulator.BundledImageID(ec2TestRegion, tc.param)
+			require.NotEmpty(t, id)
+			got := ec2DescribeOneImage(t, ts, id)
+
+			assert.Equal(t, tc.want.Name, got.Name)
+			assert.Equal(t, tc.want.Architecture, got.Architecture)
+			assert.Equal(t, tc.want.Platform, got.Platform)
+			assert.Equal(t, tc.want.PlatformDetails, got.PlatformDetails)
+			assert.Equal(t, tc.want.UsageOperation, got.UsageOperation)
+			assert.Equal(t, tc.want.RootDeviceName, got.RootDeviceName)
+			assert.Equal(t, tc.want.OwnerAlias, got.OwnerAlias)
+
+			// The members every bundled entry shares. They are asserted per row rather
+			// than once, because a value that is invariant in the catalog is not
+			// invariant in the renderer — the whole point of rendering both passes
+			// through one closure is that these hold for a registered AMI too.
+			assert.Equal(t, id, got.ImageID)
+			assert.Equal(t, "available", got.State)
+			assert.Equal(t, "ebs", got.RootDeviceType)
+			assert.Equal(t, "hvm", got.VirtualizationType)
+			assert.Equal(t, "xen", got.Hypervisor)
+			assert.Equal(t, "machine", got.ImageType)
+			assert.True(t, got.Public, "a bundled AMI resolved from a public parameter is public")
+			assert.Equal(t, tc.param, got.PublicSsmParameterName)
+
+			// No owner. A public AWS-owned AMI is not owned by the caller and substrate
+			// holds no account for the "amazon" alias, so claiming the requesting
+			// account would make an Owners=self describe match an image it does not own.
+			assert.Empty(t, got.OwnerID)
+		})
+	}
+}
+
+// TestEC2_DescribeImages_OmitsRatherThanEmpties covers the three members whose absence is
+// the answer, which unmarshalling cannot distinguish from an empty string.
+//
+// platform is AWS's own rule — "set to windows for Windows AMIs; otherwise, it is blank" —
+// and imageOwnerId is substrate's, for a bundled image with no owner to name. Through
+// v0.108.0 the owner element was rendered empty, because the member had no omitempty and
+// [bundledImage.image]'s own comment claimed nothing rendered it at all.
+func TestEC2_DescribeImages_OmitsRatherThanEmpties(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	linux := ec2DescribeImagesRaw(t, ts, map[string]string{"ImageId.1": ec2TestImage})
+	assert.NotContains(t, linux, "<platform>",
+		"a Linux AMI must omit platform, not render it empty")
+	assert.NotContains(t, linux, "<imageOwnerId>",
+		"a bundled AMI has no owner substrate can name")
+	assert.Contains(t, linux, "<isPublic>true</isPublic>",
+		"isPublic is a boolean AWS always renders")
+	assert.NotContains(t, linux, "<ownerId>",
+		"ownerId is Example 1's spelling; the Image type page says imageOwnerId")
+	assert.NotContains(t, linux, "<public>",
+		"public is Example 1's spelling; the Image type page says isPublic")
+
+	windows := ec2DescribeImagesRaw(t, ts, map[string]string{"ImageId.1": ec2TestImageWindows})
+	assert.Contains(t, windows, "<platform>windows</platform>",
+		"lowercase, per the member's own prose, Example 2 and the platform filter")
+	assert.NotContains(t, windows, "<platform>Windows</platform>",
+		"the Valid Values line's casing is the one AWS's own examples contradict")
+}
+
+// TestEC2_DescribeImages_SSMParameterNameRoundTrips is the round trip AWS added
+// publicSsmParameterName for: from a parameter to an AMI through GetParameter, and back to
+// the same parameter name through DescribeImages.
+//
+// Substrate can answer it exactly, because the parameter name is the catalog's own key — so
+// this asserts two plugins agree about one string rather than that either formats it
+// plausibly.
+func TestEC2_DescribeImages_SSMParameterNameRoundTrips(t *testing.T) {
+	ssm := newSSMTestServer(t)
+	ec2 := newEC2TestServer(t)
+
+	for _, param := range ec2BundledParameters {
+		t.Run(param, func(t *testing.T) {
+			resp := ssmRequest(t, ssm, "GetParameter", map[string]interface{}{"Name": param})
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			parameter, ok := readSSMBody(t, resp)["Parameter"].(map[string]interface{})
+			require.True(t, ok, "GetParameter %s returned no Parameter member", param)
+			imageID, ok := parameter["Value"].(string)
+			require.True(t, ok, "GetParameter %s returned no Value", param)
+
+			got := ec2DescribeOneImage(t, ec2, imageID)
+			assert.Equal(t, param, got.PublicSsmParameterName,
+				"the parameter that resolved the AMI must be the one the AMI reports")
+		})
+	}
+}
+
+// TestEC2_RegisterImage_MembersComeFromTheRequest is #750's other half: a caller-registered
+// AMI reports what the caller sent, and reports nothing where a bundled default would have
+// been wrong.
+//
+// The bundled defaults are the hazard the shared renderer creates — both passes go through
+// one closure, so a value written there for the catalog's benefit would attach to a
+// registered image too. publicSsmParameterName and imageOwnerAlias are the two that would
+// be actively false: no public parameter names a caller's own AMI and Amazon has not
+// aliased it.
+func TestEC2_RegisterImage_MembersComeFromTheRequest(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":                              "RegisterImage",
+		"Name":                                "members-from-the-request",
+		"Description":                         "registered by the caller",
+		"Architecture":                        "arm64",
+		"VirtualizationType":                  "hvm",
+		"RootDeviceName":                      "/dev/xvda",
+		"BlockDeviceMapping.1.DeviceName":     "/dev/xvda",
+		"BlockDeviceMapping.1.Ebs.VolumeSize": "30",
+	}, nil)
+
+	images := ec2DescribeImages(t, ts, nil)
+	require.Len(t, images, 1)
+	got := images[0]
+
+	assert.Equal(t, "arm64", got.Architecture, "not the i386 default, and not a bundled x86_64")
+	assert.Equal(t, "hvm", got.VirtualizationType, "not the paravirtual default")
+	assert.Equal(t, "/dev/xvda", got.RootDeviceName)
+	assert.Equal(t, "ebs", got.RootDeviceType, "no ImageLocation means the EBS registration form")
+	assert.Equal(t, "machine", got.ImageType)
+	assert.Equal(t, "xen", got.Hypervisor)
+	assert.Equal(t, "available", got.State)
+	assert.NotEmpty(t, got.OwnerID, "a registered AMI is owned by the account that registered it")
+
+	assert.Empty(t, got.PublicSsmParameterName, "no public parameter names a caller's own AMI")
+	assert.Empty(t, got.OwnerAlias, "Amazon has not aliased a caller's own AMI")
+	assert.Empty(t, got.Platform, "RegisterImage takes no Platform parameter")
+	assert.Empty(t, got.PlatformDetails, "billing details substrate has no product code to derive")
+	assert.Empty(t, got.UsageOperation, "the billing code substrate has no product code to derive")
+	assert.False(t, got.Public, "a newly registered AMI has no public launch permissions")
+
+	raw := ec2DescribeImagesRaw(t, ts, nil)
+	assert.NotContains(t, raw, "<publicSsmParameterName>")
+	assert.NotContains(t, raw, "<imageOwnerAlias>")
+	assert.Contains(t, raw, "<isPublic>false</isPublic>")
+}
+
+// TestEC2_RegisterImage_UsesAWSDocumentedDefaults pins the two defaults that will look wrong
+// to anyone reading them, so nobody "fixes" them without reading this.
+//
+// AWS documents Architecture as "Default: For Amazon EBS-backed AMIs, i386" and
+// VirtualizationType as "Default: paravirtual". No AMI a caller would actually register in
+// 2026 is either. Substrate uses them anyway: a caller that omits the parameter here gets
+// the answer AWS gives, and inventing x86_64/hvm would mean a template that passes in
+// substrate and reports something else on AWS — the divergence this project exists not to
+// make.
+func TestEC2_RegisterImage_UsesAWSDocumentedDefaults(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "RegisterImage",
+		"Name":   "defaults-are-aws-defaults",
+	}, nil)
+
+	images := ec2DescribeImages(t, ts, nil)
+	require.Len(t, images, 1)
+	assert.Equal(t, "i386", images[0].Architecture)
+	assert.Equal(t, "paravirtual", images[0].VirtualizationType)
+}
+
+// TestEC2_RegisterImage_ImageLocationIsTheInstanceStoreForm covers the one signal AWS uses
+// to distinguish the two registration forms: ImageLocation is "the full path to your AMI
+// manifest in Amazon S3 storage", which is how an instance-store-backed AMI is registered,
+// while the EBS form sends a root device and a mapping instead.
+func TestEC2_RegisterImage_ImageLocationIsTheInstanceStoreForm(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":        "RegisterImage",
+		"Name":          "from-a-manifest",
+		"ImageLocation": "my-bucket/my-ami.manifest.xml",
+	}, nil)
+
+	images := ec2DescribeImages(t, ts, nil)
+	require.Len(t, images, 1)
+	assert.Equal(t, "instance-store", images[0].RootDeviceType)
+}
+
+// TestEC2_CreateImage_InheritsFromItsSourceAMI asserts an AMI made from an instance reports
+// the operating system's own members rather than nothing.
+//
+// An AMI created from an arm64 Amazon Linux instance runs arm64 Amazon Linux, so reporting
+// no architecture while its parent reported arm64 would be two of substrate's own answers
+// disagreeing about one lineage. What is *not* inherited matters as much: the new AMI belongs
+// to the caller, so it carries no owner alias, no public parameter and no public launch
+// permission.
+func TestEC2_CreateImage_InheritsFromItsSourceAMI(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	var launched struct {
+		Instances []struct {
+			InstanceID string `xml:"instanceId"`
+		} `xml:"instancesSet>item"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":  "RunInstances",
+		"ImageId": ec2TestImageArm,
+	}, &launched)
+	require.Len(t, launched.Instances, 1)
+
+	var created struct {
+		ImageID string `xml:"imageId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":     "CreateImage",
+		"InstanceId": launched.Instances[0].InstanceID,
+		"Name":       "imaged-from-arm64",
+	}, &created)
+	require.NotEmpty(t, created.ImageID)
+
+	got := ec2DescribeOneImage(t, ts, created.ImageID)
+	assert.Equal(t, "arm64", got.Architecture, "inherited from the AMI the instance runs")
+	assert.Equal(t, "hvm", got.VirtualizationType)
+	assert.Equal(t, "Linux/UNIX", got.PlatformDetails)
+	assert.Equal(t, "RunInstances", got.UsageOperation)
+	assert.Equal(t, "/dev/xvda", got.RootDeviceName)
+	assert.Equal(t, "ebs", got.RootDeviceType, "CreateImage always materializes a snapshot")
+
+	assert.Empty(t, got.OwnerAlias, "the new AMI is the caller's, not Amazon's")
+	assert.Empty(t, got.PublicSsmParameterName, "no public parameter names it")
+	assert.False(t, got.Public)
+	assert.NotEmpty(t, got.OwnerID)
+
+	// The fabricated root mapping follows the inherited device name, so the AMI's
+	// rootDeviceName member and its blockDeviceMapping cannot contradict each other.
+	mappings := ec2ImageMappings(t, ts, created.ImageID)
+	require.Len(t, mappings, 1)
+	assert.Equal(t, "/dev/xvda", mappings[0].DeviceName)
+}
+
+// TestEC2_CreateImage_WindowsInheritsItsPlatform is the Windows half of the inheritance,
+// separate because platform is the one member whose *absence* is meaningful — a test that
+// only imaged a Linux instance would pass with the field never assigned at all.
+func TestEC2_CreateImage_WindowsInheritsItsPlatform(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	var launched struct {
+		Instances []struct {
+			InstanceID string `xml:"instanceId"`
+		} `xml:"instancesSet>item"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":  "RunInstances",
+		"ImageId": ec2TestImageWindows,
+	}, &launched)
+	require.Len(t, launched.Instances, 1)
+
+	var created struct {
+		ImageID string `xml:"imageId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":     "CreateImage",
+		"InstanceId": launched.Instances[0].InstanceID,
+		"Name":       "imaged-from-windows",
+	}, &created)
+
+	got := ec2DescribeOneImage(t, ts, created.ImageID)
+	assert.Equal(t, "windows", got.Platform)
+	assert.Equal(t, "Windows", got.PlatformDetails)
+	assert.Equal(t, "RunInstances:0002", got.UsageOperation)
+	assert.Equal(t, "x86_64", got.Architecture)
+}
+
+// TestEC2_DescribeImages_FiltersNarrowOnTheNewMembers is the reason the members and the
+// filters are one change.
+//
+// Each name below was in [ec2ImageFilterSpec]'s accepted list — named without narrowing —
+// so before #750 every one of these requests answered with the whole catalog and a caller
+// read that as a match. That is worse than a refusal, which is the argument #731 made about
+// ImageId.N and the same one applies here.
+//
+// Each row filters over four bundled AMIs the request names explicitly, because a bundled
+// image is reachable only by ID (#733); the filter then narrows within that set.
+func TestEC2_DescribeImages_FiltersNarrowOnTheNewMembers(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	named := map[string]string{
+		"ImageId.1": ec2TestImage,        // AL2023 x86_64, /dev/xvda, amazon
+		"ImageId.2": ec2TestImageArm,     // AL2023 arm64,  /dev/xvda, amazon
+		"ImageId.3": ec2TestImageWindows, // Windows,       /dev/sda1, amazon
+		"ImageId.4": ec2TestImageUbuntu,  // Ubuntu 24.04,  /dev/sda1, no alias
+	}
+
+	tests := []struct {
+		name   string
+		filter string
+		value  string
+		want   []string
+	}{
+		{"architecture selects one", "architecture", "arm64", []string{ec2TestImageArm}},
+		{"architecture selects the rest", "architecture", "x86_64", []string{ec2TestImage, ec2TestImageWindows, ec2TestImageUbuntu}},
+		{"platform selects the Windows AMI", "platform", "windows", []string{ec2TestImageWindows}},
+		{"root-device-name splits the four", "root-device-name", "/dev/xvda", []string{ec2TestImage, ec2TestImageArm}},
+		{"root-device-type matches all four", "root-device-type", "ebs", []string{ec2TestImage, ec2TestImageArm, ec2TestImageWindows, ec2TestImageUbuntu}},
+		{"virtualization-type matches all four", "virtualization-type", "hvm", []string{ec2TestImage, ec2TestImageArm, ec2TestImageWindows, ec2TestImageUbuntu}},
+		{"a virtualization type none of them has", "virtualization-type", "paravirtual", nil},
+		{"hypervisor", "hypervisor", "xen", []string{ec2TestImage, ec2TestImageArm, ec2TestImageWindows, ec2TestImageUbuntu}},
+		{"image-type", "image-type", "machine", []string{ec2TestImage, ec2TestImageArm, ec2TestImageWindows, ec2TestImageUbuntu}},
+		{"is-public true", "is-public", "true", []string{ec2TestImage, ec2TestImageArm, ec2TestImageWindows, ec2TestImageUbuntu}},
+		{"is-public false excludes every public AMI", "is-public", "false", nil},
+		{"owner-alias excludes Canonical", "owner-alias", "amazon", []string{ec2TestImage, ec2TestImageArm, ec2TestImageWindows}},
+		{"name", "name", "al2023-ami-kernel-default-arm64", []string{ec2TestImageArm}},
+		{"name with a wildcard", "name", "ubuntu-*", []string{ec2TestImageUbuntu}},
+		{"description", "description", "Amazon Linux 2023 AMI, kernel default, arm64", []string{ec2TestImageArm}},
+		{"state", "state", "available", []string{ec2TestImage, ec2TestImageArm, ec2TestImageWindows, ec2TestImageUbuntu}},
+		{"state matches nothing", "state", "pending", nil},
+		{
+			"public-ssm-parameter-name", "public-ssm-parameter-name",
+			"/aws/service/ami-windows-latest/Windows_Server-2022-English-Full-Base",
+			[]string{ec2TestImageWindows},
+		},
+		{
+			"owner-id excludes every bundled AMI, which has no owner",
+			"owner-id", "123456789012", nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			params := map[string]string{"Filter.1.Name": tc.filter, "Filter.1.Value.1": tc.value}
+			for k, v := range named {
+				params[k] = v
+			}
+			var ids []string
+			for _, img := range ec2DescribeImages(t, ts, params) {
+				ids = append(ids, img.ImageID)
+			}
+			assert.ElementsMatch(t, tc.want, ids)
+		})
+	}
+}
+
+// TestEC2_DescribeImages_FilterOnARegisteredImage covers the members only a registered AMI
+// has, which the bundled table above cannot reach: an owner ID, and the i386/paravirtual
+// defaults.
+func TestEC2_DescribeImages_FilterOnARegisteredImage(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	ec2FleetXML(t, ts, map[string]string{"Action": "RegisterImage", "Name": "filterable"}, nil)
+	all := ec2DescribeImages(t, ts, nil)
+	require.Len(t, all, 1)
+	owner := all[0].OwnerID
+	require.NotEmpty(t, owner)
+
+	tests := []struct {
+		name   string
+		filter string
+		value  string
+		want   int
+	}{
+		{"the account's own ID matches", "owner-id", owner, 1},
+		{"another account's does not", "owner-id", "999999999999", 0},
+		{"the documented architecture default", "architecture", "i386", 1},
+		{"not the architecture a modern caller assumes", "architecture", "x86_64", 0},
+		{"the documented virtualization default", "virtualization-type", "paravirtual", 1},
+		{"is-public false", "is-public", "false", 1},
+		{"is-public true", "is-public", "true", 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ec2DescribeImages(t, ts, map[string]string{
+				"Filter.1.Name":    tc.filter,
+				"Filter.1.Value.1": tc.value,
+			})
+			assert.Len(t, got, tc.want)
+		})
+	}
+}

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -4054,6 +4054,27 @@ func (p *EC2Plugin) createImage(reqCtx *RequestContext, req *AWSRequest) (*AWSRe
 		Tags:         tags,
 		AccountID:    reqCtx.AccountID,
 		Region:       reqCtx.Region,
+		Hypervisor:   bundledImageHypervisor,
+		ImageType:    bundledImageType,
+	}
+	// An AMI created from an instance runs the same operating system on the same
+	// architecture as the AMI that instance was launched from, so those members are
+	// inherited rather than defaulted (#750). Without this, imaging a bundled arm64 AL2023
+	// instance would produce an AMI reporting no architecture at all while its parent
+	// reported arm64 — two of substrate's own answers disagreeing about one lineage.
+	//
+	// Only the members the operating system decides are inherited. OwnerAlias,
+	// PublicSsmParameterName and Public are not: the new AMI belongs to the caller's
+	// account, no public parameter names it, and nothing has granted it public launch
+	// permissions. RootDeviceType is "ebs" because this path always materializes a snapshot.
+	img.RootDeviceType = "ebs"
+	if parent, ok := p.ec2InstanceSourceImage(reqCtx, instanceID); ok {
+		img.Architecture = parent.Architecture
+		img.Platform = parent.Platform
+		img.PlatformDetails = parent.PlatformDetails
+		img.UsageOperation = parent.UsageOperation
+		img.VirtualizationType = parent.VirtualizationType
+		img.RootDeviceName = parent.RootDeviceName
 	}
 	data, err := json.Marshal(img)
 	if err != nil {
@@ -4135,6 +4156,26 @@ func (p *EC2Plugin) registerImage(reqCtx *RequestContext, req *AWSRequest) (*AWS
 		}
 	}
 
+	// AWS's documented defaults for this operation — "Default: For Amazon EBS-backed AMIs,
+	// i386" and "Default: paravirtual" — and not the x86_64/hvm a modern caller expects.
+	// They look wrong, and substrate uses them anyway: a caller that omits the parameter
+	// here gets the same answer AWS gives it, and a caller that wants x86_64 has to say so
+	// in both places. A friendlier default is exactly the divergence that makes a test
+	// passing here mean nothing there.
+	//
+	// Neither value is checked against AWS's enum. That refusal is real on AWS and is
+	// deliberately not added here, for the reason this function's doc comment already gives
+	// about [ec2CheckBlockDeviceMappings]: a new refusal on a published path would arrive
+	// unannounced, and it is not what #750 asked for.
+	architecture := req.Params["Architecture"]
+	if architecture == "" {
+		architecture = "i386"
+	}
+	virtualizationType := req.Params["VirtualizationType"]
+	if virtualizationType == "" {
+		virtualizationType = "paravirtual"
+	}
+
 	imageID := generateImageID()
 	img := EC2Image{
 		ImageID:             imageID,
@@ -4147,6 +4188,20 @@ func (p *EC2Plugin) registerImage(reqCtx *RequestContext, req *AWSRequest) (*AWS
 		Tags:                tags,
 		AccountID:           reqCtx.AccountID,
 		Region:              reqCtx.Region,
+
+		Architecture:       architecture,
+		VirtualizationType: virtualizationType,
+		RootDeviceName:     req.Params["RootDeviceName"],
+		RootDeviceType:     ec2RegisteredRootDeviceType(req.Params),
+		Hypervisor:         bundledImageHypervisor,
+		ImageType:          bundledImageType,
+
+		// Platform, PlatformDetails and UsageOperation stay empty. RegisterImage takes no
+		// Platform parameter — AWS derives the member from the image itself — and the
+		// other two are billing codes derived from product codes substrate does not
+		// model, so a value would be a claim about a bill nothing backs. Public stays
+		// false: a newly registered AMI has no public launch permissions, and substrate
+		// models no ModifyImageAttribute that would grant them.
 	}
 	data, err := json.Marshal(img)
 	if err != nil {
@@ -4165,6 +4220,23 @@ func (p *EC2Plugin) registerImage(reqCtx *RequestContext, req *AWSRequest) (*AWS
 		XMLNS:   "http://ec2.amazonaws.com/doc/2016-11-15/",
 		ImageID: imageID,
 	})
+}
+
+// ec2RegisteredRootDeviceType reports whether a RegisterImage request describes an
+// EBS-backed AMI or an instance-store-backed one.
+//
+// AWS draws the line at ImageLocation: it is "the full path to your AMI manifest in Amazon
+// S3 storage", which is the instance-store registration form, while the EBS form sends
+// RootDeviceName plus a block device mapping instead. So the presence of the parameter is
+// the whole test, and it is a signal the caller sent rather than one substrate inferred.
+//
+// A request naming neither is answered "ebs", which is the form AWS's own RegisterImage
+// examples use and the one every mapping substrate stores describes.
+func ec2RegisteredRootDeviceType(params map[string]string) string {
+	if params["ImageLocation"] != "" {
+		return "instance-store"
+	}
+	return "ebs"
 }
 
 // describeImages lists the AMIs the account owns in the request's Region, narrowed by an
@@ -4224,15 +4296,42 @@ func (p *EC2Plugin) describeImages(reqCtx *RequestContext, req *AWSRequest) (*AW
 		NoDevice    *string         `xml:"noDevice,omitempty"`
 		EBS         *ebsBlockDevice `xml:"ebs,omitempty"`
 	}
+	// The member names are AWS's XML element names from API_Image.html, which are not the
+	// SDK-facing names: isPublic, not public, and imageOwnerId, not ownerId. AWS's own
+	// DescribeImages page disagrees with itself — its Example 1 response uses <ownerId> and
+	// <public> while Examples 2 and 3 and the Image type page use <imageOwnerId> and
+	// <isPublic>. Substrate follows the type page and the two examples that agree with it,
+	// which is also the spelling it already used for imageOwnerId (#750).
+	//
+	// imageOwnerId is omitempty as of #750. A bundled public AMI has no owner substrate can
+	// name — see [bundledImage.image] — and rendering an empty element claimed an account ID
+	// of "" rather than reporting no owner.
+	//
+	// platform is omitempty because AWS documents it as "set to windows for Windows AMIs;
+	// otherwise, it is blank", and an omitted element is what a caller branching on it can
+	// act on. isPublic is not omitempty-able as a bool without losing the false case, so it
+	// is rendered always, which is what AWS's examples do.
 	type imageItem struct {
-		ImageID             string            `xml:"imageId"`
-		Name                string            `xml:"name"`
-		Description         string            `xml:"description,omitempty"`
-		State               string            `xml:"imageState"`
-		OwnerID             string            `xml:"imageOwnerId"`
-		CreationDate        string            `xml:"creationDate,omitempty"`
-		BlockDeviceMappings []blockDeviceItem `xml:"blockDeviceMapping>item,omitempty"`
-		Tags                []ec2TagItem      `xml:"tagSet>item"`
+		ImageID                string            `xml:"imageId"`
+		Name                   string            `xml:"name"`
+		Description            string            `xml:"description,omitempty"`
+		State                  string            `xml:"imageState"`
+		OwnerID                string            `xml:"imageOwnerId,omitempty"`
+		OwnerAlias             string            `xml:"imageOwnerAlias,omitempty"`
+		Public                 bool              `xml:"isPublic"`
+		CreationDate           string            `xml:"creationDate,omitempty"`
+		Architecture           string            `xml:"architecture,omitempty"`
+		Platform               string            `xml:"platform,omitempty"`
+		PlatformDetails        string            `xml:"platformDetails,omitempty"`
+		UsageOperation         string            `xml:"usageOperation,omitempty"`
+		ImageType              string            `xml:"imageType,omitempty"`
+		RootDeviceType         string            `xml:"rootDeviceType,omitempty"`
+		RootDeviceName         string            `xml:"rootDeviceName,omitempty"`
+		VirtualizationType     string            `xml:"virtualizationType,omitempty"`
+		Hypervisor             string            `xml:"hypervisor,omitempty"`
+		PublicSsmParameterName string            `xml:"publicSsmParameterName,omitempty"`
+		BlockDeviceMappings    []blockDeviceItem `xml:"blockDeviceMapping>item,omitempty"`
+		Tags                   []ec2TagItem      `xml:"tagSet>item"`
 	}
 	type response struct {
 		XMLName xml.Name    `xml:"DescribeImagesResponse"`
@@ -4256,12 +4355,24 @@ func (p *EC2Plugin) describeImages(reqCtx *RequestContext, req *AWSRequest) (*AW
 	// a registered one.
 	renderImage := func(img EC2Image) imageItem {
 		item := imageItem{
-			ImageID:      img.ImageID,
-			Name:         img.Name,
-			Description:  img.Description,
-			State:        img.State,
-			OwnerID:      img.AccountID,
-			CreationDate: img.CreationDate,
+			ImageID:                img.ImageID,
+			Name:                   img.Name,
+			Description:            img.Description,
+			State:                  img.State,
+			OwnerID:                img.AccountID,
+			OwnerAlias:             img.OwnerAlias,
+			Public:                 img.Public,
+			CreationDate:           img.CreationDate,
+			Architecture:           img.Architecture,
+			Platform:               img.Platform,
+			PlatformDetails:        img.PlatformDetails,
+			UsageOperation:         img.UsageOperation,
+			ImageType:              img.ImageType,
+			RootDeviceType:         img.RootDeviceType,
+			RootDeviceName:         img.RootDeviceName,
+			VirtualizationType:     img.VirtualizationType,
+			Hypervisor:             img.Hypervisor,
+			PublicSsmParameterName: img.PublicSsmParameterName,
 		}
 		// A RegisterImage AMI renders the mapping the caller sent, entry for entry, in
 		// request order (#711). ec2ResolveSnapshotSizes fills in a size the mapping left to
@@ -4291,8 +4402,11 @@ func (p *EC2Plugin) describeImages(reqCtx *RequestContext, req *AWSRequest) (*AW
 		if len(img.BlockDeviceMappings) == 0 && img.SnapshotID != "" {
 			// Every CreateImage-minted AMI, and any AMI registered before #711, has a root
 			// snapshot and no recorded mapping — so substrate fabricates the root device
-			// entry for it. /dev/sda1 rather than a stored name because that path has none
-			// to store: it images an instance, and EC2Image records no root device.
+			// entry for it. The AMI's own RootDeviceName names the device when there is one
+			// to read: as of #750 a CreateImage AMI inherits its parent's, so an image made
+			// from a bundled Amazon Linux instance reports /dev/xvda in both the mapping and
+			// the rootDeviceName member rather than contradicting itself. /dev/sda1 remains
+			// the answer when the AMI records none, which is every AMI written before #750.
 			//
 			// An AMI whose snapshot record is gone falls back to the default rather than
 			// reporting 0, which is what a caller sizing a volume off this member can act
@@ -4304,8 +4418,12 @@ func (p *EC2Plugin) describeImages(reqCtx *RequestContext, req *AWSRequest) (*AW
 			if snap, found := resolveSnapshot(img.SnapshotID); found && snap.VolumeSize > 0 {
 				size = snap.VolumeSize
 			}
+			rootDevice := img.RootDeviceName
+			if rootDevice == "" {
+				rootDevice = ec2RootDeviceSDA1
+			}
 			item.BlockDeviceMappings = []blockDeviceItem{{
-				DeviceName: ec2RootDeviceSDA1,
+				DeviceName: rootDevice,
 				EBS:        &ebsBlockDevice{SnapshotID: img.SnapshotID, VolumeSize: size},
 			}}
 		}
@@ -4410,6 +4528,46 @@ func ec2ImageMatchesFilters(img EC2Image, filters map[string][]string) bool {
 			}
 		case name == "image-id":
 			matched = ec2FilterAccepts(vals, img.ImageID)
+
+		// The scalar members, each compared against the value the response renders, so a
+		// filter and the answer it narrows cannot disagree (#750).
+		//
+		// is-public is spelled as the boolean AWS documents rather than as Go's %t by
+		// accident: the filter's values are "true" and "false" and nothing else, so
+		// formatting it any other way would silently answer no.
+		//
+		// owner-id reads AccountID, which is empty for a bundled public AMI — so
+		// owner-id=<the caller's account> excludes the bundled images, which is the same
+		// distinction imageOwnerId's omitted element reports. A caller wanting those asks
+		// for owner-alias=amazon.
+		case name == "architecture":
+			matched = ec2FilterAccepts(vals, img.Architecture)
+		case name == "description":
+			matched = ec2FilterAccepts(vals, img.Description)
+		case name == "hypervisor":
+			matched = ec2FilterAccepts(vals, img.Hypervisor)
+		case name == "image-type":
+			matched = ec2FilterAccepts(vals, img.ImageType)
+		case name == "is-public":
+			matched = ec2FilterAccepts(vals, strconv.FormatBool(img.Public))
+		case name == "name":
+			matched = ec2FilterAccepts(vals, img.Name)
+		case name == "owner-alias":
+			matched = ec2FilterAccepts(vals, img.OwnerAlias)
+		case name == "owner-id":
+			matched = ec2FilterAccepts(vals, img.AccountID)
+		case name == "platform":
+			matched = ec2FilterAccepts(vals, img.Platform)
+		case name == "public-ssm-parameter-name":
+			matched = ec2FilterAccepts(vals, img.PublicSsmParameterName)
+		case name == "root-device-name":
+			matched = ec2FilterAccepts(vals, img.RootDeviceName)
+		case name == "root-device-type":
+			matched = ec2FilterAccepts(vals, img.RootDeviceType)
+		case name == "state":
+			matched = ec2FilterAccepts(vals, img.State)
+		case name == "virtualization-type":
+			matched = ec2FilterAccepts(vals, img.VirtualizationType)
 		default:
 			continue
 		}

--- a/emulator/ec2_snapshots.go
+++ b/emulator/ec2_snapshots.go
@@ -188,6 +188,32 @@ func (p *EC2Plugin) ec2Volume(reqCtx *RequestContext, volumeID string) (EC2Volum
 	return vol, true, nil
 }
 
+// ec2InstanceSourceImage is the AMI an instance was launched from, resolved through
+// [EC2Plugin.resolveImage] so a bundled public AMI answers as readily as a registered one.
+//
+// CreateImage needs it because the AMI it mints inherits the members the operating system
+// decides — architecture, platform, virtualization type, root device name — from the image
+// the source instance runs. It reports false rather than an error for an instance that is
+// gone or an AMI that no longer resolves: CreateImage's own answer does not depend on
+// either, and the members it would have inherited are all omitempty, so the AMI is
+// reported without them rather than with values nothing backs.
+//
+// It sits beside [EC2Plugin.ec2InstanceRootVolume] because the two are the same idea — read
+// the source instance rather than fabricate a constant for the AMI — and the constants that
+// idea replaced are what #689 and #750 each had to undo.
+func (p *EC2Plugin) ec2InstanceSourceImage(reqCtx *RequestContext, instanceID string) (EC2Image, bool) {
+	data, err := p.state.Get(context.Background(), ec2Namespace,
+		"instance:"+reqCtx.AccountID+"/"+reqCtx.Region+"/"+instanceID)
+	if err != nil || data == nil {
+		return EC2Image{}, false
+	}
+	var inst EC2Instance
+	if json.Unmarshal(data, &inst) != nil {
+		return EC2Image{}, false
+	}
+	return p.resolveImage(reqCtx, inst.ImageID)
+}
+
 // ec2InstanceRootVolume is the ID and size in GiB of the volume attached to instanceID at
 // a root device name. It reports an empty ID and [ec2DefaultVolumeSizeGiB] when the
 // instance has no root volume in state.

--- a/emulator/ec2_types.go
+++ b/emulator/ec2_types.go
@@ -511,6 +511,82 @@ type EC2Image struct {
 	// State is the image state: always "available" in Substrate.
 	State string `json:"state"`
 
+	// Architecture is the AMI's architecture, one of AWS's ArchitectureValues
+	// ("i386", "x86_64", "arm64", "x86_64_mac", "arm64_mac").
+	//
+	// RegisterImage records what the caller sent, defaulting to AWS's documented
+	// "Default: For Amazon EBS-backed AMIs, i386" rather than to the x86_64 a modern
+	// caller expects — see [EC2Plugin.registerImage] for why substrate keeps AWS's
+	// stale-looking default (#750).
+	Architecture string `json:"architecture,omitempty"`
+
+	// Platform is "windows" for a Windows AMI and empty for every other one.
+	//
+	// AWS documents the member as "set to windows for Windows AMIs; otherwise, it is
+	// blank", so empty is the answer for Linux rather than a value substrate failed to
+	// record — and [EC2Plugin.describeImages] omits the element rather than rendering
+	// it empty. AWS's own Image page contradicts itself here, listing the valid value
+	// as "Windows" while its prose, its DescribeImages example and the platform filter
+	// all spell it lowercase; substrate follows the three against the one (#750).
+	Platform string `json:"platform,omitempty"`
+
+	// PlatformDetails is the platform associated with the AMI's billing code, e.g.
+	// "Linux/UNIX" or "Windows", and UsageOperation is the matching billing code, e.g.
+	// "RunInstances" or "RunInstances:0002".
+	//
+	// Both are empty for an AMI a caller registered or created: they are billing data
+	// AWS derives from the AMI's product codes, and substrate models no product code,
+	// so a value here would be a claim about a bill nothing backs. Bundled images carry
+	// them because their platform is known from the published parameter (#750).
+	PlatformDetails string `json:"platform_details,omitempty"`
+	UsageOperation  string `json:"usage_operation,omitempty"`
+
+	// RootDeviceName is the device name of the AMI's root volume, and RootDeviceType is
+	// "ebs" or "instance-store".
+	//
+	// RegisterImage records the RootDeviceName the caller sent — the one place a caller
+	// states which device is root, which [ec2RootMappingSnapshot] already reads for the
+	// root snapshot. It is empty for a CreateImage-minted AMI that inherited nothing,
+	// and [EC2Plugin.describeImages] still fabricates a /dev/sda1 mapping for an AMI
+	// with a root snapshot and no recorded mapping.
+	RootDeviceName string `json:"root_device_name,omitempty"`
+	RootDeviceType string `json:"root_device_type,omitempty"`
+
+	// VirtualizationType is "hvm" or "paravirtual", and Hypervisor is "xen" — AWS
+	// documents "ovm" as the only other hypervisor value and says it is not supported.
+	//
+	// RegisterImage defaults VirtualizationType to AWS's documented "paravirtual", for
+	// the same reason Architecture defaults to i386.
+	VirtualizationType string `json:"virtualization_type,omitempty"`
+	Hypervisor         string `json:"hypervisor,omitempty"`
+
+	// ImageType is "machine", "kernel" or "ramdisk". Substrate mints only machine
+	// images: neither RegisterImage nor CreateImage exposes a way to register a kernel
+	// or a RAM disk here, and no bundled parameter names one.
+	ImageType string `json:"image_type,omitempty"`
+
+	// OwnerAlias is the AWS-maintained owner alias ("amazon", "aws-backup-vault" or
+	// "aws-marketplace"), set only on a bundled AMI Amazon publishes.
+	//
+	// It is empty for a caller's own AMI, and empty for the bundled Canonical Ubuntu
+	// entries — Canonical holds no AWS alias, and the aliases are "defined in an
+	// Amazon-maintained list", not inferable from a publisher's name (#750).
+	OwnerAlias string `json:"owner_alias,omitempty"`
+
+	// Public reports whether the AMI has public launch permissions. It is true for
+	// every bundled AMI, which is what makes them discoverable through a public SSM
+	// parameter, and false for one a caller registered or created — substrate models no
+	// ModifyImageAttribute launch-permission change, so nothing flips it.
+	Public bool `json:"public,omitempty"`
+
+	// PublicSsmParameterName is the AWS public Systems Manager parameter under
+	// aws/service/ that resolves to this AMI.
+	//
+	// It is the bundled catalog's own key, so a consumer that discovered an AMI through
+	// GetParameter can go the other way and get the same string back. It is empty for
+	// an AMI a caller registered or created, because no public parameter names one.
+	PublicSsmParameterName string `json:"public_ssm_parameter_name,omitempty"`
+
 	// CreationDate is the RFC3339 timestamp when the AMI was registered.
 	CreationDate string `json:"creation_date,omitempty"`
 


### PR DESCRIPTION
`DescribeImages` rendered six members — `imageId`, `name`, `description`, `imageState`, `imageOwnerId` and `creationDate` — and nothing about the image itself. So a caller that branched on architecture to pick an instance type, on the platform to decide between PowerShell and bash user data, or on the root device name to build a block device mapping read an empty string out of an AMI substrate knew the answer for.

Neither `EC2Image` nor `bundledImage` held any of this, so both gained the fields. Twelve members now render: `architecture`, `platform`, `platformDetails`, `usageOperation`, `rootDeviceName`, `rootDeviceType`, `virtualizationType`, `hypervisor`, `imageType`, `imageOwnerAlias`, `isPublic` and `publicSsmParameterName`.

## The defaults are decisions about two kinds of AMI at once

One closure (`renderImage`) serves both the state walk and the bundled pass, so a value written there for the catalog's benefit attaches to a registered image too. Four came out asymmetric on purpose:

- **`imageOwnerAlias`** is `amazon` on the seven AWS-published entries and absent on the two Canonical ones — the alias is "an Amazon-maintained list" and Canonical is not on it.
- **`publicSsmParameterName`** is the parameter an image was discovered through, and absent on a caller's own AMI: no public parameter names one.
- **`platformDetails`/`usageOperation`** are absent on a registered AMI. AWS derives both from product codes substrate does not model, so reporting `Linux/UNIX` would be a guess about what the image contains. `CreateImage` inherits them, because an image of a running instance runs the same OS its parent AMI does.
- **`imageOwnerId` is now omitted rather than rendered empty** for a bundled AMI. The member had no `omitempty` while a bundled image has no owner substrate can name, so a named bundled AMI answered with `<imageOwnerId></imageOwnerId>` — which an SDK reads as "the owner is the empty string" rather than "there is no owner". A comment in the catalog claimed nothing rendered the member at all; it did.

## `RegisterImage` and `CreateImage`

`RegisterImage` now stores `Architecture`, `VirtualizationType` and `RootDeviceName` — previously read and discarded, or never read — and derives `rootDeviceType` from whether `ImageLocation` was sent, since AWS documents that parameter as the S3 manifest path and its presence is the caller's own signal for the instance-store registration form.

Its defaults are **AWS's documented ones**, `i386` and `paravirtual`. No AMI a caller would register today is either and both will look wrong; they are used anyway, because inventing `x86_64`/`hvm` would mean a request that omits the parameter reports one thing here and another on AWS. Neither is validated against AWS's enum, following the reasoning that function's doc comment already states about the mapping rules — a new refusal on a published path arrives unannounced.

`CreateImage` inherits architecture, platform, the billing pair, virtualization type and root device name from the AMI its source instance runs. An AMI made from an arm64 Amazon Linux instance runs arm64 Amazon Linux, and reporting nothing while its parent reported `arm64` would be two of substrate's own answers disagreeing about one lineage. Ownership is *not* inherited, and the fabricated root mapping follows the inherited device name so `rootDeviceName` and `blockDeviceMapping` cannot disagree.

## Fourteen filters land with the members

`architecture`, `description`, `hypervisor`, `image-type`, `is-public`, `name`, `owner-alias`, `owner-id`, `platform`, `public-ssm-parameter-name`, `root-device-name`, `root-device-type`, `state` and `virtualization-type` were all *accepted and inert* — named without narrowing — so a request filtering on `architecture` answered with every AMI in the account and a caller read the non-empty result as a match. Rendering `architecture` while ignoring the `architecture` filter would have made the gap newly visible without closing it, so the two belong in one change. Eighteen of AWS's forty-three names are now evaluated.

## Provenance

- Each bundled entry's **root device name is substrate's reading**. AWS's device naming reference says only "Differs by AMI — `/dev/sda1` or `/dev/xvda`" and publishes no per-AMI table, so the split follows each publisher's convention: `/dev/xvda` for Amazon Linux and the ECS-optimized images, `/dev/sda1` for Windows and Ubuntu.
- **`platform`'s casing** — AWS contradicts itself. The `Image` type page's Valid Values says `Windows`; the same entry's prose says "set to `windows`", `DescribeImages`' second example renders `<platform>windows</platform>`, and the `platform` filter says "The only supported value is `windows`". Substrate renders lowercase — three statements against one.
- **`imageOwnerId`/`isPublic` against `ownerId`/`public`** — `DescribeImages`' Example 1 uses the short spellings; Examples 2–3 and the `Image` type page use the long ones. Substrate follows the type page, which is what it already used for the owner.

## Verified

`gofmt`, `go build`, `go vet`, `golangci-lint` (0 issues), `make test` (race), `make coverage` — emulator **83.4%**, total **82.8%**, both up — `make docs-reference docs-reference-check docs-versions`, `npm --prefix docs run build` plus the anchor diff, and `go vet`/`go test` under `test/e2e`.

A live run against a built binary with the AWS CLI covers all eleven behaviours: the SSM→`DescribeImages` parameter round-trip, the Windows entry's platform and billing pair, Ubuntu carrying no alias, five of the new filters narrowing, `RegisterImage` reporting what the caller sent, the `i386`/`paravirtual` defaults, `ImageLocation` giving `instance-store`, `CreateImage` inheriting from an arm64 and a Windows parent, and the raw wire showing no `<imageOwnerId>` and no `<platform>` on a Linux bundled AMI.

New tests in `emulator/ec2_image_members_test.go`: every member of all nine bundled entries (with a guard that a new catalog row cannot ship unasserted), the omit-rather-than-empty trio asserted against raw XML, the parameter round-trip across the SSM and EC2 plugins for all nine, the registered-image members, both defaults, the `ImageLocation` form, both `CreateImage` inheritance paths, and a nineteen-row filter table plus a registered-image filter table.

## Compatibility

Records written before this release carry empty architecture and root-device values, so a bundled AMI answers fully while a previously-registered one omits the new members. `RegisterImage` now defaults to `i386`/`paravirtual` rather than nothing, and a fixture asserting an empty `<imageOwnerId>` on a bundled AMI now sees the element absent.

Closes #750