### PR TITLE
fix(ec2): DescribeSecurityGroups narrows on GroupName.N (#749)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ownerId`/`public` per Example 1.
 
 ### Fixed
+- **`DescribeSecurityGroups` ignored `GroupName.N`** (#749). AWS documents the parameter and
+  substrate read it nowhere, so a caller naming one group by name was answered about **every**
+  group in the account — the superset failure #731 fixed for `DescribeImages`' `ImageId.N`, and
+  the worse of the two failure directions, because an error is visible where a superset reads as
+  a successful narrowing. Both spellings are now read, and the name list unions with `GroupId.N`
+  rather than intersecting it, matching the reading already recorded for the other paired
+  identity selectors.
+
+  Two decisions here are substrate's reading of AWS rather than its published text. A name is
+  matched **account-wide**, where AWS scopes the parameter to the default VPC: substrate does
+  model a default VPC but creates it lazily, only when a launch path asks for one, so a
+  default-VPC scope would make the parameter answer nothing in a fresh account — the same
+  invisible wrong answer as the superset, in the other direction. A consequence worth knowing is
+  that a name may match several groups, because `CreateSecurityGroup` enforces no name
+  uniqueness where AWS's is per-VPC; narrow with the `vpc-id` filter, which composes.
+
+  And a name matching nothing answers an **empty set** rather than `InvalidGroup.NotFound`. The
+  operation's Errors section is empty, and both AWS's client-error table and substrate's own
+  message for that code describe a missing security group *ID*, so refusing would mean inventing
+  wording AWS does not publish here on top of asserting a scope substrate does not implement —
+  the same declined invention `DescribeKeyPairs` already records. The ID half keeps its full
+  contract regardless: a malformed `GroupId.N` is refused before the walk and an unresolved one
+  after it, whether or not a name selected something.
 - **Fourteen `DescribeImages` filters were accepted and never applied** (#750). `architecture`,
   `description`, `hypervisor`, `image-type`, `is-public`, `name`, `owner-alias`, `owner-id`,
   `platform`, `public-ssm-parameter-name`, `root-device-name`, `root-device-type`, `state` and

--- a/docs/services.md
+++ b/docs/services.md
@@ -3437,11 +3437,12 @@ unattached, untagged gateway, because its AWS sample does. `DescribeVpcs` and
 and reproducing it per page is the point: a sweep "for consistency" would break one of them
 against its own reference.
 
-**Paired identity parameters union rather than intersect.** Five operations take two lists that
+**Paired identity parameters union rather than intersect.** Six operations take two lists that
 name the same resource two ways — `KeyName.N`+`KeyPairId.N`, `ZoneName.N`+`ZoneId.N`,
-`GroupName.N`+`GroupId.N`, `AllocationId.N`+`PublicIp.N`, and
-`LaunchTemplateId.N`+`LaunchTemplateName.N`. A request carrying both is answered with the
-resources named by **either**:
+`AllocationId.N`+`PublicIp.N`, `LaunchTemplateId.N`+`LaunchTemplateName.N`, and
+`GroupName.N`+`GroupId.N` on both `DescribePlacementGroups` and — since
+[#749](https://github.com/scttfrdmn/substrate/issues/749) — `DescribeSecurityGroups`. A request
+carrying both is answered with the resources named by **either**:
 
 ```
 DescribeKeyPairs&KeyPairId.1=key-0abc…&KeyName.1=deploy   → both key pairs
@@ -3480,11 +3481,12 @@ the template is resolved, so a typo answers `InvalidParameterValue` rather than
   `opt-in-not-required`, so the opt-in filtering the parameter controls has nothing to exclude.
 - **`IncludeUnsupportedInRegion` is not read** on `DescribeInstanceTypes`; the seeded catalog is
   the same in every region.
-- **Seven selector families answer an empty set where AWS answers `NotFound`.** `KeyName.N`
+- **Eight selector families answer an empty set where AWS answers `NotFound`.** `KeyName.N`
   and `KeyPairId.N` (AWS: `InvalidKeyPair.NotFound`), `GroupName.N` and `GroupId.N` on
   `DescribePlacementGroups` (`InvalidPlacementGroup.Unknown`), `ZoneName.N`/`ZoneId.N`,
-  `PublicIp.N`, `DescribeLaunchTemplates`' selectors, `DescribeFleets`' `FleetId.N` and
-  `DescribeRegions`' `RegionName.N` all select by membership rather than through an
+  `PublicIp.N`, `DescribeLaunchTemplates`' selectors, `DescribeFleets`' `FleetId.N`,
+  `DescribeRegions`' `RegionName.N` and `DescribeSecurityGroups`' `GroupName.N` (whose
+  `GroupId.N` **does** assert) all select by membership rather than through an
   [ID assertion](#explicit-resource-ids) — so naming one that does not exist narrows the
   answer to nothing instead of failing. This read "six of the new selectors" and named
   four families until #731, which added `DescribeLaunchTemplates` and the two whose
@@ -5055,14 +5057,15 @@ because an error is visible and a superset reads as a successful narrowing.
 `DescribeInstanceTypes`' `InstanceType.N` also asserts existence, answering
 `InvalidInstanceType`.
 
-**Seven selector families deliberately do not**, and answer an empty set where AWS
-answers `NotFound`. Two have reasons that would not change if a kind were registered
+**Eight selector families deliberately do not**, and answer an empty set where AWS
+answers `NotFound`. Three have reasons that would not change if a kind were registered
 for them:
 
 | Selector | Why not |
 |---|---|
 | `DescribeFleets`' `FleetId.N` | AWS publishes **no** `InvalidFleetId.NotFound`. The only fleet-ID absence code in the reference is `InvalidSpotFleetRequestId.*`, which is a `sfr-` request, not a `fleet-` fleet. |
 | `DescribeRegions`' `RegionName.N` | The parameter explicitly permits naming any Region, enabled for the account or not, so "this Region is not in your answer" is not absence. |
+| `DescribeSecurityGroups`' `GroupName.N` | The kind **is** registered and its `GroupId.N` asserts, but the code is `InvalidGroup.NotFound` and both AWS's client-error table and substrate's message for it describe a missing security group *ID*. This operation's own Errors section is empty, so a name-shaped refusal would be invented wording. AWS also scopes the parameter to the default VPC where substrate matches account-wide, so absence here is not the absence AWS would be reporting. |
 
 Five more have a published code but no registered `ec2IDKind`, so the assertion is
 unimplemented rather than declined: `DescribeKeyPairs`' `KeyName.N`/`KeyPairId.N`
@@ -5072,9 +5075,27 @@ unimplemented rather than declined: `DescribeKeyPairs`' `KeyName.N`/`KeyPairId.N
 `DescribeLaunchTemplates`, whose `InvalidLaunchTemplateId.NotFound` is one of the four
 hand-written codes above.
 
-`DescribeSecurityGroups` documents a `GroupName.N` alongside `GroupId.N` and substrate
-**does not read it**: only the ID list selects. A caller naming a group by name is
-answered about every group, so filter on `group-name` instead, which is evaluated.
+`DescribeSecurityGroups`' `GroupName.N` selects as of
+[#749](https://github.com/scttfrdmn/substrate/issues/749) — it was read by nothing before, so a
+caller naming one group by name was answered about **every** group in the account — and it
+unions with `GroupId.N` like the [other paired identity
+parameters](#twelve-describes-gained-filters). Two things about it are substrate's reading:
+
+- **A name is matched account-wide**, where AWS scopes the parameter to the default VPC
+  ("[Default VPC] The names of the security groups"). Substrate does model a default VPC, but
+  creates it *lazily* — only when a launch path asks for one — so scoping the parameter to it
+  would make `GroupName.N` answer nothing at all in a fresh account. That is the same
+  invisible-wrong-answer failure as the superset it replaces, in the other direction. A
+  consequence: a name may legitimately match **several** groups here, because
+  `CreateSecurityGroup` enforces no name uniqueness where AWS's is per-VPC. Narrow with the
+  `vpc-id` filter, which composes with the name.
+- **A name matching nothing answers an empty set**, not `InvalidGroup.NotFound`. This
+  operation's Errors section is empty, and EC2's client-error table describes that code as a
+  missing security group *ID* — which is what substrate's own message for it says — so refusing
+  here would mean inventing wording AWS does not publish for this operation, on top of
+  asserting a default-VPC scope substrate does not implement. The ID half keeps its full
+  contract either way: a malformed `GroupId.N` is refused before the walk and an unresolved one
+  after it, whether or not a name selected something.
 
 `DescribeImages` also does not read `Owner.N` or `ExecutableBy.N`. Substrate stores only
 images the account owns, so `self` is the answer to every describe and AWS's other three

--- a/emulator/ec2_describe_sg_names_test.go
+++ b/emulator/ec2_describe_sg_names_test.go
@@ -1,0 +1,262 @@
+package emulator_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// DescribeSecurityGroups narrows on GroupName.N (#749).
+//
+// AWS documents the parameter as "[Default VPC] The names of the security groups" and substrate
+// read it nowhere, so a caller naming one group by name was answered about every group in the
+// account — the superset failure #731 fixed for DescribeImages' ImageId.N, and the worse of the
+// two failure directions, because an error is visible where a superset reads as a successful
+// narrowing.
+//
+// Two decisions here are substrate's reading, and each has a test below that pins it rather than
+// leaving it to be rediscovered:
+//
+//   - A name is matched **account-wide**, not scoped to the default VPC. Substrate creates its
+//     default VPC lazily, only when a launch path asks for one, so a default-VPC scope would make
+//     the parameter answer nothing in a fresh account.
+//   - A name matching nothing answers an **empty set**, not InvalidGroup.NotFound. The
+//     operation's Errors section is empty and EC2's client-error table describes that code as a
+//     missing security group *ID*, so refusing would mean inventing wording AWS does not publish
+//     for this operation.
+
+// ec2CreateSG creates a security group and returns its ID.
+func ec2CreateSG(t *testing.T, ts *httptest.Server, name, description, vpcID string) string {
+	t.Helper()
+	params := map[string]string{
+		"Action":           "CreateSecurityGroup",
+		"GroupName":        name,
+		"GroupDescription": description,
+	}
+	if vpcID != "" {
+		params["VpcId"] = vpcID
+	}
+	var doc struct {
+		GroupID string `xml:"groupId"`
+	}
+	ec2FleetXML(t, ts, params, &doc)
+	require.NotEmpty(t, doc.GroupID, "CreateSecurityGroup %s", name)
+	return doc.GroupID
+}
+
+// ec2DescribeSGNames returns the group names DescribeSecurityGroups answers with, so a table
+// row can assert on the selection rather than on the rendering.
+func ec2DescribeSGNames(t *testing.T, ts *httptest.Server, params map[string]string) []string {
+	t.Helper()
+	req := map[string]string{"Action": "DescribeSecurityGroups"}
+	for k, v := range params {
+		req[k] = v
+	}
+	var doc struct {
+		Groups []struct {
+			GroupName string `xml:"groupName"`
+		} `xml:"securityGroupInfo>item"`
+	}
+	ec2FleetXML(t, ts, req, &doc)
+	var names []string
+	for _, g := range doc.Groups {
+		names = append(names, g.GroupName)
+	}
+	return names
+}
+
+// TestEC2_DescribeSecurityGroups_GroupNameNarrows is the table the issue asks for: the name
+// list selects, in both spellings, and unions with GroupId.N rather than intersecting it.
+//
+// The union is the same reading [ec2SelectedByEither] records for the five other paired identity
+// selectors: the two lists are two spellings of one question, so intersecting them would answer
+// with the empty set while both named groups exist.
+func TestEC2_DescribeSecurityGroups_GroupNameNarrows(t *testing.T) {
+	ts := newEC2TestServer(t)
+	web := ec2CreateSG(t, ts, "web", "web tier", "")
+	db := ec2CreateSG(t, ts, "db", "db tier", "")
+	ec2CreateSG(t, ts, "cache", "cache tier", "")
+
+	tests := []struct {
+		name   string
+		params map[string]string
+		want   []string
+	}{
+		{
+			name:   "no selector answers every group",
+			params: nil,
+			want:   []string{"web", "db", "cache"},
+		},
+		{
+			name:   "one indexed name",
+			params: map[string]string{"GroupName.1": "web"},
+			want:   []string{"web"},
+		},
+		{
+			name:   "the un-indexed spelling",
+			params: map[string]string{"GroupName": "db"},
+			want:   []string{"db"},
+		},
+		{
+			name:   "two names",
+			params: map[string]string{"GroupName.1": "web", "GroupName.2": "cache"},
+			want:   []string{"web", "cache"},
+		},
+		{
+			name:   "a name that matches nothing answers empty, not NotFound",
+			params: map[string]string{"GroupName.1": "no-such-group"},
+			want:   nil,
+		},
+		{
+			name:   "one name of two matching answers only the match",
+			params: map[string]string{"GroupName.1": "web", "GroupName.2": "no-such-group"},
+			want:   []string{"web"},
+		},
+		{
+			name:   "an ID alone still selects",
+			params: map[string]string{"GroupId.1": db},
+			want:   []string{"db"},
+		},
+		{
+			name:   "the two lists union",
+			params: map[string]string{"GroupId.1": web, "GroupName.1": "cache"},
+			want:   []string{"web", "cache"},
+		},
+		{
+			name:   "naming one group in both lists returns it once",
+			params: map[string]string{"GroupId.1": web, "GroupName.1": "web"},
+			want:   []string{"web"},
+		},
+		{
+			name:   "a name AND a non-matching filter answers empty",
+			params: map[string]string{"GroupName.1": "web", "Filter.1.Name": "group-name", "Filter.1.Value.1": "db"},
+			want:   nil,
+		},
+		{
+			name:   "a name AND a matching filter answers the group",
+			params: map[string]string{"GroupName.1": "web", "Filter.1.Name": "group-name", "Filter.1.Value.1": "web"},
+			want:   []string{"web"},
+		},
+		{
+			name:   "the name is exact, never a glob",
+			params: map[string]string{"GroupName.1": "we*"},
+			want:   nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tc.want, ec2DescribeSGNames(t, ts, tc.params))
+		})
+	}
+}
+
+// TestEC2_DescribeSecurityGroups_NameDoesNotWeakenTheIDContract is the half of the union that
+// could have gone wrong silently: the name list must not launder an ID the walk never resolved.
+//
+// The ID half keeps its full contract — malformed before the walk, NotFound after it — and the
+// name half has neither, so a request carrying both has to apply each rule to its own list. The
+// ordering rows matter because AWS validates ID syntax before it looks anything up, which is why
+// [ec2IDFilter.validate] runs ahead of the loop.
+func TestEC2_DescribeSecurityGroups_NameDoesNotWeakenTheIDContract(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ec2CreateSG(t, ts, "web", "web tier", "")
+
+	tests := []struct {
+		name   string
+		params map[string]string
+		status int
+		code   string
+	}{
+		{
+			name:   "an unknown ID beside a matching name is still NotFound",
+			params: map[string]string{"GroupId.1": "sg-0000000000000dead", "GroupName.1": "web"},
+			status: 400,
+			code:   "InvalidGroup.NotFound",
+		},
+		{
+			name:   "a malformed ID beside a matching name is still Malformed",
+			params: map[string]string{"GroupId.1": "not-an-id", "GroupName.1": "web"},
+			status: 400,
+			code:   "InvalidGroupId.Malformed",
+		},
+		{
+			name:   "malformed beats NotFound when both are named",
+			params: map[string]string{"GroupId.1": "not-an-id", "GroupId.2": "sg-0000000000000dead"},
+			status: 400,
+			code:   "InvalidGroupId.Malformed",
+		},
+		{
+			name:   "a malformed ID is refused even when the name selects nothing",
+			params: map[string]string{"GroupId.1": "not-an-id", "GroupName.1": "no-such-group"},
+			status: 400,
+			code:   "InvalidGroupId.Malformed",
+		},
+		{
+			name:   "a name matching nothing is not a refusal",
+			params: map[string]string{"GroupName.1": "no-such-group"},
+			status: 200,
+			code:   "",
+		},
+		{
+			name:   "a resolvable ID beside a name matching nothing succeeds",
+			params: map[string]string{"GroupName.1": "no-such-group", "Filter.1.Name": "vpc-id", "Filter.1.Value.1": "vpc-x"},
+			status: 200,
+			code:   "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := map[string]string{"Action": "DescribeSecurityGroups"}
+			for k, v := range tc.params {
+				req[k] = v
+			}
+			status, code := ec2ErrorCode(t, ts, req)
+			assert.Equal(t, tc.status, status)
+			assert.Equal(t, tc.code, code)
+		})
+	}
+}
+
+// TestEC2_DescribeSecurityGroups_NameIsMatchedAccountWide pins the scope decision.
+//
+// AWS scopes GroupName.N to the default VPC. Substrate matches account-wide, because its default
+// VPC is created lazily — only when a launch path asks for one — so a default-VPC scope would
+// answer nothing at all in a fresh account, which is the superset bug's mirror image and just as
+// silent. Two consequences follow and are asserted here: a group in a caller-made VPC is
+// selectable by name, and a name may match several groups, because CreateSecurityGroup enforces
+// no name uniqueness where AWS's is per-VPC.
+func TestEC2_DescribeSecurityGroups_NameIsMatchedAccountWide(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	var vpcA, vpcB struct {
+		VpcID string `xml:"vpc>vpcId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "CreateVpc", "CidrBlock": "10.0.0.0/16"}, &vpcA)
+	ec2FleetXML(t, ts, map[string]string{"Action": "CreateVpc", "CidrBlock": "10.1.0.0/16"}, &vpcB)
+	require.NotEmpty(t, vpcA.VpcID)
+	require.NotEqual(t, vpcA.VpcID, vpcB.VpcID)
+
+	a := ec2CreateSG(t, ts, "shared", "in vpc A", vpcA.VpcID)
+	b := ec2CreateSG(t, ts, "shared", "in vpc B", vpcB.VpcID)
+	require.NotEqual(t, a, b)
+
+	assert.Equal(t, []string{"shared", "shared"}, ec2DescribeSGNames(t, ts, map[string]string{"GroupName.1": "shared"}),
+		"a name is not unique in substrate, so it may select more than one group")
+
+	// Narrowing to one of them is what vpc-id is for, and it composes with the name.
+	var doc struct {
+		Groups []struct {
+			GroupID string `xml:"groupId"`
+		} `xml:"securityGroupInfo>item"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":           "DescribeSecurityGroups",
+		"GroupName.1":      "shared",
+		"Filter.1.Name":    "vpc-id",
+		"Filter.1.Value.1": vpcB.VpcID,
+	}, &doc)
+	require.Len(t, doc.Groups, 1)
+	assert.Equal(t, b, doc.Groups[0].GroupID)
+}

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -1762,11 +1762,37 @@ func (p *EC2Plugin) createSecurityGroup(reqCtx *RequestContext, req *AWSRequest)
 	return ec2XMLResponse(http.StatusOK, response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/", GroupID: sgID, Return: true})
 }
 
+// describeSecurityGroups reports the security groups the account holds in the region.
+//
+// Selects on GroupId.N, GroupName.N and Filter.N. GroupName.N was read by nothing before #749
+// — a caller naming one group by name was answered about every group in the account, the
+// superset failure #731 fixed for DescribeImages — and the two identity lists union rather
+// than intersect, per [ec2IDFilter.matchOrNamed].
+//
+// Two things about the name half are substrate's reading rather than AWS's text, both recorded
+// in docs/services.md:
+//
+// A name is matched **account-wide**, where AWS scopes the parameter to the default VPC
+// ("[Default VPC] The names of the security groups"). Substrate does model a default VPC —
+// [EC2VPC.IsDefault], [EC2Plugin.ensureDefaultVPC] — but creates it lazily, only when a launch
+// path asks for one, so scoping the parameter to it would make GroupName.N answer nothing in a
+// fresh account. Account-wide also means a name may legitimately match several groups here,
+// because [EC2Plugin.createSecurityGroup] enforces no name uniqueness where AWS's is per-VPC.
+//
+// A name matching nothing answers an **empty set** rather than InvalidGroup.NotFound. This
+// operation's Errors section is empty, and EC2's client-error table describes that code as a
+// missing security group *ID* — which is what [ec2SecurityGroupIDKind]'s own message says — so
+// refusing here would mean inventing wording for a refusal AWS does not publish on this
+// operation, and asserting a default-VPC scope substrate does not implement. It follows
+// [EC2Plugin.describeKeyPairs], which declines the same invention for the same reason. The ID
+// half keeps its full contract: a malformed ID is refused before the walk and an unresolved one
+// after it.
 func (p *EC2Plugin) describeSecurityGroups(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	ids := newEC2IDFilter(extractIndexedParams(req.Params, "GroupId"), ec2SecurityGroupIDKind)
 	if err := ids.validate(); err != nil {
 		return nil, err
 	}
+	names := extractIndexedParams(req.Params, "GroupName")
 	if err := ec2SecurityGroupFilterSpec().check(req.Params); err != nil {
 		return nil, err
 	}
@@ -1814,7 +1840,7 @@ func (p *EC2Plugin) describeSecurityGroups(reqCtx *RequestContext, req *AWSReque
 		if json.Unmarshal(data, &sg) != nil {
 			continue
 		}
-		if !ids.match(sg.GroupID) {
+		if !ids.matchOrNamed(sg.GroupID, names, sg.GroupName) {
 			continue
 		}
 		// A filter naming no values matches nothing, as it does everywhere else: these

--- a/emulator/ec2_resourceid.go
+++ b/emulator/ec2_resourceid.go
@@ -217,6 +217,32 @@ func (f *ec2IDFilter) match(id string) bool {
 	return true
 }
 
+// matchOrNamed is [ec2IDFilter.match] for a describe whose resources a caller can also name
+// by a non-ID selector: it takes that selector's requested list and this resource's value for
+// it, and reports whether the resource belongs in the response.
+//
+// The two lists **union**, for the reason [ec2SelectedByEither] gives — DescribeSecurityGroups'
+// GroupId.N and GroupName.N are two spellings of one question, so intersecting them would
+// answer with the empty set while both named groups exist. That helper cannot be used directly
+// here, because it takes two plain lists and this one half of the pair carries the ID filter's
+// malformed-form and NotFound contract.
+//
+// match is called unconditionally, so the ID list's resolution bookkeeping still runs whichever
+// half selected the resource: an ID a name-union let through was still resolved, and one the
+// walk never saw is still the NotFound [ec2IDFilter.unresolved] reports. That cannot let a
+// resource in wrongly, because match returning true already means the request named its ID.
+//
+// The name list has no such contract: a name matching nothing narrows the answer to nothing
+// rather than refusing (#749). It is exact membership, never a glob, for the reason
+// [ec2SelectedByEither] states.
+func (f *ec2IDFilter) matchOrNamed(id string, names []string, name string) bool {
+	matched := f.match(id)
+	if len(names) == 0 {
+		return matched
+	}
+	return (len(f.order) > 0 && matched) || containsStr(names, name)
+}
+
 // unresolved returns the kind's NotFound error for the first requested ID that
 // match never saw, or nil if every requested ID resolved. Call it after the
 // describe loop.


### PR DESCRIPTION
Closes #749.

`DescribeSecurityGroups` documented `GroupName.N` and substrate read it nowhere, so a caller
naming one group by name was answered about **every** group in the account. That is the superset
failure #731 fixed for `DescribeImages`' `ImageId.N`, and the worse of the two failure
directions — an error is visible, where a superset reads as a successful narrowing and quietly
defeats whatever the caller was asserting about the answer.

Confirmed live against a built binary before the change:

```
$ aws ec2 describe-security-groups --group-names web --query 'SecurityGroups[].GroupName'
["db", "cache", "web"]
$ aws ec2 describe-security-groups --group-names no-such-group --query 'SecurityGroups[].GroupName'
["web", "db", "cache"]
```

and after it: `["web"]` and `[]`. The same run shows both lists unioning, a name naming a group
its ID also names returning it once, a name composing with a filter, the name being exact rather
than a glob, and the ID half still refusing an unknown or malformed ID beside a matching name.

## The union, and why it is not `ec2SelectedByEither`

The two lists **union**, for the reason that helper already records: `GroupId.N` and
`GroupName.N` are two spellings of one question, so intersecting them would answer with the empty
set while both named groups exist. The helper itself cannot be reused, because it takes two plain
lists and one half of this pair carries `ec2IDFilter`'s malformed-form and NotFound contract. So
the union lands as a new `ec2IDFilter.matchOrNamed`, which calls `match` unconditionally to keep
the resolution bookkeeping running whichever half selected the resource — and guards on
`len(f.order) > 0`, because `match` returns true when no IDs were requested and a name-only
request would otherwise select everything.

## Two readings that are substrate's, not AWS's

Each has a test that pins it rather than leaving it to be rediscovered.

**A name is matched account-wide**, where AWS scopes the parameter to the default VPC. Substrate
does model a default VPC — `EC2VPC.IsDefault`, `ensureDefaultVPC`, which even mints a group named
`default` — but creates it lazily, only when a launch path asks for one, so a default-VPC scope
would make the parameter answer *nothing* in a fresh account: the same invisible wrong answer as
the superset, in the other direction. A consequence worth knowing is that a name may match
several groups, because `createSecurityGroup` enforces no name uniqueness where AWS's is per-VPC;
the `vpc-id` filter narrows, and composes.

**A name matching nothing answers an empty set**, not `InvalidGroup.NotFound`. The operation's
Errors section is empty — verified against `API_DescribeSecurityGroups.html`, which links only
the common error types — and both AWS's client-error table and substrate's own message for that
code describe a missing security group *ID*. Refusing would mean inventing wording AWS does not
publish for this operation on top of asserting a scope substrate does not implement. That is the
invention `describeKeyPairs` already declines in its own doc comment, and this follows it.

The ID half keeps its full contract regardless: malformed before the walk, NotFound after it,
whether or not a name selected something. Six rows assert that, including malformed-beats-NotFound
and a malformed ID refused even when the name selects nothing.

## Acceptance criteria

- [x] Narrows by `GroupName.N` in both spellings, and combines with `GroupId.N` and with filters
      the way the existing handlers do — 12 rows.
- [x] A name matching nothing does not refuse, and the decision is recorded in
      `docs/services.md` with its reason.
- [x] The malformed-beats-NotFound ordering is asserted.
- [x] `docs/services.md` drops `GroupName.N` from #731's documented-but-unread selector list, and
      the three counts that list feeds are re-tallied.

## Verification

`gofmt`/`go build`/`go vet`/`golangci-lint` clean; `make test` green under race; `make coverage`
holds at emulator 83.4% / total 82.8%; `make docs-reference docs-reference-check docs-versions`
clean; the docs site builds with no dangling anchors; `test/e2e` passes. Fail-before was also
proven at the unit tier by reverting the loop guard, which reds 8 subtests.