### PR TITLE
fix(ec2,iam): authorize every ID an EC2 request names (#744)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ownerId`/`public` per Example 1.
 
 ### Fixed
+- **An EC2 operation naming several resources was decided against the first alone** (#744).
+  `TerminateInstances` with three `InstanceId.N` was authorized against `InstanceId.1`'s ARN
+  and `InstanceId.1`'s tags; the other two were not authorized at all. So a policy allowing
+  instances tagged `Env=dev` and denying the rest permitted a call naming one dev instance and
+  two production ones, provided the dev one came first — and a `Deny` fencing off a production
+  instance was inert behind any instance the caller was allowed to touch. Every ID a request
+  names under one of the four resolving parameters — `InstanceId.N`, `GroupId.N`,
+  `RouteTableId.N`, `InternetGatewayId.N` — now carries its own ARN and its own tags into its
+  own decision, which is the reading #660 and #662 established and #674 already applied to a
+  tagging call's `ResourceId.N`. The permission boundary sees the whole batch too.
+
+  The denial names the first resource the policy does not allow, in fixed parameter order and
+  then request-index order, so it is deterministic across replays and it is a resource the
+  caller can act on. `GroupId` is overloaded, which pulls one more operation in:
+  `DescribePlacementGroups` reads `pg-` IDs through it and is now decided against the groups it
+  names, resolving each by prefix — a `pg-` ID to a name-form `placement-group/<name>` ARN and
+  an `sg-` ID to `security-group/<id>` — in the same request.
+
+  An ID that resolves to no ARN is **skipped**, as a tagging call's already was: a batch of one
+  resolvable and one unparseable ID is authorized as the batch of one, because the refusal such
+  an ID is owed is the handler's `Malformed`/`NotFound` rather than an `AccessDenied` naming a
+  resource that does not exist. For `TerminateInstances` that cannot launder a state change
+  past a policy — AWS documents it all-or-nothing and substrate resolves every ID before
+  terminating any — while `StopInstances`/`StartInstances` are not atomic, so there the batch is
+  authorized as the resources that exist. No ordering between the 403 and the 404 is asserted,
+  because no AWS page publishes one. The skip is narrower than it reads: a well-formed `i-` ID
+  naming no instance is still its own resource, since its ARN is built from the ID rather than
+  looked up, so a least-privilege policy must still name it.
+- **`docs/services.md` published the unresolved-policy-variable rule backwards** (#744). The
+  page claimed a divergence in `NotResource` and the negated operators, where an unresolved
+  variable was said to match on AWS and not here. AWS's *Variables and tags* page applies one
+  sentence to both elements — "used as part of the `Resource` **or** `NotResource` element …
+  will not match any resource" — and states that inverted condition operators "do match against
+  a null value", which is what substrate's literal comparison already answers. So there is no
+  unresolved-variable divergence in either direction. The divergence that *is* real is a
+  variable that would have **resolved**: safe under the positive forms, which grant less than
+  they say, and unsafe under the negated ones, where a `StringNotEquals` against an
+  un-substituted literal is inert on a `Deny` and grants on an `Allow`. That is reachable today
+  through `SimulateCustomPolicy`'s own `ContextEntries`, and is what #745 tracks.
 - **`DescribeSecurityGroups` ignored `GroupName.N`** (#749). AWS documents the parameter and
   substrate read it nowhere, so a caller naming one group by name was answered about **every**
   group in the account — the superset failure #731 fixed for `DescribeImages`' `ImageId.N`, and

--- a/docs/services.md
+++ b/docs/services.md
@@ -1360,12 +1360,33 @@ that an unresolved variable in `Resource` "will not match any resource", `aws:us
 no producer, and substrate's literal comparison reaches the same answer by a different
 route. The statement matches nothing either way.
 
-The divergence that **is** real is `NotResource` and the negated operators, where AWS says
-an unresolved variable *does* match — so the negation excludes everything on AWS and nothing
-here, and a policy written that way is more permissive under substrate. Nothing in the
-bundled catalog is written that way; a caller's own policy could be.
+**An unresolved variable diverges nowhere**, in either element and under either polarity —
+which corrects a rule this page previously published backwards
+([#744](https://github.com/scttfrdmn/substrate/issues/744)). AWS
+applies one sentence to both elements: "If a variable that has no value in the authorization
+context is used as part of the `Resource` **or** `NotResource` element of a policy, the
+resource that includes a policy variable with no value will not match any resource." An ARN
+still carrying a literal `${…}` matches no resource under either element here either, so
+both routes reach the same answer. Under a negated *condition operator* AWS is equally
+explicit that the comparison **does** match — "Inverted condition operators like
+`StringNotEquals` or `StringNotLike` do match against a null value, as the value of the
+condition key they are testing against is not equal to or like the effectively null value" —
+and substrate's literal comparison matches too, because no context value equals the string
+`${aws:PrincipalTag/Team}`. The one way to tell them apart is to pass that literal string
+*as* a context value, which only a hand-written `SimulateCustomPolicy` `ContextEntry` can do.
 
-Substitution cannot land before `aws:username` has an honest producer, and the two obvious
+**What does diverge is a variable that would have resolved**, which is what
+[#745](https://github.com/scttfrdmn/substrate/issues/745) tracks. Under the positive forms —
+`Resource`, `StringEquals`, `ArnLike` — the literal matches nothing where AWS would have
+matched, so the statement grants less than it says: a false deny, and the safe direction.
+Under the negated forms it is the reverse and it is not safe. A
+`StringNotEquals` comparing `s3:ExistingObjectTag/Team` against `${aws:ResourceTag/Team}`
+is *false* on AWS when the two agree, and *true* here, because "red" does not equal the
+un-substituted literal — so such a statement is inert on a `Deny` and grants on an `Allow`.
+That is reachable today with no new producer at all, since `SimulateCustomPolicy` copies a
+caller's `ContextEntries` straight into the context the same evaluator reads.
+
+An honest `aws:username` is what the request-signing path still owes, and the two obvious
 candidates are both wrong: the ARN's last component is the *session* name for an assumed
 role, where AWS documents `aws:username` as absent altogether, and the value the caller ARN
 is built from is an access key ID. The honest producer is the resolved IAM user name, set
@@ -4462,24 +4483,54 @@ evaluates. See [multivalued condition
 keys](#multivalued-condition-keys-forallvalues-and-foranyvalue) for the set-qualifier rules
 those examples depend on, including why AWS pairs them with `Null`.
 
-#### An operation naming one resource by ID is decided against that resource
+#### An operation naming resources by ID is decided against every one of them
 
-Four request parameters resolve to the resource they name, so the operations carrying them
-are authorized against a real ARN and against that resource's own tags rather than against
+Four request parameters resolve to the resources they name, so the operations carrying them
+are authorized against real ARNs and against those resources' own tags rather than against
 the literal `*`:
 
 | Parameter | Resolves to | The bundled actions that need it |
 |---|---|---|
-| `InstanceId` | `instance/<id>` | — (it is the one parameter that already resolved) |
-| `GroupId` | `security-group/<id>` | `ec2:DeleteSecurityGroup` |
-| `RouteTableId` | `route-table/<id>` | `ec2:DeleteRouteTable`, `ec2:DeleteRoute` |
-| `InternetGatewayId` | `internet-gateway/<id>` | `ec2:DeleteInternetGateway` |
+| `InstanceId.N` | `instance/<id>` | — (it is the one parameter that already resolved) |
+| `GroupId.N` | `security-group/<id>` | `ec2:DeleteSecurityGroup` |
+| `RouteTableId.N` | `route-table/<id>` | `ec2:DeleteRouteTable`, `ec2:DeleteRoute` |
+| `InternetGatewayId.N` | `internet-gateway/<id>` | `ec2:DeleteInternetGateway` |
 
 The list is short for a reason: each entry is a parameter one of the two `ec2:ResourceTag`
 statements in the bundled AWS managed policies names its target with. `DeleteRoute` appears
 under `RouteTableId` because the route table is the resource AWS authorizes a route change
 against. The indexed and un-indexed spellings are the same request, matching what the
 handlers themselves accept.
+
+**Every ID a request names is authorized, not the first alone**
+([#744](https://github.com/scttfrdmn/substrate/issues/744)). A `TerminateInstances` naming
+three instances was decided against `InstanceId.1`'s ARN and `InstanceId.1`'s tags, so a
+policy allowing instances tagged `Env=dev` and denying the rest permitted a call naming one
+dev instance and two production ones — provided the dev one came first. Each named resource
+now carries its own ARN and its own tags into its own decision, which is the same reading
+[tagging](#tagging-is-authorized-against-every-resource-it-names) already applies to
+`ResourceId.N` and AWS applies to any action naming several resources. Two consequences a
+consumer's test will see:
+
+- **The denial names the first resource the policy does not allow**, in fixed parameter order
+  and then request-index order. That is deterministic and replay-stable, and it is the
+  resource a caller can act on: drop it from the batch and the call proceeds.
+- **A permission boundary sees the whole batch too.** It is loaded once and evaluated against
+  each resource, so a boundary naming only the first instance refuses the rest.
+
+`GroupId` is overloaded and the expansion pulls one more operation in:
+`DescribePlacementGroups` reads `pg-` IDs through that parameter, so it is now decided
+against the groups it names. Nothing mis-resolves — the resolver keys on the ID's prefix, so
+a `pg-` ID becomes a `placement-group/<name>` ARN and an `sg-` one a `security-group/<id>`
+ARN in the same request.
+
+One pre-existing divergence is deliberately left in place rather than narrowed here.
+AWS's *Example policies to control access to the Amazon EC2 API* says `ec2:DescribeInstances`
+does not support resource-level permissions, so a real describe's request resource is `*`
+where substrate's is the instances it names. Expanding all four parameters uniformly keeps
+this one decision in one place; whether the resolver should be gated to the operations that
+support resource-level permissions is a question about the resolution itself, not about the
+batch, and is tracked as #762.
 
 `aws:ResourceTag/<key>` and `ec2:ResourceTag/<key>` both report the resolved resource's
 tags. <a id="ec2-reports-a-resource-s-tags-under-both-prefixes"></a>**EC2 reports a
@@ -4508,17 +4559,28 @@ as AWS would:
 - **`VpcId` and `SubnetId`.** Several creates carry one as the *container* the new resource
   goes into rather than as the resource acted on, and authorizing a create against its
   parent's ARN is not what AWS evaluates it against.
-- **The plural forms.** An operation naming several resources of one type is still decided
-  against the first ID alone — a `TerminateInstances` with three `InstanceId.N` is decided
-  against `InstanceId.1`. This is the shape [tagging](#tagging-is-authorized-against-every-resource-it-names)
-  already handles for `ResourceId.N` and it is tracked for the rest.
+An ID whose prefix names no type substrate can tag, or a `pg-`/`key-` ID naming no record, is
+**skipped**: it contributes no resource to the decision, so a batch of one resolvable and one
+unparseable ID is authorized as the batch of one. The refusal such an ID is owed is the
+handler's, as `Malformed` or `NotFound`, not an `AccessDenied` naming a resource that does not
+exist — and for the operation where it would matter most it cannot launder a state change
+past a policy, because AWS documents `TerminateInstances` as all-or-nothing ("If you specify
+multiple instances and the request fails (for example, because of a single incorrect instance
+ID), none of the instances are terminated") and substrate resolves every ID before it
+terminates any. `StopInstances` and `StartInstances` are not atomic, so there the batch is
+simply authorized as the resources that exist. Substrate states no ordering between the 403
+and the 404: no AWS page publishes one.
 
-An ID that resolves to no record, or whose prefix names no type substrate can tag, falls
-back to `*` rather than being refused — the handler owes that answer, as `NotFound`. The
-fallback is safe in one direction only, which is why it is the fallback: `*` as the
-*request* resource is not a wildcard, because `resourceMatches` uses the statement's own
-`Resource` as the pattern, so `*` matched only a statement whose `Resource` began with `*`.
-Replacing it with a concrete ARN can therefore narrow a grant but never widen one.
+The case is narrower than it sounds, and worth stating so a policy is not written against a
+wrong reading of it: a *well-formed* ID naming no record is not skipped. An instance's ARN is
+built from its ID rather than looked up, so `i-0123…` naming nothing still gets its own ARN
+with an empty tag set, and a least-privilege policy still has to name it.
+
+A request naming no resolvable ID at all falls back to `*`. That fallback is safe in one
+direction only, which is why it is the fallback: `*` as the *request* resource is not a
+wildcard, because `resourceMatches` uses the statement's own `Resource` as the pattern, so
+`*` matches only a statement whose `Resource` begins with `*`. Replacing it with concrete
+ARNs can therefore narrow a grant but never widen one.
 
 #### A tagged create is authorized twice
 

--- a/emulator/authz.go
+++ b/emulator/authz.go
@@ -744,6 +744,10 @@ type authzResource struct {
 //   - `ec2:CreateTags` and `ec2:DeleteTags` name up to 1000 resources of mixed
 //     types in ResourceId.N, and were decided against that same absent
 //     InstanceId.1 — so against "*" (#674).
+//   - Every other EC2 operation naming resources by ID — `TerminateInstances` with
+//     three InstanceId.N, and the three other plural parameters in
+//     [ec2AuthzIDParams] — was decided against the first ID alone, leaving the
+//     rest of the batch unauthorized (#744).
 //
 // Each exception is gated on len(multi) > 0, which is what keeps every other
 // operation of those two services on the single-resource path below.
@@ -762,6 +766,9 @@ func (a *AuthController) buildResourceARNs(reqCtx *RequestContext, req *AWSReque
 			return multi
 		}
 		if multi := ec2AuthzTagResources(a.state, reqCtx, req); len(multi) > 0 {
+			return multi
+		}
+		if multi := ec2AuthzNamedResources(a.state, reqCtx, req); len(multi) > 0 {
 			return multi
 		}
 	}
@@ -789,15 +796,12 @@ func (a *AuthController) buildResourceARN(reqCtx *RequestContext, req *AWSReques
 	case "iam":
 		return "arn:aws:iam::" + acct + ":*"
 	case "ec2":
-		// RunInstances does not reach here: it names five resources and is resolved
-		// by [ec2AuthzRunInstancesResources] (#662). Nor does a CreateTags or
-		// DeleteTags naming any resource substrate can tag, resolved by
-		// [ec2AuthzTagResources] (#674). What is left is the operations that name one
-		// resource by ID — an instance, a security group, a route table or an internet
-		// gateway (#730) — and everything else, which still resolves to "*".
-		if target, ok := ec2AuthzNamedResource(a.state, reqCtx, req); ok {
-			return target.arn(region, acct)
-		}
+		// No EC2 request that names a resource substrate can resolve reaches here. A
+		// launch names five and is answered by [ec2AuthzRunInstancesResources] (#662);
+		// a tagging call's up-to-1000 by [ec2AuthzTagResources] (#674); and every ID
+		// named under one of [ec2AuthzIDParams] by [ec2AuthzNamedResources] (#730,
+		// #744), which returns a non-empty list whenever any of them resolves. What is
+		// left is an operation naming none of them, whose request resource is "*".
 		return "*"
 	case "lambda":
 		name := lambdaNameFromPath(req.Path)
@@ -1049,18 +1053,15 @@ func (a *AuthController) resourceTagsFor(reqCtx *RequestContext, req *AWSRequest
 			return nil
 		}
 
-	case "ec2":
-		// The same resolver [AuthController.buildResourceARN] uses, so the tags a
-		// condition is evaluated against always belong to the ARN the decision is made
-		// about. Reading them through [ec2AuthzTagsFor] is also what generalizes this
-		// arm past instances: it decodes the "tags" member every EC2 record spells the
-		// same way, which is how a security group's, route table's or internet gateway's
-		// tags become readable without a decoder per type (#730).
-		target, ok := ec2AuthzNamedResource(a.state, reqCtx, req)
-		if !ok {
-			return nil
-		}
-		tags = ec2AuthzTagsFor(a.state, target.stateKey)
+	// EC2 has no arm here, and its absence is deliberate rather than a gap. Every EC2
+	// request naming a resource substrate can resolve is answered by one of
+	// buildResourceARNs' multi-resource arms, each of which reads that resource's own tags
+	// through [ec2AuthzTagsFor] beside its ARN — so the tags always belong to the ARN the
+	// decision is made about, which one arm here could not guarantee for a request naming
+	// several resources. An ec2 arm did exist for the single-resource path until
+	// [ec2AuthzNamedResources] made that path unreachable for any request with a resolvable
+	// ID (#744); leaving it would have been a second reading of the same request that no
+	// call could reach.
 
 	case "dynamodb":
 		tbl := req.Params["TableName"]

--- a/emulator/ec2_authz.go
+++ b/emulator/ec2_authz.go
@@ -229,6 +229,9 @@ func ec2AuthzTagResources(state StateManager, reqCtx *RequestContext, req *AWSRe
 // no EC2 operation carries two of these four. `DeleteRoute` and `DeleteRouteTable` share
 // `RouteTableId`, which is the resource both act on.
 //
+// Each is plural: [ec2AuthzNamedResources] resolves every ID a request names under one of
+// them, not the first alone (#744).
+//
 // Deliberately absent, each for its own reason rather than by oversight:
 //
 //   - `NetworkInterfaceId`, which `AmazonEKSClusterPolicy` conditions
@@ -242,39 +245,73 @@ func ec2AuthzTagResources(state StateManager, reqCtx *RequestContext, req *AWSRe
 //     `AttachInternetGateway`) as the container the new resource goes into rather than as
 //     the resource acted on. Resolving one there would authorize a create against its
 //     parent's ARN, which is not the ARN AWS evaluates it against.
-//   - The plural forms. An operation naming several resources of one type —
-//     `TerminateInstances` with three `InstanceId.N` — is still decided against the first
-//     alone, which is the #674-shaped gap [ec2AuthzTagResources] closed for tagging calls
-//     and #744 tracks for the rest.
+//
+// One more is overloaded rather than absent: `GroupId` names a *placement* group on
+// `DescribePlacementGroups`, which reads `pg-` IDs through it. Nothing mis-resolves —
+// [ec2TaggableResource] keys on the ID's prefix, so a `pg-` ID becomes a placement-group
+// ARN and an `sg-` one a security-group ARN — but it does mean that operation is decided
+// against the groups it names rather than against "*".
 var ec2AuthzIDParams = []string{"InstanceId", "GroupId", "RouteTableId", "InternetGatewayId"}
 
-// ec2AuthzNamedResource resolves the resource an EC2 request names by ID, for the
-// operations that are not a launch and not a tagging call.
+// ec2AuthzNamedResources returns every resource an EC2 request names by ID under one of
+// [ec2AuthzIDParams], each paired with its own tags. It returns nil for a request that
+// names none, which is what leaves those on buildResourceARNs' single-resource path.
 //
-// It reads the parameter through [extractIndexedParams], so `GroupId` and `GroupId.1` are
+// It reads each parameter through [extractIndexedParams], so `GroupId` and `GroupId.1` are
 // the same request — which is the form the handlers themselves accept, and it is what
-// keeps the resource a policy is evaluated against the resource the handler will act on.
+// keeps the resources a policy is evaluated against the resources the handler will act on.
 //
-// ok=false means the request names no resource this can resolve, which sends the caller
-// back to the wildcard it used before. That is the only safe direction: "*" as the request
-// resource matches a statement whose own Resource starts with "*", so it can only ever
-// narrow a grant, never widen one.
-func ec2AuthzNamedResource(state StateManager, reqCtx *RequestContext, req *AWSRequest) (ec2Taggable, bool) {
+// **Every** named ID is resolved, not the first alone (#744). Deciding a
+// `TerminateInstances` naming three instances against `InstanceId.1` left the other two
+// unauthorized, so a policy allowing `Env=dev` instances and denying the rest permitted a
+// call naming one dev instance and two production ones — provided the dev one came first.
+// That is the #674-shaped gap [ec2AuthzTagResources] closed for tagging calls, on the same
+// reading of AWS's rule for an action naming several resources that #660 and #662 follow
+// here: every resource required for the action must be allowed.
+//
+// Order is fixed parameter order, then the request's own index order within a parameter,
+// which makes the denial message — which names the first resource the policy does not
+// allow — deterministic and replay-stable. The parameter order is inert today, since no EC2
+// operation carries two of the four.
+//
+// An unresolvable ID mid-batch is **skipped**, not denied and not widened to "*", which is
+// [ec2AuthzTagResources]' rule and for the same reason: there is no ARN to build, and the
+// refusal the caller is owed is the handler's `NotFound`, not an `AccessDenied` naming a
+// resource that does not exist. Skipping cannot launder a state change past a policy for
+// the operation where it would matter most, because AWS documents `TerminateInstances` as
+// all-or-nothing — "If you specify multiple instances and the request fails (for example,
+// because of a single incorrect instance ID), none of the instances are terminated" — and
+// substrate implements it with a resolve-everything pre-pass, so the bogus ID fails the
+// whole call. `StopInstances` and `StartInstances` are *not* atomic, so there the batch is
+// simply authorized as the batch of resources that exist.
+//
+// A request naming only unresolvable IDs returns nil and falls back to the wildcard it used
+// before. That is the only safe direction: "*" as the request resource matches a statement
+// whose own Resource starts with "*", so it can only ever narrow a grant, never widen one.
+func ec2AuthzNamedResources(state StateManager, reqCtx *RequestContext, req *AWSRequest) []authzResource {
+	acct := reqCtx.AccountID
+	region := reqCtx.Region
+	var out []authzResource
 	for _, param := range ec2AuthzIDParams {
-		ids := extractIndexedParams(req.Params, param)
-		if len(ids) == 0 || ids[0] == "" {
-			continue
+		for _, id := range extractIndexedParams(req.Params, param) {
+			if id == "" {
+				continue
+			}
+			target, ok := ec2TaggableResource(state, reqCtx, id)
+			if !ok || !target.resolved() {
+				// A prefix naming no taggable type, or a pg-/key- ID naming no record.
+				// See [ec2Taggable.resolved] and the skip rule above.
+				continue
+			}
+			out = append(out, authzResource{
+				ARN: target.arn(region, acct),
+				// The same state key the handler will read, so a tag condition is
+				// evaluated against the tags of the resource the ARN names.
+				Tags: ec2AuthzTagsFor(state, target.stateKey),
+			})
 		}
-		target, ok := ec2TaggableResource(state, reqCtx, ids[0])
-		if !ok || !target.resolved() {
-			// A prefix naming no taggable type, or a pg-/key- ID naming no record.
-			// Neither is a resource an ARN can be built for — see [ec2Taggable.resolved]
-			// — and neither is this function's to refuse: the handler owes that answer.
-			return ec2Taggable{}, false
-		}
-		return target, true
 	}
-	return ec2Taggable{}, false
+	return out
 }
 
 // ec2CreateTagsAction is the action AWS authorizes a tag-carrying create against a

--- a/emulator/ec2_authz_multi_id_test.go
+++ b/emulator/ec2_authz_multi_id_test.go
@@ -1,0 +1,370 @@
+package emulator_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// An EC2 operation naming several resources of one type is authorized against every one
+// of them, not the first alone (#744).
+//
+// #730 taught the decision to resolve a single EC2 resource from four ID parameters, but
+// kept `ids[0]`. So a `TerminateInstances` naming three instances was decided against
+// `InstanceId.1`'s ARN and `InstanceId.1`'s tags, and the other two were not authorized at
+// all: a policy allowing instances tagged `Env=dev` and denying the rest permitted a call
+// naming one dev instance and two production ones, provided the dev one came first. That is
+// the same shape #674 fixed for tagging calls, and the failure direction that matters —
+// it grants.
+//
+// One decision here is substrate's reading and is pinned below rather than left to be
+// rediscovered: an ID mid-batch that resolves to no ARN is **skipped**, so a batch of one
+// resolvable and one unparseable ID is authorized as a batch of one. See
+// [ec2AuthzNamedResources] for why, and note the narrowness of the case — a well-formed
+// `i-` ID naming no instance still gets its own ARN, because an instance's state key is
+// computed from its ID rather than looked up.
+
+// The IDs the batch tests name. Two of each type, so "the second one is evaluated too" is
+// what every table row asserts.
+const (
+	ec2MultiInstanceA = "i-0aaa11112222bbbb3"
+	ec2MultiInstanceB = "i-0bbb22223333cccc4"
+	ec2MultiInstanceC = "i-0ccc33334444dddd5"
+	ec2MultiSGB       = "sg-0ddd44445555eeee6"
+	ec2MultiRTBB      = "rtb-0eee55556666ffff7"
+	ec2MultiIGWB      = "igw-0fff66667777aaa08"
+)
+
+// ec2MultiARN builds the ARN the decision names a resource of type arnType by.
+func ec2MultiARN(arnType, id string) string {
+	return "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":" + arnType + "/" + id
+}
+
+// putInstance writes one instance record, which is what gives the ID tags to be
+// evaluated against. An instance with no record still resolves to an ARN — its state key
+// is computed from the ID — so this is about the tags, not about the ARN.
+func (f *ec2AuthzFixture) putInstance(t *testing.T, id string, tags map[string]string) {
+	t.Helper()
+	f.put(t, "instance:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+id,
+		emulator.EC2Instance{InstanceID: id, Tags: ec2AuthzTags(tags)})
+}
+
+// ec2MultiStatement allows one action on the given resources, which is the least-privilege
+// shape a batch has to satisfy for every member.
+func ec2MultiStatement(action string, resources ...string) emulator.PolicyStatement {
+	return emulator.PolicyStatement{
+		Effect:   "Allow",
+		Action:   emulator.StringOrSlice{action},
+		Resource: emulator.StringOrSlice(resources),
+	}
+}
+
+// TestEC2_Authz_EveryNamedInstanceIsAuthorized is the issue's own scenario: a
+// TerminateInstances naming three instances is denied unless the policy admits all three.
+//
+// The denial names the first instance the policy does not allow, in request order, which
+// is the resource a caller can act on — remove it from the batch and the call proceeds.
+func TestEC2_Authz_EveryNamedInstanceIsAuthorized(t *testing.T) {
+	f := newEC2AuthzFixture(t, "nadia", emulator.PolicyDocument{})
+	params := map[string]string{
+		"InstanceId.1": ec2MultiInstanceA,
+		"InstanceId.2": ec2MultiInstanceB,
+		"InstanceId.3": ec2MultiInstanceC,
+	}
+	arnA := ec2MultiARN("instance", ec2MultiInstanceA)
+	arnB := ec2MultiARN("instance", ec2MultiInstanceB)
+	arnC := ec2MultiARN("instance", ec2MultiInstanceC)
+
+	// The first ID alone is what the decision used to resolve, so this policy used to
+	// permit the whole batch.
+	f.setPolicy(t, ec2MultiStatement("ec2:TerminateInstances", arnA))
+	err := f.call(t, "TerminateInstances", params)
+	require.True(t, ec2AuthzDenied(t, err), "a batch was allowed by a policy naming only its first instance")
+	assert.Equal(t, arnB, deniedResource(t, err), "the denial names the first instance the policy omits")
+
+	// Two of three is still not all of them, and the denial moves on to the third.
+	f.setPolicy(t, ec2MultiStatement("ec2:TerminateInstances", arnA, arnB))
+	err = f.call(t, "TerminateInstances", params)
+	require.True(t, ec2AuthzDenied(t, err), "a batch was allowed by a policy naming two of its three instances")
+	assert.Equal(t, arnC, deniedResource(t, err))
+
+	// All three: allowed.
+	f.setPolicy(t, ec2MultiStatement("ec2:TerminateInstances", arnA, arnB, arnC))
+	require.NoError(t, f.call(t, "TerminateInstances", params))
+}
+
+// TestEC2_Authz_ScopedDenyReachesEveryNamedInstance is the guardrail direction, which is
+// the one a consumer writes: a broad Allow beside a Deny scoped to one instance.
+//
+// It was inert for every instance but the first, so a Deny fencing off a production
+// instance did not stop a batch that put a dev instance in front of it.
+func TestEC2_Authz_ScopedDenyReachesEveryNamedInstance(t *testing.T) {
+	f := newEC2AuthzFixture(t, "omar", emulator.PolicyDocument{})
+	f.setPolicy(t,
+		ec2MultiStatement("ec2:StopInstances", "*"),
+		emulator.PolicyStatement{
+			Effect:   "Deny",
+			Action:   emulator.StringOrSlice{"ec2:StopInstances"},
+			Resource: emulator.StringOrSlice{ec2MultiARN("instance", ec2MultiInstanceC)},
+		},
+	)
+
+	require.NoError(t, f.call(t, "StopInstances", map[string]string{"InstanceId.1": ec2MultiInstanceA}),
+		"an instance the Deny does not name is still allowed")
+
+	err := f.call(t, "StopInstances", map[string]string{
+		"InstanceId.1": ec2MultiInstanceA,
+		"InstanceId.2": ec2MultiInstanceC,
+	})
+	require.True(t, ec2AuthzDenied(t, err), "a Deny on the second instance of a batch was inert")
+	assert.Equal(t, ec2MultiARN("instance", ec2MultiInstanceC), deniedResource(t, err))
+}
+
+// TestEC2_Authz_EachInstanceIsJudgedByItsOwnTags is why every resource carries its own
+// tags rather than one merged map: the tag condition the issue describes.
+//
+// A policy allowing ec2:TerminateInstances on instances tagged Env=dev must refuse a batch
+// that also names a production one. Merging the two tag sets would let the dev tag satisfy
+// the condition about the production instance, which is the false allow
+// orgAuthzResourceID's comment exists to prevent — so this asserts the denial names the
+// production instance specifically, not merely that something was denied.
+func TestEC2_Authz_EachInstanceIsJudgedByItsOwnTags(t *testing.T) {
+	f := newEC2AuthzFixture(t, "priya", emulator.PolicyDocument{})
+	f.putInstance(t, ec2MultiInstanceA, map[string]string{"Env": "dev"})
+	f.putInstance(t, ec2MultiInstanceB, map[string]string{"Env": "prod"})
+
+	for _, prefix := range []string{"aws:ResourceTag/", "ec2:ResourceTag/"} {
+		t.Run(prefix, func(t *testing.T) {
+			f.setPolicy(t, ec2AuthzConditionStatement("ec2:TerminateInstances",
+				ec2AuthzTagCondition("StringEquals", prefix+"Env", "dev")))
+
+			require.NoError(t, f.call(t, "TerminateInstances",
+				map[string]string{"InstanceId.1": ec2MultiInstanceA}),
+				"the dev instance alone satisfies the condition")
+
+			err := f.call(t, "TerminateInstances", map[string]string{
+				"InstanceId.1": ec2MultiInstanceA,
+				"InstanceId.2": ec2MultiInstanceB,
+			})
+			require.True(t, ec2AuthzDenied(t, err),
+				"a production instance behind a dev one was terminated under an Env=dev policy")
+			assert.Equal(t, ec2MultiARN("instance", ec2MultiInstanceB), deniedResource(t, err),
+				"the denial names the instance whose own tags failed the condition")
+		})
+	}
+}
+
+// TestEC2_Authz_AllFourIDParametersExpand pins that the expansion covers every parameter in
+// ec2AuthzIDParams, not only InstanceId — each of the other three is in that list because a
+// bundled AWS policy conditions a delete on the tags of the resource it names (#730), and a
+// delete of several is the same batch.
+//
+// GroupId's placement-group row is the overload worth naming: DescribePlacementGroups reads
+// pg- IDs through the same parameter, and nothing mis-resolves because ec2TaggableResource
+// keys on the ID's prefix.
+func TestEC2_Authz_AllFourIDParametersExpand(t *testing.T) {
+	const pgName, pgID = "cluster-a", "pg-0aab11112222bbbb3"
+	tests := []struct {
+		name      string
+		operation string
+		param     string
+		first     string
+		second    string
+		firstARN  string
+		secondARN string
+		seed      func(f *ec2AuthzFixture, t *testing.T)
+	}{
+		{
+			name:      "InstanceId",
+			operation: "TerminateInstances",
+			param:     "InstanceId",
+			first:     ec2MultiInstanceA, second: ec2MultiInstanceB,
+			firstARN:  ec2MultiARN("instance", ec2MultiInstanceA),
+			secondARN: ec2MultiARN("instance", ec2MultiInstanceB),
+		},
+		{
+			name:      "GroupId",
+			operation: "DeleteSecurityGroup",
+			param:     "GroupId",
+			first:     ec2AuthzSG, second: ec2MultiSGB,
+			firstARN:  ec2AuthzSGARN,
+			secondARN: ec2MultiARN("security-group", ec2MultiSGB),
+			seed: func(f *ec2AuthzFixture, t *testing.T) {
+				f.putSecurityGroup(t, ec2MultiSGB, nil)
+			},
+		},
+		{
+			name:      "RouteTableId",
+			operation: "DeleteRouteTable",
+			param:     "RouteTableId",
+			first:     ec2AuthzRouteTable, second: ec2MultiRTBB,
+			firstARN:  ec2AuthzRouteTableARN,
+			secondARN: ec2MultiARN("route-table", ec2MultiRTBB),
+			seed: func(f *ec2AuthzFixture, t *testing.T) {
+				f.putRouteTable(t, ec2AuthzRouteTable, nil)
+				f.putRouteTable(t, ec2MultiRTBB, nil)
+			},
+		},
+		{
+			name:      "InternetGatewayId",
+			operation: "DeleteInternetGateway",
+			param:     "InternetGatewayId",
+			first:     ec2AuthzIGW, second: ec2MultiIGWB,
+			firstARN:  ec2AuthzIGWARN,
+			secondARN: ec2MultiARN("internet-gateway", ec2MultiIGWB),
+			seed: func(f *ec2AuthzFixture, t *testing.T) {
+				f.putInternetGateway(t, ec2AuthzIGW, nil)
+				f.putInternetGateway(t, ec2MultiIGWB, nil)
+			},
+		},
+		{
+			// The placement group ARN is by *name*, so this also proves the expansion
+			// carries each resource's own translation rather than echoing the request.
+			name:      "GroupId naming placement groups",
+			operation: "DescribePlacementGroups",
+			param:     "GroupId",
+			first:     pgID, second: ec2MultiSGB,
+			firstARN:  ec2MultiARN("placement-group", pgName),
+			secondARN: ec2MultiARN("security-group", ec2MultiSGB),
+			seed: func(f *ec2AuthzFixture, t *testing.T) {
+				f.put(t, "placement_group:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+pgName,
+					emulator.EC2PlacementGroup{GroupName: pgName, GroupID: pgID})
+				f.putSecurityGroup(t, ec2MultiSGB, nil)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newEC2AuthzFixture(t, "quinn", emulator.PolicyDocument{})
+			if tt.seed != nil {
+				tt.seed(f, t)
+			}
+			params := map[string]string{
+				tt.param + ".1": tt.first,
+				tt.param + ".2": tt.second,
+			}
+			action := "ec2:" + tt.operation
+
+			f.setPolicy(t, ec2MultiStatement(action, tt.firstARN))
+			err := f.call(t, tt.operation, params)
+			require.True(t, ec2AuthzDenied(t, err), "the second %s was not authorized", tt.param)
+			assert.Equal(t, tt.secondARN, deniedResource(t, err))
+
+			f.setPolicy(t, ec2MultiStatement(action, tt.firstARN, tt.secondARN))
+			require.NoError(t, f.call(t, tt.operation, params))
+		})
+	}
+}
+
+// TestEC2_Authz_UnindexedAndIndexedIDsAreTheSameRequest pins that the un-indexed spelling
+// still resolves, which is what extractIndexedParams gives and what the handlers accept.
+func TestEC2_Authz_UnindexedAndIndexedIDsAreTheSameRequest(t *testing.T) {
+	f := newEC2AuthzFixture(t, "ravi", emulator.PolicyDocument{})
+	arnA := ec2MultiARN("instance", ec2MultiInstanceA)
+	f.setPolicy(t, ec2MultiStatement("ec2:TerminateInstances", arnA))
+
+	require.NoError(t, f.call(t, "TerminateInstances", map[string]string{"InstanceId": ec2MultiInstanceA}))
+
+	err := f.call(t, "TerminateInstances", map[string]string{"InstanceId": ec2MultiInstanceB})
+	require.True(t, ec2AuthzDenied(t, err))
+	assert.Equal(t, ec2MultiARN("instance", ec2MultiInstanceB), deniedResource(t, err))
+}
+
+// TestEC2_Authz_UnresolvableIDInABatchIsSkipped pins the decision the issue asks to be
+// decided rather than assumed.
+//
+// An ID that resolves to no ARN is skipped, as [ec2AuthzTagResources] skips one, so a batch
+// of one resolvable and one unparseable ID is authorized as a batch of one. The refusal the
+// caller is owed is the handler's — AWS answers a malformed instance ID with
+// InvalidInstanceID.Malformed, not AccessDenied — and TerminateInstances is documented
+// all-or-nothing, so the bogus ID fails the whole call regardless of what the policy said.
+//
+// The case is narrower than it sounds, and the second half here is why: a well-formed i- ID
+// naming no instance is *not* unresolvable. Its state key is computed from the ID, so it
+// gets its own ARN with an empty tag set, and a least-privilege policy still has to name it.
+func TestEC2_Authz_UnresolvableIDInABatchIsSkipped(t *testing.T) {
+	f := newEC2AuthzFixture(t, "sona", emulator.PolicyDocument{})
+	arnA := ec2MultiARN("instance", ec2MultiInstanceA)
+	f.setPolicy(t, ec2MultiStatement("ec2:TerminateInstances", arnA))
+
+	require.NoError(t, f.call(t, "TerminateInstances", map[string]string{
+		"InstanceId.1": ec2MultiInstanceA,
+		// No prefix any taggable type answers to, so there is no ARN to decide about.
+		"InstanceId.2": "not-an-instance-id",
+	}), "an unparseable ID beside an allowed one is skipped, not denied")
+
+	// And it is not laundering the batch: an absent-but-well-formed ID is still its own
+	// resource, so the same policy refuses it.
+	err := f.call(t, "TerminateInstances", map[string]string{
+		"InstanceId.1": ec2MultiInstanceA,
+		"InstanceId.2": ec2MultiInstanceB,
+	})
+	require.True(t, ec2AuthzDenied(t, err), "an instance with no record was not authorized")
+	assert.Equal(t, ec2MultiARN("instance", ec2MultiInstanceB), deniedResource(t, err))
+
+	// A request naming only unresolvable IDs falls back to the wildcard it used before,
+	// which can only narrow a grant: "*" as the request resource matches a statement whose
+	// own Resource starts with "*".
+	f.setPolicy(t, emulator.PolicyStatement{
+		Effect:   "Deny",
+		Action:   emulator.StringOrSlice{"ec2:TerminateInstances"},
+		Resource: emulator.StringOrSlice{"*"},
+	})
+	err = f.call(t, "TerminateInstances", map[string]string{"InstanceId.1": "not-an-instance-id"})
+	require.True(t, ec2AuthzDenied(t, err))
+	assert.Equal(t, "*", deniedResource(t, err))
+}
+
+// TestEC2_Authz_BatchDenialIsReplayStable pins the ordering guarantee: the same request
+// against the same state names the same resource every time.
+//
+// The decision walks a fixed parameter order and then the request's own index order, so
+// nothing here depends on Go's map iteration — which is what makes the denial message
+// replayable, and it is the message a consumer's test asserts on.
+func TestEC2_Authz_BatchDenialIsReplayStable(t *testing.T) {
+	f := newEC2AuthzFixture(t, "tarek", emulator.PolicyDocument{})
+	params := map[string]string{
+		"InstanceId.1": ec2MultiInstanceA,
+		"InstanceId.2": ec2MultiInstanceB,
+		"InstanceId.3": ec2MultiInstanceC,
+	}
+	// Nothing is allowed, so every resource in the batch would deny — which is what makes
+	// this an ordering assertion rather than a matching one.
+	f.setPolicy(t, ec2MultiStatement("ec2:DescribeInstances", "arn:aws:ec2:*:*:instance/none"))
+
+	want := ec2MultiARN("instance", ec2MultiInstanceA)
+	for i := 0; i < 25; i++ {
+		err := f.call(t, "DescribeInstances", params)
+		require.True(t, ec2AuthzDenied(t, err))
+		require.Equal(t, want, deniedResource(t, err), "run %d named a different resource", i)
+	}
+}
+
+// TestEC2_Authz_BatchIsCheckedAgainstThePermissionBoundary pins that the boundary sees every
+// resource in a batch too. It is loaded once outside the loop, so a boundary allowing only
+// the first instance must still refuse the second.
+func TestEC2_Authz_BatchIsCheckedAgainstThePermissionBoundary(t *testing.T) {
+	f := newEC2AuthzFixture(t, "ulla", emulator.PolicyDocument{})
+	arnA := ec2MultiARN("instance", ec2MultiInstanceA)
+	arnB := ec2MultiARN("instance", ec2MultiInstanceB)
+	params := map[string]string{"InstanceId.1": ec2MultiInstanceA, "InstanceId.2": ec2MultiInstanceB}
+
+	f.setPolicy(t, ec2MultiStatement("ec2:TerminateInstances", arnA, arnB))
+	require.NoError(t, f.call(t, "TerminateInstances", params), "the identity policy allows both")
+
+	f.setBoundary(t, emulator.PolicyDocument{
+		Version:   "2012-10-17",
+		Statement: []emulator.PolicyStatement{ec2MultiStatement("ec2:TerminateInstances", arnA)},
+	})
+	err := f.call(t, "TerminateInstances", params)
+	require.True(t, ec2AuthzDenied(t, err), "a boundary naming only the first instance allowed the batch")
+
+	f.setBoundary(t, emulator.PolicyDocument{
+		Version:   "2012-10-17",
+		Statement: []emulator.PolicyStatement{ec2MultiStatement("ec2:TerminateInstances", arnA, arnB)},
+	})
+	require.NoError(t, f.call(t, "TerminateInstances", params))
+}

--- a/emulator/ec2_authz_test.go
+++ b/emulator/ec2_authz_test.go
@@ -741,11 +741,16 @@ func TestEC2_Authz_ImageARNCarriesNoAccountID(t *testing.T) {
 	assert.Equal(t, ec2AuthzImageARN, deniedResource(t, err))
 }
 
-// TestEC2_Authz_SingleResourceOperationsAreUnchanged pins which operations take the
-// multi-resource path: RunInstances (#662) and the two tagging operations (#674),
-// and nothing else. Every other EC2 operation keeps the decision it had before —
-// these changes are about resolving the resources a request names, not about
-// tightening EC2 as a whole.
+// TestEC2_Authz_SingleResourceOperationsAreUnchanged pins the floor of the resolution:
+// an EC2 operation that names no resource substrate can resolve is still decided against
+// the literal "*", exactly as it was. These changes are about resolving the resources a
+// request names, not about tightening EC2 as a whole.
+//
+// Its rows name one ID each, so the two instance rows go through
+// [ec2AuthzNamedResources] and come back with the single resource that parameter names —
+// which is what #744 left unchanged for a batch of one. The multi-resource paths a request
+// can take are RunInstances' five (#662), a tagging call's up-to-1000 (#674) and every ID
+// under one of [ec2AuthzIDParams] (#730, #744); everything else is here.
 func TestEC2_Authz_SingleResourceOperationsAreUnchanged(t *testing.T) {
 	instanceARN := "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":instance/i-0abc"
 	tests := []struct {


### PR DESCRIPTION
## What

An EC2 operation naming several resources of one type was authorized against the first alone.
`TerminateInstances` with three `InstanceId.N` was decided against `InstanceId.1`'s ARN and
`InstanceId.1`'s tags; the other two were not authorized at all.

Every ID under the four resolving parameters — `InstanceId.N`, `GroupId.N`, `RouteTableId.N`,
`InternetGatewayId.N` — now carries its own ARN and its own tags into its own decision. That is
the reading #660 and #662 established and #674 already applied to a tagging call's
`ResourceId.N`; this makes EC2's ID path agree with it.

## Why it matters

Proved live against a built binary, an IAM user, and a policy allowing `ec2:TerminateInstances`
on one instance ARN. Before this change:

- a batch naming an allowed instance and a *disallowed* one **terminated both**;
- a `Deny` scoped to one instance was **inert** behind any instance the caller could stop;
- a `StringEquals` on `aws:ResourceTag/Env` = `dev` **terminated the production instance** in the
  same call.

Each was refused after, naming the offending instance, and each denial was position-independent —
the pre-change binary happened to refuse only when the disallowed instance came first.

## Decisions recorded rather than left to be rediscovered

- **Ordering.** Fixed `ec2AuthzIDParams` order, then request index, matching the two existing
  multi-resource arms. So the denial names the same resource on every replay, which is what a
  consumer's test asserts on.
- **An unresolvable ID mid-batch is skipped**, as a tagging call's already was. The refusal it is
  owed is the handler's `InvalidInstanceID.Malformed`, not an `AccessDenied` naming a resource
  that does not exist, and for `TerminateInstances` that cannot launder a state change past a
  policy — AWS documents it all-or-nothing ("If you specify multiple instances and the request
  fails … none of the instances are terminated") and substrate resolves every ID before
  terminating any. `StopInstances`/`StartInstances` are *not* atomic, so there the batch is
  authorized as the resources that exist. **No 403-before-404 ordering is asserted**: no AWS page
  publishes one. Note the narrowness — a well-formed `i-` ID naming no instance is still its own
  resource, because its ARN is built from the ID rather than looked up.
- **`GroupId` is overloaded**, so `DescribePlacementGroups` is pulled in and is now decided
  against the groups it names. Nothing mis-resolves: the resolver keys on the prefix, so a `pg-`
  ID becomes a name-form `placement-group/<name>` ARN and an `sg-` one `security-group/<id>` in
  the same request. Pinned by a test row.
- **The two single-resource ec2 arms are deleted, not left beside the new one.** Once the multi arm
  answers every resolvable EC2 request, `buildResourceARN`'s ec2 case and `resourceTagsFor`'s ec2
  case could only ever return `"*"`/`nil` — and leaving them would be two readings of one request
  with the multi path's inline tags silently winning. The deliberate absence is explained where
  the arm used to be.
- **`DescribeInstances` keeps a pre-existing divergence**, deliberately. AWS says it supports no
  resource-level permissions, so a real request's resource is `*`. #730 already resolved the first
  ID for describes and this multiplies it to N; gating the resolver is a decision about #730, and
  is filed as #762.

## Also in this PR

`docs/services.md` published the unresolved-policy-variable rule **backwards**. AWS's *Variables
and tags* page applies one sentence to both elements — "used as part of the `Resource` **or**
`NotResource` element … will not match any resource" — and states that inverted operators "do
match against a null value", which is what substrate's literal comparison already answers. So
there is no unresolved-variable divergence in either direction. What *does* diverge is a variable
that would have **resolved**, and the dangerous polarity is the negated one, where a
`StringNotEquals` against an un-substituted literal is inert on a `Deny` and grants on an
`Allow` — reachable today through `SimulateCustomPolicy`'s own `ContextEntries`. That is #745;
this correction is not hostage to it landing.

## Verification

`gofmt`/`go build`/`go vet`/`golangci-lint` clean (0 issues); `make test` (race) green; coverage
emulator 83.4%, total 82.8%; `make docs-reference-check docs-versions` clean; vitepress build with
no broken in-page anchor; `test/e2e` green. Fail-before proven at the unit tier by returning after
the first append (13 subtests fail) and live as described above, against a binary built from
`main` in a throwaway worktree.

Closes #744
