### PR TITLE
feat(cloudformation,ec2): stamp aws:cloudformation:* on the EC2 resources a stack creates (#746)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `imageOwnerId`/`isPublic` per the `Image` type page and Examples 2–3 rather than
   `ownerId`/`public` per Example 1.
 
+- **CloudFormation stamps its own tags on the EC2 resources it creates** (#746). AWS puts
+  `aws:cloudformation:stack-name`, `aws:cloudformation:stack-id` and
+  `aws:cloudformation:logical-id` on every resource a stack creates; substrate's deployer put
+  none. That is not only a missing member — it left a bundled policy permanently unsatisfiable.
+  `AmazonECS_FullAccess`'s `ManagedCloudformationResourcesCleanupPolicy` allows four EC2 deletes
+  on any resource whose `ec2:ResourceTag/aws:cloudformation:stack-name` is like
+  `EC2ContainerService-*`; the resolution for that key already worked (#730), `CreateTags`
+  refuses an `aws:` key as AWS does, and no path existed by which the tag could ever exist — so
+  the statement granted nothing at all and no test could tell that apart from a policy bug. It
+  now grants the deletes for a resource an `EC2ContainerService-…` stack created and still
+  refuses them for one created by a stack whose name does not match.
+
+  The stamp is a state write from the single place that already holds everything it needs — the
+  one caller of the resource dispatcher, which has the logical ID, the physical ID and the
+  stack's name, account and region — so none of the 110 dispatch arms is touched. It is
+  deliberately not a synthesized `CreateTags`: that call refuses the `aws:` keys it would be
+  carrying, and every synthesized request is authorized, so the parameter route would newly
+  require `ec2:CreateTags` of every principal whose deployment succeeds today. The stack ID
+  written is the same ARN `AWS::StackId` resolves to rather than a second derivation of it,
+  which is the defect #517 was; the write is an upsert, so re-deploying a stack rewrites the
+  three tags rather than accumulating them; and `aws:` keys are already outside the 50-tag
+  limit, so the stamp cannot push a caller's own tags over it.
+
+  Scoped to EC2, which is what the bundled statement needs: the resolver maps an ID prefix to a
+  state key and only EC2 keeps tags in a store shaped that way, so all nine EC2 resource types
+  the deployer creates are covered by prefix and a tenth arrives free. A non-EC2 physical ID is
+  skipped silently — a stack creates far more non-EC2 resources than EC2 ones, so a warning per
+  resource would bury a real one — as is a resource that failed to deploy or has no physical
+  ID, since tagging one would put a stack's bookkeeping on something the stack does not own.
+  Extending the stamp beyond EC2 is #765, and caller-supplied stack tags, which `CreateStack`
+  still drops, are #764.
+
+  Of the three keys, only `aws:cloudformation:stack-name` appears on any AWS CloudFormation
+  page that was reachable: every user-guide page documenting the set returned an empty body, and
+  `API_CreateStack.html` documents caller-supplied stack-tag propagation, which is the other
+  mechanism. The triple is therefore **observed behavior rather than the API model**, and
+  `docs/services.md` records it as such.
+
 ### Fixed
 - **An EC2 operation naming several resources was decided against the first alone** (#744).
   `TerminateInstances` with three `InstanceId.N` was authorized against `InstanceId.1`'s ARN

--- a/docs/services.md
+++ b/docs/services.md
@@ -4541,13 +4541,48 @@ key compared case-insensitively, and only EC2 gets a second prefix. Reporting, s
 bucket's tags under an `s3:ResourceTag/` key AWS does not publish would honor a policy real
 AWS ignores, which is a divergence in the granting direction.
 
-One caveat on the bundled statement that motivated the prefix: it conditions on
+The bundled statement that motivated the prefix conditions on
 `ec2:ResourceTag/aws:cloudformation:stack-name`, and that tag is not one a caller can set —
-`CreateTags` refuses a key beginning with `aws:`, as AWS does, and substrate's CloudFormation
-deployer does not apply stack tags to the resources it creates. So the prefix and the
-resolution work, and a policy you write against `ec2:ResourceTag/<your key>` evaluates, but
-`ManagedCloudformationResourcesCleanupPolicy`'s own statement stays unsatisfiable until the
-deployer tags what it creates ([#746](https://github.com/scttfrdmn/substrate/issues/746)).
+`CreateTags` refuses a key beginning with `aws:`, as AWS does. <a id="cloudformation-stamps-its-own-tags-on-the-ec2-resources-it-creates"></a>**CloudFormation
+stamps its own tags on the EC2 resources it creates**
+([#746](https://github.com/scttfrdmn/substrate/issues/746)), which is what makes
+`ManagedCloudformationResourcesCleanupPolicy`'s statement satisfiable rather than inert: a
+resource a stack creates carries `aws:cloudformation:stack-name`,
+`aws:cloudformation:stack-id` and `aws:cloudformation:logical-id`, so the bundled statement's
+`StringLike` on `EC2ContainerService-*` now grants the four EC2 deletes for a resource an
+`EC2ContainerService-…` stack created and still refuses them elsewhere.
+
+The stamp is written to state by the deployer rather than sent as a `TagSpecification`, for
+two reasons a consumer can observe: a synthesized `CreateTags` would refuse the `aws:` keys it
+is carrying, and every synthesized request is authorized, so the parameter route would newly
+require `ec2:CreateTags` of every principal whose deployment succeeds today. The three values
+are the stack's own — the stack ID is the same ARN `AWS::StackId` resolves to, not a second
+derivation of it — and the write is an upsert, so re-deploying a stack rewrites the three
+rather than accumulating them. `aws:` keys are already excluded from the 50-tag limit, so the
+stamp cannot push a caller's own tags over it.
+
+Four limits on the stamp, each named because a policy or an assertion written against it will
+otherwise assume more:
+
+- **EC2 only.** The resolver maps an ID prefix to a state key, and only EC2 keeps tags in a
+  store shaped that way; S3, DynamoDB, Lambda and SQS each keep them differently and ELBv2
+  keeps none. A non-EC2 physical ID is skipped silently — a stack creates far more non-EC2
+  resources than EC2 ones, so a warning per resource would bury a real one. Extending the
+  stamp is [#765](https://github.com/scttfrdmn/substrate/issues/765).
+- **A resource that failed to deploy is not stamped**, and neither is one with no physical ID.
+  Tagging it would put a stack's bookkeeping on something the stack does not own.
+- **Caller-supplied stack tags are still unmodelled.** `CreateStack`'s `Tags.member.N` is
+  dropped, and nothing propagates a stack tag to a created resource. That is the other half of
+  the mechanism and is [#764](https://github.com/scttfrdmn/substrate/issues/764).
+- **A physical ID that merely looks like an EC2 ID is stamped.** The resolver keys on the
+  prefix alone, so an S3 bucket a template names `i-something` would resolve as an instance.
+  No AWS naming rule prevents it and substrate does not check for it.
+
+Provenance: of the three keys, only `aws:cloudformation:stack-name` appears on any AWS
+CloudFormation page that was reachable when this was implemented — every user-guide page
+documenting the set returned an empty body, and `API_CreateStack.html` documents caller-supplied
+stack-tag propagation, which is the different mechanism above. So the triple is observed
+behavior rather than the API model, and is recorded here as such.
 
 What still resolves to `*`, each named because a policy written against it will not behave
 as AWS would:
@@ -4559,6 +4594,7 @@ as AWS would:
 - **`VpcId` and `SubnetId`.** Several creates carry one as the *container* the new resource
   goes into rather than as the resource acted on, and authorizing a create against its
   parent's ARN is not what AWS evaluates it against.
+
 An ID whose prefix names no type substrate can tag, or a `pg-`/`key-` ID naming no record, is
 **skipped**: it contributes no resource to the decision, so a batch of one resolvable and one
 unparseable ID is authorized as the batch of one. The refusal such an ID is owed is the

--- a/emulator/cfn_deployer.go
+++ b/emulator/cfn_deployer.go
@@ -2375,6 +2375,9 @@ func (d *StackDeployer) deployResource(
 	dr, cost, err := d.dispatchResource(ctx, logicalID, res, streamID, cctx)
 	failures := cctx.takeFailures()
 	if err != nil || len(failures) == 0 {
+		// Stamped after the helper has run and before the result is reported, so
+		// the tags are on the resource by the time any Describe can observe it.
+		d.stampCFNResourceTags(dr, cctx)
 		return dr, cost, err
 	}
 	// A resolution failure takes precedence over a dispatch error: the request
@@ -2388,6 +2391,92 @@ func (d *StackDeployer) deployResource(
 	d.logger.Warn("cfn: resource failed to resolve an intrinsic",
 		"logical_id", logicalID, "type", res.Type, "reason", reason)
 	return dr, cost, nil
+}
+
+// cfnStackResourceTagKeys are the three tags CloudFormation puts on every resource it
+// creates, in the order [cfnStackResourceTags] renders them.
+//
+// Named as constants so the state writer, the docs and the tests cannot drift: a policy
+// conditioning on `ec2:ResourceTag/aws:cloudformation:stack-name` — which AWS's own
+// `ManagedCloudformationResourcesCleanupPolicy` does — reads the key literally, and a typo
+// here would make it silently unsatisfiable rather than wrong.
+const (
+	cfnTagStackName = "aws:cloudformation:stack-name"
+	cfnTagStackID   = "aws:cloudformation:stack-id"
+	cfnTagLogicalID = "aws:cloudformation:logical-id"
+)
+
+// cfnStackResourceTags is the stamp CloudFormation applies to the resources a stack
+// creates, for the one resource named by logicalID.
+//
+// Provenance: of the three, only `aws:cloudformation:stack-name` appears on a reachable AWS
+// page. Every CloudFormation user-guide page documenting the set returned an empty body, and
+// `API_CreateStack.html` documents *stack tag propagation*, which is the other mechanism —
+// caller-supplied `Tags.member.N` flowing down, which substrate does not model at all
+// ([#764](https://github.com/scttfrdmn/substrate/issues/764) tracks it). So the triple is
+// observed AWS behavior rather than published API model, and is labeled as such in
+// `docs/services.md`. The values are AWS's: the stack's name, the stack's ARN — which is what
+// `AWS::StackId` resolves to and what `CreateStack` reports — and the resource's logical ID.
+//
+// Ordering is fixed and alphabetical by key so a test can assert the rendered tag list
+// without depending on map iteration. AWS publishes no order, and a real caller sorts.
+func cfnStackResourceTags(stackName, stackID, logicalID string) []EC2Tag {
+	return []EC2Tag{
+		{Key: cfnTagLogicalID, Value: logicalID},
+		{Key: cfnTagStackID, Value: stackID},
+		{Key: cfnTagStackName, Value: stackName},
+	}
+}
+
+// stampCFNResourceTags writes CloudFormation's own three tags onto a resource the deployer
+// just created, for the resource types substrate can tag.
+//
+// Called from the single place that has everything it needs: [StackDeployer.deployResource]
+// is the sole caller of [StackDeployer.dispatchResource] and already holds the physical ID,
+// the logical ID and the stack's name, account and region. So none of the deploy helpers is
+// touched, and a helper added later is stamped without being changed.
+//
+// **A state write, not a synthesized `CreateTags`.** Two reasons, both fatal to the request
+// route: [StackDeployer.dispatch] runs `CheckAccess` on every request it builds, so a
+// `CreateTags` would newly require every already-authorized deployment to hold
+// `ec2:CreateTags`; and `CreateTags` refuses a key beginning with `aws:`, as AWS does, so the
+// stamp would have to punch a hole in the check that exists to keep callers out of AWS's own
+// namespace. CloudFormation on AWS is likewise not observed issuing a tagging call — the
+// tags are simply on the resource — so the state write is also the closer model.
+//
+// Scoped to EC2, because [ec2TaggableResource] resolves a physical ID to a state key by
+// prefix and therefore covers all nine EC2 resource types the deployer creates at once, plus
+// any tenth that arrives. S3, DynamoDB, Lambda and SQS each keep tags in a store with a
+// different key shape and ELBv2 keeps none at all, so each needs its own resolver
+// ([#765](https://github.com/scttfrdmn/substrate/issues/765)). EC2 is what the bundled
+// cleanup policy conditions on, which is the statement this makes satisfiable.
+//
+// A physical ID that is not an EC2 ID resolves to nothing and is skipped silently — a bucket
+// name is the common case, and it must not log. A physical ID that merely *looks* like one
+// (a bucket named "i-something") resolves to a state key holding no record, which
+// [ec2ApplyTagsToResource] treats as the no-op it treats every absent resource as.
+//
+// A failed resource is not stamped: there may be nothing to stamp, and a tag on a resource
+// CloudFormation reports as CREATE_FAILED would claim a resource exists.
+func (d *StackDeployer) stampCFNResourceTags(dr DeployedResource, cctx *cfnContext) {
+	if dr.Error != "" || dr.PhysicalID == "" || dr.LogicalID == "" {
+		return
+	}
+	reqCtx := &RequestContext{AccountID: cctx.accountID, Region: cctx.region}
+	if target, ok := ec2TaggableResource(d.state, reqCtx, dr.PhysicalID); !ok || !target.resolved() {
+		return
+	}
+	tags := cfnStackResourceTags(
+		cctx.stackName,
+		cfnStackARN(cctx.region, cctx.accountID, cctx.stackName),
+		dr.LogicalID,
+	)
+	if err := ec2ApplyTagsToResource(d.state, reqCtx, dr.PhysicalID, tags, false); err != nil {
+		// Recorded, not returned: the resource itself deployed, and a stack does not fail
+		// because CloudFormation could not stamp its own bookkeeping tag.
+		d.logger.Warn("cfn: could not stamp aws:cloudformation tags",
+			"logical_id", dr.LogicalID, "physical_id", dr.PhysicalID, "error", err)
+	}
 }
 
 // dispatchResource routes a CFN resource type to its deploy helper.

--- a/emulator/cfn_stack_tags_test.go
+++ b/emulator/cfn_stack_tags_test.go
@@ -1,0 +1,324 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/xml"
+	"log/slog"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// CloudFormation's own tag stamp on the resources a stack creates (#746).
+//
+// AWS puts three tags on every resource a stack creates — aws:cloudformation:stack-name,
+// aws:cloudformation:stack-id and aws:cloudformation:logical-id — and substrate's deployer
+// put none, which left AmazonECS_FullAccess's ManagedCloudformationResourcesCleanupPolicy
+// statement permanently unsatisfiable: it conditions on
+// ec2:ResourceTag/aws:cloudformation:stack-name, the resolution for that key works (#730),
+// and there was no path by which the tag could ever exist. CreateTags refuses an aws: key as
+// AWS does, so a caller could not fabricate it either.
+//
+// The last test here is the one that matters most, because it asserts the whole chain rather
+// than the tag: deploy a stack, then have the bundled policy actually authorize a delete.
+
+const (
+	cfnStampAccount = "123456789012"
+	cfnStampRegion  = "us-east-1"
+
+	cfnStampStackNameTag = "aws:cloudformation:stack-name"
+	cfnStampStackIDTag   = "aws:cloudformation:stack-id"
+	cfnStampLogicalIDTag = "aws:cloudformation:logical-id"
+)
+
+// cfnStampFixture is a deployer and an EC2 plugin over one state, which is what makes the
+// stamp observable the way a caller observes it: the deployer writes it and DescribeTags
+// reads it back.
+type cfnStampFixture struct {
+	deployer *emulator.StackDeployer
+	ec2      *emulator.EC2Plugin
+	state    emulator.StateManager
+}
+
+// newCFNStampFixture builds the fixture over the given state, so a test that also needs an
+// AuthController can share one store with it. A nil state gets a fresh one.
+func newCFNStampFixture(t *testing.T, state emulator.StateManager) *cfnStampFixture {
+	t.Helper()
+	if state == nil {
+		state = emulator.NewMemoryStateManager()
+	}
+	cfg := emulator.DefaultConfig()
+	registry := emulator.NewPluginRegistry()
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	store := emulator.NewEventStore(cfg.EventStore.ToEventStoreConfig())
+	tc := emulator.NewTimeController(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	costs := emulator.NewCostController(emulator.CostConfig{Enabled: true})
+
+	ec2Plugin := &emulator.EC2Plugin{}
+	require.NoError(t, ec2Plugin.Initialize(context.Background(), emulator.PluginConfig{
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc},
+	}))
+	registry.Register(ec2Plugin)
+
+	// S3 too, so "a physical ID that is not an EC2 ID is skipped" is asserted against a real
+	// bucket rather than a fabricated one.
+	s3Plugin := &emulator.S3Plugin{}
+	require.NoError(t, s3Plugin.Initialize(context.Background(), emulator.PluginConfig{
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc, "filesystem": afero.NewMemMapFs()},
+	}))
+	registry.Register(s3Plugin)
+
+	return &cfnStampFixture{
+		deployer: emulator.NewStackDeployer(registry, store, state, tc, logger, costs),
+		ec2:      ec2Plugin,
+		state:    state,
+	}
+}
+
+// tagsFor returns the tags DescribeTags reports for one resource, as "key=value" strings
+// sorted so the assertion does not depend on an element order AWS says may vary.
+func (f *cfnStampFixture) tagsFor(t *testing.T, resourceID string) []string {
+	t.Helper()
+	resp, err := f.ec2.HandleRequest(&emulator.RequestContext{
+		AccountID: cfnStampAccount,
+		Region:    cfnStampRegion,
+		Metadata:  map[string]interface{}{},
+	}, &emulator.AWSRequest{
+		Service:   "ec2",
+		Operation: "DescribeTags",
+		Params: map[string]string{
+			"Action":           "DescribeTags",
+			"Filter.1.Name":    "resource-id",
+			"Filter.1.Value.1": resourceID,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	var doc struct {
+		Tags []struct {
+			Key   string `xml:"key"`
+			Value string `xml:"value"`
+		} `xml:"tagSet>item"`
+	}
+	require.NoError(t, xml.Unmarshal(resp.Body, &doc), "DescribeTags body: %s", resp.Body)
+
+	out := make([]string, 0, len(doc.Tags))
+	for _, tag := range doc.Tags {
+		out = append(out, tag.Key+"="+tag.Value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// physicalIDs maps each deployed resource's logical ID to its physical ID.
+func physicalIDs(t *testing.T, result *emulator.DeployResult) map[string]string {
+	t.Helper()
+	out := make(map[string]string, len(result.Resources))
+	for _, r := range result.Resources {
+		require.Empty(t, r.Error, "%s failed to deploy", r.LogicalID)
+		out[r.LogicalID] = r.PhysicalID
+	}
+	return out
+}
+
+// cfnStampTemplate is a stack covering every EC2 resource type the deployer creates whose
+// physical ID is an EC2 ID: all nine, so no arm of the resolver is left unproven.
+var cfnStampTemplate = `{
+	"AWSTemplateFormatVersion": "2010-09-09",
+	"Resources": {
+		"Vpc":     {"Type": "AWS::EC2::VPC", "Properties": {"CidrBlock": "10.7.0.0/16"}},
+		"Subnet":  {"Type": "AWS::EC2::Subnet", "Properties": {
+			"VpcId": {"Ref": "Vpc"}, "CidrBlock": "10.7.1.0/24"}},
+		"Sg":      {"Type": "AWS::EC2::SecurityGroup", "Properties": {
+			"GroupDescription": "stamped", "VpcId": {"Ref": "Vpc"}}},
+		"Igw":     {"Type": "AWS::EC2::InternetGateway", "Properties": {}},
+		"Rtb":     {"Type": "AWS::EC2::RouteTable", "Properties": {"VpcId": {"Ref": "Vpc"}}},
+		"Eip":     {"Type": "AWS::EC2::EIP", "Properties": {"Domain": "vpc"}},
+		"Nat":     {"Type": "AWS::EC2::NatGateway", "Properties": {
+			"SubnetId": {"Ref": "Subnet"}, "AllocationId": {"Ref": "Eip"}}},
+		"Lt":      {"Type": "AWS::EC2::LaunchTemplate", "Properties": {
+			"LaunchTemplateName": "stamped-lt",
+			"LaunchTemplateData": {"InstanceType": "t3.micro"}}},
+		"Instance": {"Type": "AWS::EC2::Instance", "Properties": {
+			"ImageId": "` + ec2TestImage + `", "InstanceType": "t3.micro",
+			"SubnetId": {"Ref": "Subnet"}}}
+	},
+	"Outputs": {"StackId": {"Value": {"Ref": "AWS::StackId"}}}
+}`
+
+// TestCFN_StampsItsOwnTagsOnEveryEC2ResourceItCreates is the issue's own scenario, across
+// every EC2 type the deployer creates.
+//
+// One assertion per resource rather than one for the stack, because the stamp is written from
+// a single place keyed on the physical ID's prefix: a type whose ID the resolver does not
+// recognize would be silently skipped, and only a per-type assertion catches that.
+func TestCFN_StampsItsOwnTagsOnEveryEC2ResourceItCreates(t *testing.T) {
+	f := newCFNStampFixture(t, nil)
+	const stackName = "stamped-stack"
+
+	result, err := f.deployer.Deploy(context.Background(), cfnStampTemplate, stackName, nil)
+	require.NoError(t, err)
+	ids := physicalIDs(t, result)
+	require.Len(t, ids, 9, "every resource in the template deployed")
+
+	for logicalID, physicalID := range ids {
+		t.Run(logicalID, func(t *testing.T) {
+			require.NotEmpty(t, physicalID)
+			tags := f.tagsFor(t, physicalID)
+			assert.Contains(t, tags, cfnStampStackNameTag+"="+stackName)
+			assert.Contains(t, tags, cfnStampLogicalIDTag+"="+logicalID)
+
+			var stackID string
+			for _, tag := range tags {
+				if strings.HasPrefix(tag, cfnStampStackIDTag+"=") {
+					stackID = strings.TrimPrefix(tag, cfnStampStackIDTag+"=")
+				}
+			}
+			assert.Equal(t, result.Outputs["StackId"], stackID,
+				"the stamped stack-id is the stack ARN AWS::StackId resolves to")
+		})
+	}
+}
+
+// TestCFN_StampedStackIDIsTheStackTheAPIReports pins that the tag names the same stack the
+// rest of the deployment does. Two derivations of one identity is the defect #517 was, so the
+// tag has to agree with AWS::StackId rather than be built again beside it.
+func TestCFN_StampedStackIDIsTheStackTheAPIReports(t *testing.T) {
+	f := newCFNStampFixture(t, nil)
+	const stackName = "identity-stack"
+	tmpl := `{
+		"Resources": {"Vpc": {"Type": "AWS::EC2::VPC", "Properties": {"CidrBlock": "10.8.0.0/16"}}},
+		"Outputs": {"StackId": {"Value": {"Ref": "AWS::StackId"}}}
+	}`
+
+	result, err := f.deployer.Deploy(context.Background(), tmpl, stackName, nil)
+	require.NoError(t, err)
+	stackID := result.Outputs["StackId"]
+	require.True(t, strings.HasPrefix(stackID,
+		"arn:aws:cloudformation:"+cfnStampRegion+":"+cfnStampAccount+":stack/"+stackName+"/"),
+		"AWS::StackId is the stack ARN, got %q", stackID)
+
+	assert.Equal(t, []string{
+		cfnStampLogicalIDTag + "=Vpc",
+		cfnStampStackIDTag + "=" + stackID,
+		cfnStampStackNameTag + "=" + stackName,
+	}, f.tagsFor(t, physicalIDs(t, result)["Vpc"]),
+		"exactly the three tags, and nothing else")
+}
+
+// TestCFN_StampIsIdempotent pins that re-deploying a stack does not accumulate tags.
+//
+// The stamp is an upsert through the same writer CreateTags uses, so a second deployment
+// rewrites the three values rather than appending three more. That matters because an
+// UpdateStack re-creates unchanged resources here, so the second pass is the normal case
+// rather than an edge one.
+func TestCFN_StampIsIdempotent(t *testing.T) {
+	f := newCFNStampFixture(t, nil)
+	const stackName = "twice-stack"
+	tmpl := `{"Resources": {"Igw": {"Type": "AWS::EC2::InternetGateway", "Properties": {}}}}`
+
+	first, err := f.deployer.Deploy(context.Background(), tmpl, stackName, nil)
+	require.NoError(t, err)
+	igw := physicalIDs(t, first)["Igw"]
+	require.Len(t, f.tagsFor(t, igw), 3)
+
+	// A second deployment of the same template mints a second gateway; the first one's tags
+	// must be untouched and un-duplicated.
+	_, err = f.deployer.Deploy(context.Background(), tmpl, stackName, nil)
+	require.NoError(t, err)
+	assert.Len(t, f.tagsFor(t, igw), 3, "the stamp upserts rather than appends")
+}
+
+// TestCFN_ANonEC2ResourceIsNotStamped pins the silent skip.
+//
+// A bucket name resolves to no EC2 state key, so nothing is written and nothing is logged —
+// the deployer creates far more non-EC2 resources than EC2 ones, and a warning per resource
+// would drown a real one. The stamp beyond EC2 is #765.
+func TestCFN_ANonEC2ResourceIsNotStamped(t *testing.T) {
+	f := newCFNStampFixture(t, nil)
+	tmpl := `{"Resources": {
+		"Bucket": {"Type": "AWS::S3::Bucket", "Properties": {"BucketName": "stamp-test-bucket"}},
+		"Vpc":    {"Type": "AWS::EC2::VPC", "Properties": {"CidrBlock": "10.9.0.0/16"}}
+	}}`
+
+	result, err := f.deployer.Deploy(context.Background(), tmpl, "mixed-stack", nil)
+	require.NoError(t, err)
+	ids := physicalIDs(t, result)
+
+	assert.Empty(t, f.tagsFor(t, ids["Bucket"]), "a bucket carries no EC2 tags")
+	assert.Len(t, f.tagsFor(t, ids["Vpc"]), 3, "and the EC2 resource beside it is still stamped")
+}
+
+// TestCFN_AFailedResourceIsNotStamped pins that the stamp does not claim a resource exists.
+//
+// A resource CloudFormation reports as CREATE_FAILED may have no physical ID at all, and
+// tagging one would put a stack's bookkeeping on something the stack does not own.
+func TestCFN_AFailedResourceIsNotStamped(t *testing.T) {
+	f := newCFNStampFixture(t, nil)
+	tmpl := `{"Resources": {"Instance": {"Type": "AWS::EC2::Instance", "Properties": {
+		"ImageId": "ami-000000000000nope", "InstanceType": "t3.micro"}}}}`
+
+	result, err := f.deployer.Deploy(context.Background(), tmpl, "failed-stack", nil)
+	require.NoError(t, err)
+	require.Len(t, result.Resources, 1)
+	require.NotEmpty(t, result.Resources[0].Error, "an unknown AMI fails the resource")
+	assert.Empty(t, f.tagsFor(t, result.Resources[0].PhysicalID))
+}
+
+// TestCFN_BundledCleanupStatementBecomesSatisfiable is the end of the chain and the reason
+// the issue exists.
+//
+// AmazonECS_FullAccess's ManagedCloudformationResourcesCleanupPolicy allows four EC2 deletes
+// on any resource tagged aws:cloudformation:stack-name like "EC2ContainerService-*". Before
+// the stamp, no resource could carry that tag, so the statement granted nothing at all. Here
+// it authorizes a delete of a resource an EC2ContainerService-* stack created, and still
+// refuses the same delete for a resource created by a stack whose name does not match — which
+// is what shows the tag is being read rather than the condition ignored.
+func TestCFN_BundledCleanupStatementBecomesSatisfiable(t *testing.T) {
+	state := newAuthTestState(t, "ecsuser", "arn:aws:iam::aws:policy/AmazonECS_FullAccess",
+		emulator.PolicyDocument{})
+	f := newCFNStampFixture(t, state)
+	auth := emulator.NewAuthController(state, emulator.NewDefaultLogger(slog.LevelError, false))
+
+	tmpl := `{"Resources": {
+		"Vpc": {"Type": "AWS::EC2::VPC", "Properties": {"CidrBlock": "10.10.0.0/16"}},
+		"Sg":  {"Type": "AWS::EC2::SecurityGroup", "Properties": {
+			"GroupDescription": "cluster sg", "VpcId": {"Ref": "Vpc"}}}
+	}}`
+
+	matching, err := f.deployer.Deploy(context.Background(), tmpl, "EC2ContainerService-web", nil)
+	require.NoError(t, err)
+	other, err := f.deployer.Deploy(context.Background(), tmpl, "unrelated-stack", nil)
+	require.NoError(t, err)
+
+	deleteSG := func(groupID string) error {
+		return auth.CheckAccess(
+			newAuthTestReqCtx("arn:aws:iam::"+cfnStampAccount+":user/ecsuser"),
+			&emulator.AWSRequest{
+				Service:   "ec2",
+				Operation: "DeleteSecurityGroup",
+				Path:      "/",
+				Params:    map[string]string{"GroupId.1": groupID},
+			})
+	}
+
+	require.NoError(t, deleteSG(physicalIDs(t, matching)["Sg"]),
+		"the bundled cleanup statement grants the delete for a stack it names")
+
+	err = deleteSG(physicalIDs(t, other)["Sg"])
+	require.Error(t, err, "a security group from an unrelated stack is not covered")
+	assert.True(t, strings.Contains(err.Error(), "not authorized"),
+		"refused by the policy, got %v", err)
+}

--- a/emulator/ec2_describetags.go
+++ b/emulator/ec2_describetags.go
@@ -190,7 +190,7 @@ func (p *EC2Plugin) describeTags(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 //
 // Each record is decoded into a member map, so a new resource type joins the scan by being
 // listed in [ec2TagScanTargets] and needs no decoder of its own: "tags" is the
-// type-agnostic shape [EC2Plugin.applyTagsToResource] writes and [ec2AuthzTagsFor] reads,
+// type-agnostic shape [ec2ApplyTagsToResource] writes and [ec2AuthzTagsFor] reads,
 // and a name-keyed type's ID member is named by the target rather than by a Go type.
 //
 // A record that cannot be read or decoded is skipped rather than failing the request: a

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -2675,7 +2675,7 @@ func (p *EC2Plugin) createTags(reqCtx *RequestContext, req *AWSRequest) (*AWSRes
 		return nil, awsErr
 	}
 	for _, id := range resourceIDs {
-		existing, found, err := p.resourceTags(reqCtx, id)
+		existing, found, err := ec2ResourceTags(p.state, reqCtx, id)
 		if err != nil {
 			return nil, err
 		}
@@ -2690,7 +2690,7 @@ func (p *EC2Plugin) createTags(reqCtx *RequestContext, req *AWSRequest) (*AWSRes
 		}
 	}
 	for _, id := range resourceIDs {
-		if err := p.applyTagsToResource(reqCtx, id, tags, false); err != nil {
+		if err := ec2ApplyTagsToResource(p.state, reqCtx, id, tags, false); err != nil {
 			return nil, err
 		}
 	}
@@ -2726,7 +2726,7 @@ func (p *EC2Plugin) deleteTags(reqCtx *RequestContext, req *AWSRequest) (*AWSRes
 		return nil, awsErr
 	}
 	for _, id := range resourceIDs {
-		if err := p.applyTagsToResource(reqCtx, id, tags, true); err != nil {
+		if err := ec2ApplyTagsToResource(p.state, reqCtx, id, tags, true); err != nil {
 			return nil, err
 		}
 	}
@@ -2895,7 +2895,7 @@ func ec2TaggableResource(state StateManager, reqCtx *RequestContext, id string) 
 		// Volumes were the one taggable resource with no arm here, so CreateTags on a
 		// vol- ID fell through to the default and answered <return>true</return> having
 		// written nothing (#670). Nothing else needed changing:
-		// [EC2Plugin.applyTagsToResource] is type-agnostic — it reads and writes the
+		// [ec2ApplyTagsToResource] is type-agnostic — it reads and writes the
 		// record's "tags" JSON member — and [EC2Volume.Tags] already serializes there.
 		return ec2Taggable{stateKey: ec2VolumeStateKey(acct, region, id), arnType: "volume", arnID: id}, true
 	case strings.HasPrefix(id, "snap-"):
@@ -3014,7 +3014,7 @@ func ec2InvalidTagResourceID(id string) *AWSError {
 // ec2CheckTagResourceIDs refuses the whole request when any ResourceId names a resource
 // type substrate cannot tag, before anything is written.
 //
-// Ordering, not redundancy: [EC2Plugin.applyTagsToResource] answers the same refusal from
+// Ordering, not redundancy: [ec2ApplyTagsToResource] answers the same refusal from
 // the same constructor, but it answers it partway through the apply loop, which would
 // leave the resources named ahead of the bad ID tagged. That is the partially-tagged state
 // CreateTags' three other whole-request checks exist to prevent, and real EC2 never
@@ -3028,20 +3028,25 @@ func ec2CheckTagResourceIDs(state StateManager, reqCtx *RequestContext, ids []st
 	return nil
 }
 
-// resourceTags returns the tags currently on the resource named by id, and whether the
+// ec2ResourceTags returns the tags currently on the resource named by id, and whether the
 // resource was found at all.
 //
 // A missing resource reports found=false rather than an error, matching
-// [EC2Plugin.applyTagsToResource]: CreateTags on an absent resource is a no-op in
+// [ec2ApplyTagsToResource]: CreateTags on an absent resource is a no-op in
 // substrate rather than a rejection, so the tag-limit check has nothing to count.
-func (p *EC2Plugin) resourceTags(reqCtx *RequestContext, id string) ([]EC2Tag, bool, error) {
-	target, ok := ec2TaggableResource(p.state, reqCtx, id)
+//
+// A free function taking the state rather than an [EC2Plugin] method, as
+// [ec2LookupDefaultVPC] already is, because the CloudFormation deployer stamps its own
+// tags on the EC2 resources it creates (#746) and holds no plugin — only a
+// [StateManager]. Nothing about reading a record's tags needs the plugin.
+func ec2ResourceTags(state StateManager, reqCtx *RequestContext, id string) ([]EC2Tag, bool, error) {
+	target, ok := ec2TaggableResource(state, reqCtx, id)
 	if !ok || !target.resolved() {
 		return nil, false, nil
 	}
-	data, err := p.state.Get(context.Background(), ec2Namespace, target.stateKey)
+	data, err := state.Get(context.Background(), ec2Namespace, target.stateKey)
 	if err != nil || data == nil {
-		return nil, false, nil //nolint:nilerr // Absent resource — ignored, as by applyTagsToResource.
+		return nil, false, nil //nolint:nilerr // Absent resource — ignored, as by ec2ApplyTagsToResource.
 	}
 	var resource map[string]json.RawMessage
 	if err := json.Unmarshal(data, &resource); err != nil {
@@ -3054,21 +3059,30 @@ func (p *EC2Plugin) resourceTags(reqCtx *RequestContext, id string) ([]EC2Tag, b
 	return existing, true, nil
 }
 
-// applyTagsToResource loads the EC2 resource identified by id, merges or
+// ec2ApplyTagsToResource loads the EC2 resource identified by id, merges or
 // removes the provided tags, and saves the updated resource back to state.
 // When remove is true, matching tag keys are deleted; otherwise tags are upserted.
 //
 // An ID whose prefix names no taggable type is refused with [ec2InvalidTagResourceID]
 // rather than silently ignored, which is what it was until #708 — the comment there read
-// "matches AWS behavior", and AWS's behavior is InvalidID. Both callers check every ID
-// through [ec2CheckTagResourceIDs] first, so the refusal here is reached only by a caller
-// that skipped that pass; it is kept so no future one can reintroduce the silent success.
+// "matches AWS behavior", and AWS's behavior is InvalidID. The two `CreateTags`/
+// `DeleteTags` callers check every ID through [ec2CheckTagResourceIDs] first, so the
+// refusal here is reached only by a caller that skipped that pass; it is kept so no future
+// one can reintroduce the silent success.
 //
 // An ID that resolves to no record is still a no-op, deliberately: substrate does not
 // verify a taggable resource's existence, so a tag applied to an absent resource is
 // discarded rather than refused.
-func (p *EC2Plugin) applyTagsToResource(reqCtx *RequestContext, id string, tags []EC2Tag, remove bool) error {
-	target, ok := ec2TaggableResource(p.state, reqCtx, id)
+//
+// A free function taking the state, for the reason given on [ec2ResourceTags]: the
+// CloudFormation deployer writes the `aws:cloudformation:*` stamp through here (#746) and
+// holds no [EC2Plugin]. It reads and writes the record's "tags" JSON member rather than a
+// typed field, so it is type-agnostic and every taggable type is covered by whatever
+// [ec2TaggableResource] resolves.
+func ec2ApplyTagsToResource(
+	state StateManager, reqCtx *RequestContext, id string, tags []EC2Tag, remove bool,
+) error {
+	target, ok := ec2TaggableResource(state, reqCtx, id)
 	if !ok {
 		return ec2InvalidTagResourceID(id)
 	}
@@ -3077,7 +3091,7 @@ func (p *EC2Plugin) applyTagsToResource(reqCtx *RequestContext, id string, tags 
 	}
 	stateKey := target.stateKey
 
-	data, err := p.state.Get(context.Background(), ec2Namespace, stateKey)
+	data, err := state.Get(context.Background(), ec2Namespace, stateKey)
 	if err != nil || data == nil {
 		return nil //nolint:nilerr // Resource not found — ignore (matches AWS behavior).
 	}
@@ -3129,7 +3143,7 @@ func (p *EC2Plugin) applyTagsToResource(reqCtx *RequestContext, id string, tags 
 	if err != nil {
 		return fmt.Errorf("ec2 applyTagsToResource marshal %s: %w", id, err)
 	}
-	return p.state.Put(context.Background(), ec2Namespace, stateKey, updated)
+	return state.Put(context.Background(), ec2Namespace, stateKey, updated)
 }
 
 // extractEC2Tags extracts Tag.N.Key / Tag.N.Value pairs from query params.

--- a/emulator/ec2_types.go
+++ b/emulator/ec2_types.go
@@ -203,7 +203,7 @@ type EC2KeyPair struct {
 	// Tags holds key-value metadata tags.
 	//
 	// Spelled "tags" like every other EC2 record's, rather than following this struct's
-	// camelCase members: that is the member [EC2Plugin.applyTagsToResource] and
+	// camelCase members: that is the member [ec2ApplyTagsToResource] and
 	// [EC2Plugin.scanTags] read and write on every type, and a key pair spelling it
 	// differently would be tagged into a member nothing reports (#708).
 	Tags []EC2Tag `json:"tags,omitempty"`


### PR DESCRIPTION
AWS puts three tags on every resource a stack creates —
`aws:cloudformation:stack-name`, `aws:cloudformation:stack-id` and
`aws:cloudformation:logical-id` — and substrate's deployer put none. That is not only a
missing member: it left a bundled policy permanently unsatisfiable.
`AmazonECS_FullAccess`'s `ManagedCloudformationResourcesCleanupPolicy` allows four EC2
deletes on any resource whose `ec2:ResourceTag/aws:cloudformation:stack-name` is like
`EC2ContainerService-*`; the resolution for that key already worked (#730), `CreateTags`
refuses an `aws:` key as AWS does, and no path existed by which the tag could ever exist —
so the statement granted nothing at all, and nothing distinguished that from a policy bug.

### Design

The stamp is written from `deployResource`, the **sole** caller of `dispatchResource`, which
already holds the logical ID, the physical ID and the stack's name, account and region. So
none of the 110 dispatch arms is touched.

It is deliberately a state write and not a synthesized `CreateTags`: that call refuses the
`aws:` keys it would be carrying, and `StackDeployer.dispatch` runs `CheckAccess` on every
synthesized request, so the parameter route would newly require `ec2:CreateTags` of every
principal whose deployment succeeds today. `resourceTags` and `applyTagsToResource` are
promoted to free functions taking a `StateManager`, the same refactor `ec2LookupDefaultVPC`
already had, because the deployer holds no plugin.

The stack ID written is the ARN `AWS::StackId` resolves to rather than a second derivation of
it — two derivations of one identity is the defect #517 was. The write is an upsert, so
re-deploying rewrites the three tags rather than accumulating them, and `aws:` keys are
already outside the 50-tag limit, so the stamp cannot push a caller's own tags over it.

Scoped to EC2, which is what the bundled statement needs: the resolver maps an ID prefix to a
state key and only EC2 keeps tags in a store shaped that way, so all nine EC2 types the
deployer creates are covered by prefix and a tenth arrives free. A non-EC2 physical ID is
skipped silently — a stack creates far more non-EC2 resources than EC2 ones, so a warning per
resource would bury a real one — as is a resource that failed to deploy or has no physical ID.

### Provenance

Of the three keys, only `aws:cloudformation:stack-name` appears on any AWS CloudFormation page
that was reachable: every user-guide page documenting the set returned an empty body, and
`API_CreateStack.html` documents caller-supplied stack-tag propagation, which is the other
mechanism. **The triple is observed behavior rather than the API model**, and
`docs/services.md` records it as such.

### Verification

`gofmt`/`go build`/`go vet`/`golangci-lint` clean (0 issues); `make test` green with race;
coverage holds at emulator 83.4%, total 82.8%; `make docs-reference docs-reference-check
docs-versions` pass; the VitePress build succeeds with no `href="#…"` lacking an `id`;
`test/e2e` vet and test green.

Six new tests (`emulator/cfn_stack_tags_test.go`), the last of which asserts the whole chain
rather than the tag: it attaches the bundled `AmazonECS_FullAccess`, deploys
`EC2ContainerService-web` and `unrelated-stack`, and has the policy actually authorize a
`DeleteSecurityGroup` for the first and refuse it for the second. Fail-before: 14 `FAIL` lines
across 5 tests with the stamp call removed.

**Live SDK fail-before/pass-after** against built binaries, `aws` CLI over `--endpoint-url`,
deploying a ten-resource stack (nine EC2 types plus a bucket):

| | `main` | this branch |
|---|---|---|
| tags on each of the nine EC2 resources | none | the three, on all nine |
| tags on the S3 bucket | none | none (skipped) |
| `aws:cloudformation:stack-id` vs the `AWS::StackId` output | `None` | identical ARNs |
| `create-tags Key=aws:cloudformation:stack-name` by a caller | `InvalidParameterValue` | `InvalidParameterValue` |
| bundled cleanup delete, `EC2ContainerService-live`'s SG | `AccessDenied` | `Return: true` |
| bundled cleanup delete, `unrelated-stack`'s SG | `AccessDenied` | `AccessDenied` |
| tag count after re-deploying the stack | 0 → 0 | 3 → 3 |

### Carve-outs, filed not dropped

- #764 — caller-supplied `CreateStack` `Tags.member.N`, still dropped, and their propagation.
- #765 — the stamp beyond EC2 (S3, DynamoDB, Lambda, SQS each key tags differently; ELBv2 has
  no tag store until #748).

Also fixes a lazy-continuation bug in `docs/services.md` introduced by #744, where a paragraph
following a bullet list was rendered into the list item.

### Compatibility

A test asserting an exact tag set on a CFN-deployed EC2 resource now sees three more tags, and
a tag-scoped policy that matched nothing before may now match.

Closes #746
