### PR TITLE
feat(config): read substrate.yaml's credentials: section (#736)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   binary's behavior changes: every documented credential still resolves to
   `arn:aws:iam::123456789012:root` and an IAM-minted key still resolves to its user.
 
+- **`substrate.yaml`'s `credentials:` section is read** (#736). It had been documented
+  from the beginning with an `enabled` flag and a list of `entries` carrying
+  `access_key_id` / `secret_access_key` / `account_id`, and `Config` had no field for any of
+  it — so viper read the keys, nothing consumed them, and a consumer who configured a
+  registry got no registry, no verification and no error. `CredentialRegistry` was reachable
+  only in-process through `ServerOptions`. It now has `CredentialsCfg`,
+  `CredentialEntryCfg`, `CredentialsCfg.ToCredentialRegistry` and `CredentialsCfg.RegisterInto`,
+  and `cmd/substrate` passes the result through `ServerOptions`.
+
+  `verify_signatures` was added beside `enabled` and defaults to **true**, because the
+  section has documented `enabled` as *"enable SigV4 signature verification"* since it was
+  written and `enabled: true` on its own has to keep meaning that. Setting it to `false` is
+  the combination #630 opened up — resolve an account per access key without authenticating
+  anyone — which is what a multi-account test usually wants.
+
+  `Validate` refuses an empty `access_key_id`, an `account_id` that is not twelve digits, a
+  duplicated access key, and a missing `secret_access_key` while verification is on. Entries
+  are checked whether or not the section is enabled, so a typo does not stay hidden until
+  someone flips the flag. `SIGHUP` adds newly listed entries to the live registry; `enabled`
+  and `verify_signatures` are startup-only and changing either logs a warning saying so.
+
+  `NewCredentialRegistry` now seeds the three credentials substrate's own documentation
+  tells a caller to use — `AKIATEST12345678901`, `test`/`test` and `AKIAIOSFODNN7EXAMPLE`,
+  all in the default account — rather than only the first. Without that, turning
+  verification on would have made substrate's own quickstart wrong: a consumer who followed
+  `README.md` or the testing guide exactly would have been answered
+  `InvalidClientTokenId` 403. Their secrets are documented too, so signing with one still
+  proves the caller holds the secret; this widens who may sign, not what a signature has to
+  satisfy. An `entries:` row reusing one of those access key IDs replaces it, which is how a
+  test moves the built-in key into another account.
+
+  **The `auth:` section was removed from `substrate.yaml.example` rather than wired**, and
+  the issue's expectation there is recorded as wrong. `substrate server` already builds an
+  `AuthController` unconditionally, and `IAMPlugin.authorize` holds no controller at all —
+  it resolves against state directly — so `auth.enabled: false` could never have meant
+  "off". Enforcement is opt-in by *existence*: a request is checked only once its access key
+  resolves to an IAM entity substrate holds. A flag would have overpromised in both
+  directions, so the example file now says there is nothing to enable and why.
+
+  Nothing changes for an existing deployment: `credentials.enabled` ships `false`, which
+  wires no registry, attributes every caller to `account.default` and checks no signature.
+  One thing to expect on turning it on with verification: a verified key that IAM does not
+  know names *itself* as the principal, so `GetCallerIdentity` reports
+  `arn:aws:iam::111122223333:user/AKIAEXAMPLE00000001` rather than `…:root`. That is #630's
+  rule — a verified key has proven the caller holds the secret — and the ARN still resolves
+  to no policies. With `verify_signatures: false` the answer stays `…:root`.
+
 ### Fixed
 - **An EC2 operation naming several resources was decided against the first alone** (#744).
   `TerminateInstances` with three `InstanceId.N` was authorized against `InstanceId.1`'s ARN

--- a/cmd/substrate/main.go
+++ b/cmd/substrate/main.go
@@ -194,30 +194,24 @@ configured address will have their requests emulated and recorded.`,
 			// nil unless credentials.enabled is set, which is the shipped default —
 			// so an existing deployment resolves every caller to account.default and
 			// checks no signature, exactly as before (#736).
-			credRegistry := cfg.Credentials.ToCredentialRegistry(cfg.Account.Default)
+			credRegistry, verifySignatures := cfg.Credentials.ToServerCredentials(cfg.Account.Default)
 			if credRegistry != nil {
 				logger.Info("credential registry enabled",
 					"entries", len(cfg.Credentials.Entries),
-					"verify_signatures", cfg.Credentials.VerifySignatures)
+					"verify_signatures", verifySignatures)
 			}
 
 			srv := substrate.NewServer(*cfg, registry, store, state, tc, logger,
 				substrate.ServerOptions{
-					Quota:       quotaCtrl,
-					Consistency: consistencyCtrl,
-					Costs:       costCtrl,
-					Auth:        authCtrl,
-					Metrics:     metricsCollector,
-					Tracer:      tracer,
-					Fault:       faultCtrl,
-					Credentials: credRegistry,
-					// Gated on the registry rather than passed straight through:
-					// credentials.verify_signatures defaults to true so that
-					// `enabled: true` alone enforces signatures, so a bare copy would
-					// hand NewServer verify-without-registry on every default startup
-					// and log its downgrade warning at a consumer who configured
-					// nothing.
-					VerifySignatures: credRegistry != nil && cfg.Credentials.VerifySignatures,
+					Quota:            quotaCtrl,
+					Consistency:      consistencyCtrl,
+					Costs:            costCtrl,
+					Auth:             authCtrl,
+					Metrics:          metricsCollector,
+					Tracer:           tracer,
+					Fault:            faultCtrl,
+					Credentials:      credRegistry,
+					VerifySignatures: verifySignatures,
 				})
 
 			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -246,8 +240,7 @@ configured address will have their requests emulated and recorded.`,
 					// added to, so an appended entry is reachable without a restart.
 					// Whether the section is on at all is not (#736).
 					newCfg.Credentials.RegisterInto(credRegistry, newCfg.Account.Default)
-					if newCfg.Credentials.Enabled != cfg.Credentials.Enabled ||
-						newCfg.Credentials.VerifySignatures != cfg.Credentials.VerifySignatures {
+					if newCfg.Credentials.StartupOnlyDiffers(cfg.Credentials) {
 						logger.Warn("credentials.enabled and credentials.verify_signatures are read at startup; restart to change them",
 							"enabled", cfg.Credentials.Enabled,
 							"verify_signatures", cfg.Credentials.VerifySignatures)

--- a/cmd/substrate/main.go
+++ b/cmd/substrate/main.go
@@ -95,6 +95,41 @@ func newFaultController(cfg substrate.FaultCfg) *substrate.FaultController {
 	return substrate.NewFaultController(cfg.ToFaultConfig(), cfg.Seed)
 }
 
+// newCredentialWiring builds the server's credential options from the
+// credentials: section and reports that the registry is on.
+//
+// Both returns are nil/false unless credentials.enabled is set, and off is the
+// shipped default — so an existing deployment resolves every caller to
+// account.default and checks no signature, exactly as before (#736).
+//
+// This is a function rather than three inline lines for the same reason as
+// [newFaultController]: a RunE closure cannot be called from a test, and what the
+// shipped binary does with this section is the whole of what #736 changed.
+func newCredentialWiring(cfg *substrate.Config, logger substrate.Logger) (*substrate.CredentialRegistry, bool) {
+	registry, verifySignatures := cfg.Credentials.ToServerCredentials(cfg.Account.Default)
+	if registry != nil {
+		logger.Info("credential registry enabled",
+			"entries", len(cfg.Credentials.Entries),
+			"verify_signatures", verifySignatures)
+	}
+	return registry, verifySignatures
+}
+
+// reloadCredentials applies to a running server what a reload of the credentials:
+// section can apply, and warns about what it cannot.
+//
+// The registry the server holds cannot be swapped, but it can be added to, so an
+// appended entry is reachable without a restart. Whether the section is on at all,
+// and whether it verifies, are read once at startup (#736).
+func reloadCredentials(registry *substrate.CredentialRegistry, newCfg, cfg *substrate.Config, logger substrate.Logger) {
+	newCfg.Credentials.RegisterInto(registry, newCfg.Account.Default)
+	if newCfg.Credentials.StartupOnlyDiffers(cfg.Credentials) {
+		logger.Warn("credentials.enabled and credentials.verify_signatures are read at startup; restart to change them",
+			"enabled", cfg.Credentials.Enabled,
+			"verify_signatures", cfg.Credentials.VerifySignatures)
+	}
+}
+
 func newServerCmd() *cobra.Command {
 	var configPath string
 	var address string
@@ -191,15 +226,7 @@ configured address will have their requests emulated and recorded.`,
 				defer func() { _ = tracerShutdown(context.Background()) }()
 			}
 
-			// nil unless credentials.enabled is set, which is the shipped default —
-			// so an existing deployment resolves every caller to account.default and
-			// checks no signature, exactly as before (#736).
-			credRegistry, verifySignatures := cfg.Credentials.ToServerCredentials(cfg.Account.Default)
-			if credRegistry != nil {
-				logger.Info("credential registry enabled",
-					"entries", len(cfg.Credentials.Entries),
-					"verify_signatures", verifySignatures)
-			}
+			credRegistry, verifySignatures := newCredentialWiring(cfg, logger)
 
 			srv := substrate.NewServer(*cfg, registry, store, state, tc, logger,
 				substrate.ServerOptions{
@@ -236,15 +263,7 @@ configured address will have their requests emulated and recorded.`,
 					if faultCtrl != nil {
 						faultCtrl.UpdateConfig(newCfg.Fault.ToFaultConfig())
 					}
-					// The registry the server holds cannot be swapped, but it can be
-					// added to, so an appended entry is reachable without a restart.
-					// Whether the section is on at all is not (#736).
-					newCfg.Credentials.RegisterInto(credRegistry, newCfg.Account.Default)
-					if newCfg.Credentials.StartupOnlyDiffers(cfg.Credentials) {
-						logger.Warn("credentials.enabled and credentials.verify_signatures are read at startup; restart to change them",
-							"enabled", cfg.Credentials.Enabled,
-							"verify_signatures", cfg.Credentials.VerifySignatures)
-					}
+					reloadCredentials(credRegistry, newCfg, cfg, logger)
 					logger.Info("config reloaded")
 				}
 			}()

--- a/cmd/substrate/main.go
+++ b/cmd/substrate/main.go
@@ -191,6 +191,16 @@ configured address will have their requests emulated and recorded.`,
 				defer func() { _ = tracerShutdown(context.Background()) }()
 			}
 
+			// nil unless credentials.enabled is set, which is the shipped default —
+			// so an existing deployment resolves every caller to account.default and
+			// checks no signature, exactly as before (#736).
+			credRegistry := cfg.Credentials.ToCredentialRegistry(cfg.Account.Default)
+			if credRegistry != nil {
+				logger.Info("credential registry enabled",
+					"entries", len(cfg.Credentials.Entries),
+					"verify_signatures", cfg.Credentials.VerifySignatures)
+			}
+
 			srv := substrate.NewServer(*cfg, registry, store, state, tc, logger,
 				substrate.ServerOptions{
 					Quota:       quotaCtrl,
@@ -200,6 +210,14 @@ configured address will have their requests emulated and recorded.`,
 					Metrics:     metricsCollector,
 					Tracer:      tracer,
 					Fault:       faultCtrl,
+					Credentials: credRegistry,
+					// Gated on the registry rather than passed straight through:
+					// credentials.verify_signatures defaults to true so that
+					// `enabled: true` alone enforces signatures, so a bare copy would
+					// hand NewServer verify-without-registry on every default startup
+					// and log its downgrade warning at a consumer who configured
+					// nothing.
+					VerifySignatures: credRegistry != nil && cfg.Credentials.VerifySignatures,
 				})
 
 			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -223,6 +241,16 @@ configured address will have their requests emulated and recorded.`,
 					costCtrl.SetDiscounts(newCfg.Costs.Discounts)
 					if faultCtrl != nil {
 						faultCtrl.UpdateConfig(newCfg.Fault.ToFaultConfig())
+					}
+					// The registry the server holds cannot be swapped, but it can be
+					// added to, so an appended entry is reachable without a restart.
+					// Whether the section is on at all is not (#736).
+					newCfg.Credentials.RegisterInto(credRegistry, newCfg.Account.Default)
+					if newCfg.Credentials.Enabled != cfg.Credentials.Enabled ||
+						newCfg.Credentials.VerifySignatures != cfg.Credentials.VerifySignatures {
+						logger.Warn("credentials.enabled and credentials.verify_signatures are read at startup; restart to change them",
+							"enabled", cfg.Credentials.Enabled,
+							"verify_signatures", cfg.Credentials.VerifySignatures)
 					}
 					logger.Info("config reloaded")
 				}

--- a/cmd/substrate/main_test.go
+++ b/cmd/substrate/main_test.go
@@ -65,6 +65,117 @@ func TestNewDebugCmd(t *testing.T) {
 	}
 }
 
+// recordingLogger keeps every message so a test can assert what the binary told
+// its operator, which for the credentials: section is half of the behavior (#736).
+type recordingLogger struct {
+	info []string
+	warn []string
+}
+
+func (l *recordingLogger) Debug(string, ...any) {}
+
+func (l *recordingLogger) Info(msg string, _ ...any) { l.info = append(l.info, msg) }
+
+func (l *recordingLogger) Warn(msg string, _ ...any) { l.warn = append(l.warn, msg) }
+
+func (l *recordingLogger) Error(string, ...any) {}
+
+// TestNewCredentialWiring covers what `substrate server` does with the
+// credentials: section, which was decorative until #736: the shipped default must
+// change nothing, and the two flags must reach the server the way the section has
+// always been documented.
+func TestNewCredentialWiring(t *testing.T) {
+	defaults := substrate.DefaultConfig()
+	if defaults.Credentials.Enabled {
+		t.Fatal("precondition: the default config must not enable the credentials section")
+	}
+	if !defaults.Credentials.VerifySignatures {
+		t.Fatal("precondition: verify_signatures defaults to true, so `enabled: true` alone enforces signatures")
+	}
+
+	logger := &recordingLogger{}
+	registry, verifySignatures := newCredentialWiring(defaults, logger)
+	if registry != nil {
+		t.Error("a default config must build no registry; every caller resolves to account.default")
+	}
+	if verifySignatures {
+		t.Error("verify-without-registry must never reach the server, whatever verify_signatures says")
+	}
+	if len(logger.info) != 0 {
+		t.Errorf("a default config logged %v; it configured nothing", logger.info)
+	}
+
+	// enabled: true alone attributes accounts and enforces signatures.
+	cfg := substrate.DefaultConfig()
+	cfg.Credentials.Enabled = true
+	cfg.Credentials.Entries = []substrate.CredentialEntryCfg{
+		{AccessKeyID: "AKIAEXAMPLE00000001", SecretAccessKey: "s", AccountID: "111122223333"},
+	}
+	logger = &recordingLogger{}
+	registry, verifySignatures = newCredentialWiring(cfg, logger)
+	if registry == nil || !verifySignatures {
+		t.Fatalf("enabled: true gave registry=%v verify=%v, want a registry that verifies", registry != nil, verifySignatures)
+	}
+	entry, ok := registry.Lookup("AKIAEXAMPLE00000001")
+	if !ok || entry.AccountID != "111122223333" {
+		t.Errorf("configured entry resolved to %+v (found=%v), want account 111122223333", entry, ok)
+	}
+	if !slices.Contains(logger.info, "credential registry enabled") {
+		t.Errorf("logged %v; an operator must be told the section is on", logger.info)
+	}
+
+	// verify_signatures: false is the combination #630 opened — attribution
+	// without authentication.
+	cfg.Credentials.VerifySignatures = false
+	if registry, verifySignatures = newCredentialWiring(cfg, &recordingLogger{}); registry == nil || verifySignatures {
+		t.Errorf("verify_signatures: false gave registry=%v verify=%v, want a registry that does not verify",
+			registry != nil, verifySignatures)
+	}
+}
+
+// TestReloadCredentials covers the reload split: an appended entry reaches the
+// live registry, and the two settings a reload cannot apply say so rather than
+// appearing to have been applied (#736).
+func TestReloadCredentials(t *testing.T) {
+	cfg := substrate.DefaultConfig()
+	cfg.Credentials.Enabled = true
+	registry, _ := newCredentialWiring(cfg, &recordingLogger{})
+	if registry == nil {
+		t.Fatal("precondition: an enabled section must build a registry")
+	}
+
+	newCfg := substrate.DefaultConfig()
+	newCfg.Credentials.Enabled = true
+	newCfg.Account.Default = "210987654321"
+	newCfg.Credentials.Entries = []substrate.CredentialEntryCfg{
+		{AccessKeyID: "AKIARELOADED00000001", SecretAccessKey: "s"},
+	}
+	logger := &recordingLogger{}
+	reloadCredentials(registry, newCfg, cfg, logger)
+
+	entry, ok := registry.Lookup("AKIARELOADED00000001")
+	if !ok {
+		t.Fatal("an appended entry must be reachable without a restart")
+	}
+	if entry.AccountID != "210987654321" {
+		t.Errorf("reloaded entry account = %q, want the new account.default", entry.AccountID)
+	}
+	if len(logger.warn) != 0 {
+		t.Errorf("warned %v about a change it did apply", logger.warn)
+	}
+
+	// Turning the section off is not something a reload can do.
+	newCfg.Credentials.Enabled = false
+	logger = &recordingLogger{}
+	reloadCredentials(registry, newCfg, cfg, logger)
+	if len(logger.warn) != 1 {
+		t.Errorf("warned %v, want one warning that the flag is read at startup", logger.warn)
+	}
+	if _, ok := registry.Lookup("AKIARELOADED00000001"); !ok {
+		t.Error("the entry must survive; a reload cannot take the registry away either")
+	}
+}
+
 // TestNewFaultController_AlwaysBuiltAndSeeded covers the two wiring properties a
 // default `substrate server` depends on. The controller used to be built only when
 // the config named faults, so /v1/fault/rules answered 501 on a default server and

--- a/docs/services.md
+++ b/docs/services.md
@@ -266,7 +266,7 @@ single answer. Substrate resolves it in one place and in this order:
 |---|---|
 | `123456789012` | Always, as the starting point. AWS's documented example account. |
 | `account.default` in `substrate.yaml` | Whenever it is set and 12 digits. Set it to whatever your fixtures assert on. |
-| A `CredentialRegistry` entry | When the request is signed with an access key the registry holds. |
+| A `CredentialRegistry` entry | When the request is signed with an access key the registry holds. Wire one with `credentials:` in `substrate.yaml` or `ServerOptions.Credentials`. |
 | An STS session record | When the request is signed with credentials `AssumeRole` minted. |
 
 Later rows win. The order is what it is because each row knows strictly more than the
@@ -307,12 +307,64 @@ under the old account is unreachable** after upgrading. Re-seed it, or set
 - **IAM's state keys are account-blind.** A user is stored under `user:{name}` with no
   account in the key, so `resolveIAMEntity` resolves a principal by name across
   accounts and two accounts cannot both hold a role of the same name. Filed as
-  [#737](https://github.com/scttfrdmn/substrate/issues/737); it is reachable only with
-  a credential registry, which is in-process only today.
-- **`substrate.yaml`'s `credentials:` and `auth:` sections are not read.** `Config` has
-  no fields for them, so the shipped `substrate server` discards both. Both subsystems
-  are real and reachable in-process through `ServerOptions`. Filed as
-  [#736](https://github.com/scttfrdmn/substrate/issues/736).
+  [#737](https://github.com/scttfrdmn/substrate/issues/737). It is now reachable from
+  the shipped binary as well as in-process, since a `credentials:` block can put two
+  access keys in two accounts.
+
+### Configuring the registry from `substrate.yaml`
+
+```yaml
+account:
+  default: "123456789012"
+credentials:
+  enabled: true              # build the registry; without it there is none
+  verify_signatures: true    # the default — see below
+  entries:
+    - access_key_id: "AKIAEXAMPLE00000001"
+      secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+      account_id: "111122223333"
+```
+
+`enabled: false` — the shipped default — wires no registry at all, so every caller
+resolves to `account.default` and no signature is checked. Nothing about an existing
+deployment changes.
+
+`verify_signatures` defaults to **true**, because this section has documented `enabled`
+as *"enable SigV4 signature verification"* since it was written and `enabled: true`
+alone has to keep meaning that. Set it to `false` for the combination
+[#630](https://github.com/scttfrdmn/substrate/issues/630) opened up: resolve an account
+per access key without authenticating anyone. That is the setting a multi-account test
+usually wants, since the registry is there to answer *which account* and no call needs a
+real signature.
+
+`account_id` is optional and falls back to `account.default`, so an entry can exist only
+to make a key signable. `secret_access_key` is required while verification is on and
+unused otherwise. A malformed entry — an empty `access_key_id`, an `account_id` that is
+not twelve digits, a duplicated key — is a startup error rather than a silently dropped
+row, and it is checked whether or not the section is enabled, so a typo does not stay
+hidden until someone flips the flag.
+
+Every registry — configured or built in-process — is seeded with the three credentials
+substrate's own documentation tells a caller to use, all in `account.default`:
+`AKIATEST12345678901`, `test`/`test` (README, endpoint configuration) and
+`AKIAIOSFODNN7EXAMPLE` (testing guide, `test/e2e`). Without that, turning verification
+on would make the quickstart wrong — a consumer would have followed the documentation
+exactly and been answered `InvalidClientTokenId` 403. Reusing one of those access key
+IDs in `entries:` replaces it, which is how a test moves the built-in key into another
+account.
+
+`SIGHUP` re-reads the file and adds any new `entries:` to the live registry. `enabled`
+and `verify_signatures` are read once at startup; changing either logs a warning saying
+so and takes effect on restart.
+
+**Cross-service IAM authorization has no flag, and there is nothing to enable.**
+`substrate server` always builds an `AuthController`. Enforcement is opt-in by
+*existence* instead: a request is checked against attached policies, inline policies and
+a permission boundary only once its access key resolves to an IAM entity substrate
+actually holds, and a caller that never created a user or role is authorized against
+nothing. An `auth.enabled` flag would overpromise in both directions — it could not turn
+enforcement off for a principal that exists, because IAM's own authorization resolves
+against state directly rather than through the controller.
 
 ### Attributing accounts and enforcing signatures are separate
 
@@ -320,10 +372,12 @@ under the old account is unreachable** after upgrading. Re-seed it, or set
 `ServerOptions.VerifySignatures` answers *is this signature valid*. One field used to
 mean both ([#630](https://github.com/scttfrdmn/substrate/issues/630)), so wiring a
 registry in order to reach a second account also refused every credential substrate
-documents — `test`/`test` and `AKIAIOSFODNN7EXAMPLE` are in no registry, and an
+documents — `test`/`test` and `AKIAIOSFODNN7EXAMPLE` were in no registry, and an
 unregistered key is `InvalidClientTokenId` 403. All four combinations are expressible
 now, and the one that did not exist before — a registry with verification off — is
-what every test server uses.
+what every test server uses. Both of those credentials are seeded into every registry
+as of [#736](https://github.com/scttfrdmn/substrate/issues/736), so signing with one is
+no longer refused either way.
 
 One consequence worth knowing, because it decides what `GetCallerIdentity` reports. A
 key the registry holds but IAM does not know names a principal only when its signature

--- a/emulator/config.go
+++ b/emulator/config.go
@@ -28,6 +28,9 @@ type Config struct {
 	// Consistency controls eventual-consistency simulation.
 	Consistency ConsistencyCfg `mapstructure:"consistency"`
 
+	// Credentials controls the credential registry and SigV4 verification.
+	Credentials CredentialsCfg `mapstructure:"credentials"`
+
 	// Costs controls per-request cost estimation.
 	Costs CostCfg `mapstructure:"costs"`
 
@@ -288,6 +291,94 @@ func (c ConsistencyCfg) ToConsistencyConfig() (ConsistencyConfig, error) {
 	}, nil
 }
 
+// CredentialsCfg is the YAML-friendly configuration for the credential
+// registry. Use [CredentialsCfg.ToCredentialRegistry] to build the registry it
+// describes.
+type CredentialsCfg struct {
+	// Enabled gates the whole section. Default false, which wires no registry at
+	// all: every caller resolves to Account.Default and no signature is checked.
+	Enabled bool `mapstructure:"enabled"`
+
+	// VerifySignatures gates SigV4 enforcement. Default true, because this
+	// section has documented `enabled` as "enable SigV4 signature verification"
+	// since it was written and `enabled: true` on its own must keep meaning that.
+	//
+	// Set it to false for the combination [ServerOptions.VerifySignatures] opened
+	// up (#630): resolve an account per access key without requiring any request
+	// to be signed. That is the useful setting for a multi-account test, where the
+	// point of the registry is attribution rather than authentication.
+	//
+	// It does nothing while Enabled is false — there is no key material to check a
+	// signature against.
+	VerifySignatures bool `mapstructure:"verify_signatures"`
+
+	// Entries are the credentials the registry holds in addition to the built-in
+	// ones [NewCredentialRegistry] seeds. An entry whose AccessKeyID collides with
+	// a built-in replaces it, which is how a test moves AKIATEST12345678901 into
+	// another account.
+	Entries []CredentialEntryCfg `mapstructure:"entries"`
+}
+
+// CredentialEntryCfg is one credential in a [CredentialsCfg], the YAML-friendly
+// spelling of [CredentialEntry].
+type CredentialEntryCfg struct {
+	// AccessKeyID is the access key a request signs with. Required.
+	AccessKeyID string `mapstructure:"access_key_id"`
+
+	// SecretAccessKey is the secret the signature is checked against. Required
+	// when VerifySignatures is on, and pointless without it.
+	SecretAccessKey string `mapstructure:"secret_access_key"`
+
+	// AccountID is the account this credential resolves to. An empty value adopts
+	// Account.Default, which is the whole point of the field being optional: an
+	// entry that exists only to make a key signable needs no account of its own.
+	AccountID string `mapstructure:"account_id"`
+
+	// SessionToken is non-empty for a temporary credential. Substrate does not
+	// check it; it is recorded so a fixture can carry one.
+	SessionToken string `mapstructure:"session_token"`
+}
+
+// ToCredentialRegistry builds the [CredentialRegistry] this section describes, or
+// nil when Enabled is false. A nil registry is what [ServerOptions.Credentials]
+// takes to mean "attribute every caller to the default account".
+//
+// defaultAccount fills in an entry that names none; pass Account.Default.
+func (c CredentialsCfg) ToCredentialRegistry(defaultAccount string) *CredentialRegistry {
+	if !c.Enabled {
+		return nil
+	}
+	reg := NewCredentialRegistry()
+	c.RegisterInto(reg, defaultAccount)
+	return reg
+}
+
+// RegisterInto adds this section's entries to an existing registry, replacing any
+// entry with the same access key ID. It exists for SIGHUP reload, where the
+// registry the server holds cannot be swapped but can be added to — so a
+// consumer who appends an entry and signals the process reaches it without a
+// restart. Enabled and VerifySignatures are read once at startup and are not
+// reconsidered here.
+//
+// defaultAccount fills in an entry that names none; pass Account.Default.
+func (c CredentialsCfg) RegisterInto(reg *CredentialRegistry, defaultAccount string) {
+	if reg == nil {
+		return
+	}
+	for _, e := range c.Entries {
+		accountID := e.AccountID
+		if accountID == "" {
+			accountID = defaultAccount
+		}
+		reg.Register(CredentialEntry{
+			AccessKeyID:     e.AccessKeyID,
+			SecretAccessKey: e.SecretAccessKey,
+			AccountID:       accountID,
+			SessionToken:    e.SessionToken,
+		})
+	}
+}
+
 // CostCfg is the YAML-friendly configuration for cost tracking.
 // Use [CostCfg.ToCostConfig] to convert it for use with [NewCostController].
 type CostCfg struct {
@@ -505,6 +596,12 @@ func DefaultConfig() *Config {
 			PropagationDelay: "2s",
 			AffectedServices: []string{"iam"},
 		},
+		Credentials: CredentialsCfg{
+			Enabled: false,
+			// True so that `credentials: {enabled: true}` alone means what the
+			// section has always documented it to mean (#736).
+			VerifySignatures: true,
+		},
 		Costs: CostCfg{
 			Enabled: true,
 		},
@@ -581,6 +678,8 @@ func LoadConfig(path string) (*Config, error) {
 	v.SetDefault("consistency.enabled", defaults.Consistency.Enabled)
 	v.SetDefault("consistency.propagation_delay", defaults.Consistency.PropagationDelay)
 	v.SetDefault("consistency.affected_services", defaults.Consistency.AffectedServices)
+	v.SetDefault("credentials.enabled", defaults.Credentials.Enabled)
+	v.SetDefault("credentials.verify_signatures", defaults.Credentials.VerifySignatures)
 	v.SetDefault("costs.enabled", defaults.Costs.Enabled)
 	v.SetDefault("metrics.enabled", defaults.Metrics.Enabled)
 	v.SetDefault("metrics.path", defaults.Metrics.Path)
@@ -672,6 +771,33 @@ func Validate(cfg *Config) error {
 		if _, err := time.ParseDuration(cfg.Consistency.PropagationDelay); err != nil {
 			return fmt.Errorf("consistency.propagation_delay %q is not a valid duration: %w",
 				cfg.Consistency.PropagationDelay, err)
+		}
+	}
+
+	// Entries are checked whether or not the section is enabled: a typo in a
+	// credential should not stay hidden until someone flips the flag, and the
+	// registry's Register would silently accept every one of these mistakes.
+	seenAccessKeys := make(map[string]int, len(cfg.Credentials.Entries))
+	for i, entry := range cfg.Credentials.Entries {
+		if entry.AccessKeyID == "" {
+			return fmt.Errorf("credentials.entries[%d].access_key_id must not be empty", i)
+		}
+		if first, dup := seenAccessKeys[entry.AccessKeyID]; dup {
+			return fmt.Errorf("credentials.entries[%d].access_key_id %q duplicates entries[%d]",
+				i, entry.AccessKeyID, first)
+		}
+		seenAccessKeys[entry.AccessKeyID] = i
+		// An empty account_id adopts account.default, so only a non-empty one can
+		// be wrong. A malformed one lands in every ARN the caller signing with this
+		// key gets back.
+		if entry.AccountID != "" && !isAccountIDPattern(entry.AccountID) {
+			return fmt.Errorf("credentials.entries[%d].account_id %q is not valid; an AWS account ID is 12 digits",
+				i, entry.AccountID)
+		}
+		// Only refused when it would actually be used: an entry that exists to
+		// attribute an account needs no secret while verification is off.
+		if cfg.Credentials.Enabled && cfg.Credentials.VerifySignatures && entry.SecretAccessKey == "" {
+			return fmt.Errorf("credentials.entries[%d].secret_access_key must not be empty when credentials.verify_signatures is true", i)
 		}
 	}
 

--- a/emulator/config.go
+++ b/emulator/config.go
@@ -353,6 +353,33 @@ func (c CredentialsCfg) ToCredentialRegistry(defaultAccount string) *CredentialR
 	return reg
 }
 
+// StartupOnlyDiffers reports whether the two settings a reload cannot apply
+// differ between c and other.
+//
+// [CredentialsCfg.RegisterInto] can add an entry to the registry a running server
+// holds, but nothing can hand it a registry it was not built with or change
+// whether it verifies. A caller that reloads configuration uses this to say so
+// rather than appearing to have applied the change.
+func (c CredentialsCfg) StartupOnlyDiffers(other CredentialsCfg) bool {
+	return c.Enabled != other.Enabled || c.VerifySignatures != other.VerifySignatures
+}
+
+// ToServerCredentials returns what [ServerOptions.Credentials] and
+// [ServerOptions.VerifySignatures] should be set to for this section — the whole
+// of what a server has to do to honor it.
+//
+// The second return is gated on the registry rather than being VerifySignatures
+// copied out: that field defaults to true so `enabled: true` alone enforces
+// signatures, so passing it through unconditionally would hand [NewServer]
+// verify-without-registry on every default startup and log its downgrade warning
+// at a consumer who configured nothing.
+//
+// defaultAccount fills in an entry that names none; pass Account.Default.
+func (c CredentialsCfg) ToServerCredentials(defaultAccount string) (*CredentialRegistry, bool) {
+	reg := c.ToCredentialRegistry(defaultAccount)
+	return reg, reg != nil && c.VerifySignatures
+}
+
 // RegisterInto adds this section's entries to an existing registry, replacing any
 // entry with the same access key ID. It exists for SIGHUP reload, where the
 // registry the server holds cannot be swapped but can be added to — so a

--- a/emulator/config_credentials_test.go
+++ b/emulator/config_credentials_test.go
@@ -1,0 +1,390 @@
+package emulator_test
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// substrate.yaml's credentials: section is read (#736).
+//
+// It was documented from the beginning and Config had no field for it, so viper
+// read the keys and nothing consumed them: a consumer who enabled it got no
+// registry, no verification and no error. These tests cover the parse, the
+// refusals Validate owes, and — the part that decides whether the section is
+// actually wired — a server built from a config file behaving accordingly.
+
+// credentialsYAML writes a substrate.yaml holding body and returns its path.
+func credentialsYAML(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "substrate.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	return path
+}
+
+// serverFromConfig builds a server wired the way cmd/substrate does, and returns
+// the capture plugin a request lands on. The two ServerOptions fields below are
+// the whole of that wiring, which is what makes this the behavior test #736
+// asks for rather than a restatement of ToCredentialRegistry.
+func serverFromConfig(t *testing.T, cfg *emulator.Config) (*emulator.Server, *principalCapturePlugin) {
+	t.Helper()
+	registry := emulator.NewPluginRegistry()
+	capture := &principalCapturePlugin{}
+	registry.Register(capture)
+	state := emulator.NewMemoryStateManager()
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	store := emulator.NewEventStore(cfg.EventStore.ToEventStoreConfig())
+	tc := emulator.NewTimeController(time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC))
+
+	reg := cfg.Credentials.ToCredentialRegistry(cfg.Account.Default)
+	srv := emulator.NewServer(*cfg, registry, store, state, tc, logger, emulator.ServerOptions{
+		Credentials:      reg,
+		VerifySignatures: reg != nil && cfg.Credentials.VerifySignatures,
+	})
+	return srv, capture
+}
+
+// signedDynamoCall issues the same request principalDynamoCall does, but signed
+// for real, so a 200 means the signature verified rather than that verification
+// was skipped.
+func signedDynamoCall(t *testing.T, srv *emulator.Server, accessKey, secretKey string) *http.Response {
+	t.Helper()
+	const (
+		host     = "dynamodb.us-east-1.amazonaws.com"
+		dateTime = "20250101T120000Z"
+	)
+	body := []byte(`{}`)
+	authHeader := computeSigV4Signature(t, http.MethodPost, "http://"+host+"/", body,
+		accessKey, secretKey, "us-east-1", "dynamodb", dateTime)
+
+	r := httptest.NewRequest(http.MethodPost, "http://"+host+"/", bytes.NewReader(body))
+	r.Host = host
+	r.Header.Set("X-Amz-Target", "DynamoDB_20120810.GetItem")
+	r.Header.Set("X-Amz-Date", dateTime)
+	r.Header.Set("Authorization", authHeader)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	return w.Result()
+}
+
+func TestCredentialsCfg_Defaults(t *testing.T) {
+	cfg := emulator.DefaultConfig()
+	assert.False(t, cfg.Credentials.Enabled, "the section is off unless asked for")
+	assert.True(t, cfg.Credentials.VerifySignatures,
+		"enabled: true alone must keep meaning what the section documented")
+	assert.Empty(t, cfg.Credentials.Entries)
+}
+
+func TestLoadConfig_CredentialsSection(t *testing.T) {
+	path := credentialsYAML(t, `
+credentials:
+  enabled: true
+  entries:
+    - access_key_id: "AKIAEXAMPLE00000001"
+      secret_access_key: "secret-one"
+      account_id: "111122223333"
+    - access_key_id: "AKIAEXAMPLE00000002"
+      secret_access_key: "secret-two"
+`)
+	cfg, err := emulator.LoadConfig(path)
+	require.NoError(t, err)
+
+	assert.True(t, cfg.Credentials.Enabled)
+	assert.True(t, cfg.Credentials.VerifySignatures, "unset means the documented default")
+	require.Len(t, cfg.Credentials.Entries, 2)
+	assert.Equal(t, "AKIAEXAMPLE00000001", cfg.Credentials.Entries[0].AccessKeyID)
+	assert.Equal(t, "secret-one", cfg.Credentials.Entries[0].SecretAccessKey)
+	assert.Equal(t, "111122223333", cfg.Credentials.Entries[0].AccountID)
+	assert.Empty(t, cfg.Credentials.Entries[1].AccountID, "optional, and adopts account.default")
+}
+
+func TestLoadConfig_CredentialsVerificationCanBeTurnedOff(t *testing.T) {
+	// The combination #630 opened up. A viper default of true is easy to write in a
+	// way that cannot be overridden back to false, so this is worth pinning.
+	path := credentialsYAML(t, `
+credentials:
+  enabled: true
+  verify_signatures: false
+`)
+	cfg, err := emulator.LoadConfig(path)
+	require.NoError(t, err)
+	assert.True(t, cfg.Credentials.Enabled)
+	assert.False(t, cfg.Credentials.VerifySignatures)
+}
+
+func TestCredentialsCfg_ToCredentialRegistry(t *testing.T) {
+	t.Run("disabled builds nothing", func(t *testing.T) {
+		cfg := emulator.CredentialsCfg{
+			Entries: []emulator.CredentialEntryCfg{{AccessKeyID: "AKIAEXAMPLE00000001"}},
+		}
+		assert.Nil(t, cfg.ToCredentialRegistry("123456789012"),
+			"a nil registry is how the server is told to attribute everyone to the default")
+	})
+
+	t.Run("entries and built-ins coexist", func(t *testing.T) {
+		cfg := emulator.CredentialsCfg{
+			Enabled: true,
+			Entries: []emulator.CredentialEntryCfg{{
+				AccessKeyID:     "AKIAEXAMPLE00000001",
+				SecretAccessKey: "secret-one",
+				AccountID:       "111122223333",
+				SessionToken:    "token-one",
+			}},
+		}
+		reg := cfg.ToCredentialRegistry("123456789012")
+		require.NotNil(t, reg)
+
+		entry, ok := reg.Lookup("AKIAEXAMPLE00000001")
+		require.True(t, ok)
+		assert.Equal(t, "111122223333", entry.AccountID)
+		assert.Equal(t, "secret-one", entry.SecretAccessKey)
+		assert.Equal(t, "token-one", entry.SessionToken)
+
+		builtin, ok := reg.Lookup("AKIATEST12345678901")
+		require.True(t, ok, "the built-ins are not displaced by a configured entry")
+		assert.Equal(t, "123456789012", builtin.AccountID)
+	})
+
+	t.Run("an empty account_id adopts the default", func(t *testing.T) {
+		cfg := emulator.CredentialsCfg{
+			Enabled: true,
+			Entries: []emulator.CredentialEntryCfg{{AccessKeyID: "AKIAEXAMPLE00000001"}},
+		}
+		entry, ok := cfg.ToCredentialRegistry("210987654321").Lookup("AKIAEXAMPLE00000001")
+		require.True(t, ok)
+		assert.Equal(t, "210987654321", entry.AccountID)
+	})
+
+	t.Run("a configured entry replaces a built-in", func(t *testing.T) {
+		// The route to moving the built-in key into another account, and the reason
+		// the built-ins are seeded first rather than last.
+		cfg := emulator.CredentialsCfg{
+			Enabled: true,
+			Entries: []emulator.CredentialEntryCfg{{
+				AccessKeyID:     "AKIATEST12345678901",
+				SecretAccessKey: "another-secret",
+				AccountID:       "111122223333",
+			}},
+		}
+		entry, ok := cfg.ToCredentialRegistry("123456789012").Lookup("AKIATEST12345678901")
+		require.True(t, ok)
+		assert.Equal(t, "111122223333", entry.AccountID)
+		assert.Equal(t, "another-secret", entry.SecretAccessKey)
+	})
+}
+
+func TestCredentialsCfg_RegisterInto(t *testing.T) {
+	// SIGHUP reload cannot swap the registry the server holds, so it adds to it.
+	reg := emulator.NewCredentialRegistry()
+	cfg := emulator.CredentialsCfg{
+		Enabled: true,
+		Entries: []emulator.CredentialEntryCfg{{AccessKeyID: "AKIARELOADED00000001"}},
+	}
+	cfg.RegisterInto(reg, "111122223333")
+
+	entry, ok := reg.Lookup("AKIARELOADED00000001")
+	require.True(t, ok)
+	assert.Equal(t, "111122223333", entry.AccountID)
+
+	assert.NotPanics(t, func() { cfg.RegisterInto(nil, "111122223333") },
+		"the server may hold no registry at all")
+}
+
+func TestValidate_CredentialsEntries(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*emulator.Config)
+		wantErr string
+	}{
+		{
+			name: "empty access key id",
+			mutate: func(c *emulator.Config) {
+				c.Credentials.Enabled = true
+				c.Credentials.Entries = []emulator.CredentialEntryCfg{
+					{SecretAccessKey: "secret"},
+				}
+			},
+			wantErr: "credentials.entries[0].access_key_id",
+		},
+		{
+			name: "account id that is not an account id",
+			mutate: func(c *emulator.Config) {
+				c.Credentials.Enabled = true
+				c.Credentials.Entries = []emulator.CredentialEntryCfg{
+					{AccessKeyID: "AKIAEXAMPLE00000001", SecretAccessKey: "s", AccountID: "1234"},
+				}
+			},
+			wantErr: "12 digits",
+		},
+		{
+			name: "duplicate access key id",
+			mutate: func(c *emulator.Config) {
+				c.Credentials.Enabled = true
+				c.Credentials.Entries = []emulator.CredentialEntryCfg{
+					{AccessKeyID: "AKIAEXAMPLE00000001", SecretAccessKey: "s"},
+					{AccessKeyID: "AKIAEXAMPLE00000001", SecretAccessKey: "t"},
+				}
+			},
+			wantErr: "duplicates entries[0]",
+		},
+		{
+			name: "missing secret while verifying",
+			mutate: func(c *emulator.Config) {
+				c.Credentials.Enabled = true
+				c.Credentials.Entries = []emulator.CredentialEntryCfg{
+					{AccessKeyID: "AKIAEXAMPLE00000001"},
+				}
+			},
+			wantErr: "secret_access_key",
+		},
+		{
+			name: "a malformed entry is refused even with the section off",
+			mutate: func(c *emulator.Config) {
+				c.Credentials.Entries = []emulator.CredentialEntryCfg{
+					{AccessKeyID: "AKIAEXAMPLE00000001", AccountID: "not-an-account"},
+				}
+			},
+			wantErr: "12 digits",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := emulator.DefaultConfig()
+			tt.mutate(cfg)
+			err := emulator.Validate(cfg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestValidate_CredentialsSecretOptionalWithoutVerification(t *testing.T) {
+	// An entry that exists only to say which account a key belongs to has no
+	// signature to satisfy, so requiring a secret would be noise.
+	cfg := emulator.DefaultConfig()
+	cfg.Credentials.Enabled = true
+	cfg.Credentials.VerifySignatures = false
+	cfg.Credentials.Entries = []emulator.CredentialEntryCfg{
+		{AccessKeyID: "AKIAEXAMPLE00000001", AccountID: "111122223333"},
+	}
+	assert.NoError(t, emulator.Validate(cfg))
+}
+
+func TestConfig_CredentialsEnabled_AttributesAndEnforces(t *testing.T) {
+	path := credentialsYAML(t, `
+credentials:
+  enabled: true
+  entries:
+    - access_key_id: "AKIAEXAMPLE00000001"
+      secret_access_key: "secret-one"
+      account_id: "111122223333"
+`)
+	cfg, err := emulator.LoadConfig(path)
+	require.NoError(t, err)
+	srv, capture := serverFromConfig(t, cfg)
+
+	// A key the file names, signed with the secret the file gives it, verifies and
+	// resolves to the account the file gives it.
+	resp := signedDynamoCall(t, srv, "AKIAEXAMPLE00000001", "secret-one")
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.True(t, capture.called)
+	assert.Equal(t, "111122223333", capture.accountID)
+
+	// The same key with the wrong secret does not, which is what distinguishes
+	// verification from a table lookup.
+	srvBad, captureBad := serverFromConfig(t, cfg)
+	respBad := signedDynamoCall(t, srvBad, "AKIAEXAMPLE00000001", "not-the-secret")
+	bodyBad, err := io.ReadAll(respBad.Body)
+	require.NoError(t, err)
+	require.NoError(t, respBad.Body.Close())
+	assert.Equal(t, http.StatusForbidden, respBad.StatusCode)
+	assert.Contains(t, string(bodyBad), "SignatureDoesNotMatch")
+	assert.False(t, captureBad.called)
+
+	// A key it does not name is refused, which is the enforcement half.
+	srv2, capture2 := serverFromConfig(t, cfg)
+	resp2 := principalDynamoCall(t, srv2, "AKIANEVERREGISTERED1")
+	require.NoError(t, resp2.Body.Close())
+	assert.Equal(t, http.StatusForbidden, resp2.StatusCode)
+	assert.False(t, capture2.called)
+}
+
+func TestConfig_CredentialsEnabled_AcceptsTheDocumentedCredentials(t *testing.T) {
+	// The reason NewCredentialRegistry seeds three keys. A consumer who follows
+	// README.md, docs/endpoint-configuration.md or docs/testing-guide.md and then
+	// enables this section must not start getting InvalidClientTokenId 403s.
+	path := credentialsYAML(t, "credentials:\n  enabled: true\n")
+	cfg, err := emulator.LoadConfig(path)
+	require.NoError(t, err)
+
+	const exampleSecret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	tests := []struct {
+		accessKey, secretKey, source string
+	}{
+		{"test", "test", "README.md, docs/endpoint-configuration.md"},
+		{"AKIAIOSFODNN7EXAMPLE", exampleSecret, "docs/testing-guide.md, test/e2e"},
+		{"AKIATEST12345678901", exampleSecret, "NewCredentialRegistry's original entry"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.accessKey, func(t *testing.T) {
+			srv, capture := serverFromConfig(t, cfg)
+			resp := signedDynamoCall(t, srv, tt.accessKey, tt.secretKey)
+			require.NoError(t, resp.Body.Close())
+			assert.Equal(t, http.StatusOK, resp.StatusCode, "documented in %s", tt.source)
+			assert.True(t, capture.called)
+		})
+	}
+}
+
+func TestConfig_CredentialsWithoutVerification_AcceptsAnyKey(t *testing.T) {
+	path := credentialsYAML(t, `
+credentials:
+  enabled: true
+  verify_signatures: false
+  entries:
+    - access_key_id: "AKIAEXAMPLE00000001"
+      account_id: "111122223333"
+`)
+	cfg, err := emulator.LoadConfig(path)
+	require.NoError(t, err)
+
+	srv, capture := serverFromConfig(t, cfg)
+	resp := principalDynamoCall(t, srv, "AKIAEXAMPLE00000001")
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.True(t, capture.called)
+	assert.Equal(t, "111122223333", capture.accountID, "attribution without authentication")
+
+	srv2, capture2 := serverFromConfig(t, cfg)
+	resp2 := principalDynamoCall(t, srv2, "AKIANEVERREGISTERED1")
+	require.NoError(t, resp2.Body.Close())
+	assert.Equal(t, http.StatusOK, resp2.StatusCode, "nothing is being enforced")
+	require.True(t, capture2.called)
+	assert.Equal(t, cfg.Account.Default, capture2.accountID)
+}
+
+func TestConfig_CredentialsDisabled_ChangesNothing(t *testing.T) {
+	// The shipped default. Every caller lands in account.default and no signature
+	// is checked, which is what every existing deployment sees.
+	cfg := emulator.DefaultConfig()
+	srv, capture := serverFromConfig(t, cfg)
+
+	resp := principalDynamoCall(t, srv, "AKIANEVERREGISTERED1")
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.True(t, capture.called)
+	assert.Equal(t, cfg.Account.Default, capture.accountID)
+	assert.Nil(t, capture.principal)
+}

--- a/emulator/config_credentials_test.go
+++ b/emulator/config_credentials_test.go
@@ -201,6 +201,82 @@ func TestCredentialsCfg_RegisterInto(t *testing.T) {
 		"the server may hold no registry at all")
 }
 
+func TestCredentialsCfg_ToServerCredentials(t *testing.T) {
+	// The whole of what the shipped binary has to decide, so the four
+	// combinations are decided here rather than in an untestable RunE closure.
+	tests := []struct {
+		name          string
+		cfg           emulator.CredentialsCfg
+		wantRegistry  bool
+		wantVerifying bool
+	}{
+		{
+			name:          "the shipped default",
+			cfg:           emulator.CredentialsCfg{Enabled: false, VerifySignatures: true},
+			wantRegistry:  false,
+			wantVerifying: false, // never verify-without-registry, whatever the flag says
+		},
+		{
+			name:          "off in both",
+			cfg:           emulator.CredentialsCfg{Enabled: false, VerifySignatures: false},
+			wantRegistry:  false,
+			wantVerifying: false,
+		},
+		{
+			name:          "enabled means what the section has always documented",
+			cfg:           emulator.CredentialsCfg{Enabled: true, VerifySignatures: true},
+			wantRegistry:  true,
+			wantVerifying: true,
+		},
+		{
+			name:          "attribution without authentication",
+			cfg:           emulator.CredentialsCfg{Enabled: true, VerifySignatures: false},
+			wantRegistry:  true,
+			wantVerifying: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg, verifying := tt.cfg.ToServerCredentials("111122223333")
+			assert.Equal(t, tt.wantRegistry, reg != nil)
+			assert.Equal(t, tt.wantVerifying, verifying)
+		})
+	}
+}
+
+func TestCredentialsCfg_StartupOnlyDiffers(t *testing.T) {
+	on := emulator.CredentialsCfg{Enabled: true, VerifySignatures: true}
+
+	tests := []struct {
+		name  string
+		newer emulator.CredentialsCfg
+		want  bool
+	}{
+		{
+			name:  "an appended entry is applied by a reload",
+			newer: emulator.CredentialsCfg{Enabled: true, VerifySignatures: true, Entries: []emulator.CredentialEntryCfg{{AccessKeyID: "AKIARELOADED00000001"}}},
+			want:  false,
+		},
+		{
+			name:  "turning the section off is not",
+			newer: emulator.CredentialsCfg{Enabled: false, VerifySignatures: true},
+			want:  true,
+		},
+		{
+			name:  "nor is turning verification off",
+			newer: emulator.CredentialsCfg{Enabled: true, VerifySignatures: false},
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.newer.StartupOnlyDiffers(on))
+		})
+	}
+}
+
 func TestValidate_CredentialsEntries(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/emulator/credentials.go
+++ b/emulator/credentials.go
@@ -39,17 +39,46 @@ type CredentialRegistry struct {
 // defaultTestAccessKeyID is the access key for the built-in test credential.
 const defaultTestAccessKeyID = "AKIATEST12345678901"
 
-// defaultTestSecretKey is the secret for the built-in test credential.
+// defaultTestSecretKey is the secret for the built-in test credential. It is
+// AWS's own documented example secret, which is also what substrate's docs pair
+// with documentedExampleAccessKeyID.
 const defaultTestSecretKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 
+// documentedShortAccessKeyID is the access key README.md and
+// docs/endpoint-configuration.md tell a caller to configure, paired with an
+// identical secret.
+const documentedShortAccessKeyID = "test"
+
+// documentedShortSecretKey is the secret paired with documentedShortAccessKeyID.
+const documentedShortSecretKey = "test"
+
+// documentedExampleAccessKeyID is AWS's canonical example access key, which
+// substrate's testing guide and every e2e check sign with.
+const documentedExampleAccessKeyID = "AKIAIOSFODNN7EXAMPLE"
+
 // NewCredentialRegistry creates a CredentialRegistry pre-loaded with the
-// built-in test credential (AKIATEST12345678901 → account 123456789012).
+// credentials substrate's own documentation tells a caller to use, each bound to
+// account 123456789012: AKIATEST12345678901, "test" (README.md,
+// docs/endpoint-configuration.md) and AKIAIOSFODNN7EXAMPLE (docs/testing-guide.md,
+// test/e2e).
+//
+// All three are seeded because a registry is what
+// [ServerOptions.VerifySignatures] checks a signature against, and a key it does
+// not hold is InvalidClientTokenId 403 (#736). A registry that omitted them would
+// make substrate's own quickstart wrong the moment a consumer set
+// credentials.enabled in substrate.yaml — the caller would have followed the
+// documentation exactly and been refused. Their secrets are documented too, so
+// signing with them still proves the caller holds the secret; seeding them
+// widens who can sign, not what a signature has to satisfy.
 func NewCredentialRegistry() *CredentialRegistry {
 	r := &CredentialRegistry{store: make(map[string]CredentialEntry)}
-	r.store[defaultTestAccessKeyID] = CredentialEntry{
-		AccessKeyID:     defaultTestAccessKeyID,
-		SecretAccessKey: defaultTestSecretKey,
-		AccountID:       defaultAccountID,
+	for _, e := range []CredentialEntry{
+		{AccessKeyID: defaultTestAccessKeyID, SecretAccessKey: defaultTestSecretKey},
+		{AccessKeyID: documentedShortAccessKeyID, SecretAccessKey: documentedShortSecretKey},
+		{AccessKeyID: documentedExampleAccessKeyID, SecretAccessKey: defaultTestSecretKey},
+	} {
+		e.AccountID = defaultAccountID
+		r.store[e.AccessKeyID] = e
 	}
 	return r
 }

--- a/substrate.yaml.example
+++ b/substrate.yaml.example
@@ -61,36 +61,50 @@ consistency:
   affected_services:
     - "iam"
 
-# Credential registry for multi-account isolation and SigV4 signature verification.
-# When enabled, every incoming request must carry a valid AWS4-HMAC-SHA256 Authorization
-# header signed with a key registered here. Omitting this section disables both credential
-# resolution and signature verification (all requests are accepted, backward-compatible default).
+# Credential registry: which account an access key belongs to, and whether its
+# signature is checked. Omitting the section (the default) resolves every caller to
+# account.default and checks nothing, which is the backward-compatible behaviour.
 #
-# NOT YET READ FROM THIS FILE (#736). Config has no field for this section, so the
-# shipped `substrate server` discards it and starts with verification off. The
-# registry itself is real — reach it in-process through ServerOptions.Credentials.
-# Wiring it here waits on #630, because a registry also switches SigV4 enforcement
-# on, which would 403 substrate's own documented test/test credentials.
+# An unsigned request is never refused, even with verification on — a caller that
+# sends no Authorization header has nothing to verify, so SigV4 enforcement bounds
+# who may sign rather than requiring that everyone does.
 credentials:
-  # Set to true to enable SigV4 signature verification.
+  # Enables the registry. With verify_signatures left at its default, a request
+  # carrying an Authorization header must be signed with a key listed below (or one
+  # of the built-ins) or it answers InvalidClientTokenId 403.
   # enabled: true
-  # Static credentials. Production deployments can load these from Secrets Manager or env vars.
+
+  # Default true, which is what this section has always documented `enabled` to
+  # mean. Set it to false to attribute accounts without authenticating anyone —
+  # useful for a multi-account test, where the registry answers "which account"
+  # and no call needs a real signature.
+  # verify_signatures: true
+
+  # Static credentials, in addition to the built-in ones every registry seeds:
+  # AKIATEST12345678901, "test" and AKIAIOSFODNN7EXAMPLE, all in account.default,
+  # so the credentials this project's own docs tell you to configure keep working
+  # with verification on. Reusing one of those access key IDs below replaces it.
+  #
+  # account_id is optional and falls back to account.default. secret_access_key is
+  # required while verify_signatures is on and unused otherwise.
   # entries:
   #   - access_key_id: "AKIAEXAMPLE00000001"
   #     secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
   #     account_id: "111122223333"
 
-# Cross-service IAM authorization.
-# When enabled, every request whose caller principal has been resolved via the credential
-# registry is checked against that principal's attached managed policies, inline policies,
-# and permission boundary before the request reaches the plugin layer.
+# Cross-service IAM authorization is ALWAYS ON and has no flag (#736).
 #
-# NOT YET READ FROM THIS FILE (#736), for the same reason as credentials: above.
-# AuthController is reachable in-process through ServerOptions.Auth, which is how
-# StartTestServer wires it.
-auth:
-  # Set to true to enable cross-service IAM enforcement.
-  # enabled: true
+# There is nothing to enable: `substrate server` always builds an AuthController,
+# and enforcement is opt-in by existence instead — a request is checked against
+# attached policies, inline policies and a permission boundary only once its access
+# key resolves to an IAM entity substrate actually holds. A caller that never
+# created a user or role resolves to no principal and is authorized against
+# nothing, so there is no configuration that turns enforcement "off" for it and
+# none that turns it "on" without creating the principal first.
+#
+# A flag here would therefore overpromise: `auth.enabled: false` could not disable
+# IAM's own authorization, which resolves against state directly rather than
+# through the controller.
 
 # Per-request cost estimation.
 # Built-in table: IAM/STS=$0, s3/PutObject=$0.000005, s3/GetObject=$0.0000004,


### PR DESCRIPTION
`substrate.yaml`'s `credentials:` section was documented from the beginning — an `enabled` flag and a list of `entries` carrying `access_key_id` / `secret_access_key` / `account_id` — and `Config` had no field for any of it. Viper read the keys, nothing consumed them, and a consumer who configured a registry got no registry, no verification and **no error**. `CredentialRegistry` was reachable only in-process through `ServerOptions`.

The fail-before run makes the point better than prose: against a `main` binary, all eight sections of the live script answer identically to the no-config case.

| | `main` | this branch |
|---|---|---|
| listed key `AKIAEXAMPLE00000001` → account `111122223333` | `123456789012` / `:root` | `111122223333` / `user/AKIAEXAMPLE00000001` |
| same key, wrong secret | 200 | `SignatureDoesNotMatch` |
| key the file does not name | 200 | `InvalidClientTokenId` |
| `account_id: "1234"` | starts anyway, row dropped | `load config: credentials.entries[0].account_id "1234" is not valid; an AWS account ID is 12 digits` |
| duplicate access key | starts anyway, row silently replaced | `load config: credentials.entries[1].access_key_id … duplicates entries[0]` |
| entry appended + `SIGHUP` | 403 before and after | 403 before, `210987654321` after |

## `verify_signatures`

New, beside `enabled`, defaulting to **true** — because the section has documented `enabled` as *"enable SigV4 signature verification"* since it was written and `enabled: true` on its own has to keep meaning that. Setting it to `false` is the combination #630 opened up: resolve an account per access key without authenticating anyone, which is what a multi-account test usually wants.

It is gated on the registry in `main.go` rather than passed straight through. Because the default is `true`, a bare copy would hand `NewServer` verify-without-registry on every default startup and log its downgrade warning at a consumer who configured nothing.

## `NewCredentialRegistry` seeds three credentials, not one

`AKIATEST12345678901`, `test`/`test` and `AKIAIOSFODNN7EXAMPLE`, all in the default account. Without this, turning verification on would make substrate's own quickstart wrong: a consumer who followed `README.md:221`, `docs/endpoint-configuration.md:58` or `docs/testing-guide.md:549` exactly would be answered `InvalidClientTokenId` 403. Their secrets are documented too, so signing with one still proves the caller holds the secret — this widens *who may sign*, not *what a signature has to satisfy*. An `entries:` row reusing one of those access key IDs replaces it, which is how a test moves the built-in key into another account.

Verified live with verification on: `test`/`test`, `AKIAIOSFODNN7EXAMPLE` and `AKIATEST12345678901` all return 200 and account `123456789012`.

## `auth:` is removed from the example file rather than wired

The issue's expectation there is wrong, and this records why. `substrate server` already builds an `AuthController` unconditionally (`main.go:137`), and `IAMPlugin.authorize` holds no controller at all — it resolves against `p.state` directly — so `auth.enabled: false` could never have meant "off". Enforcement is opt-in by *existence*: a request is checked only once its access key resolves to an IAM entity substrate holds. A flag would have overpromised in both directions, so the example file now says there is nothing to enable and why.

The stale claim at the top of the old `credentials:` block is gone too — it said enabling the section makes every request carry a valid SigV4 header, and `VerifySigV4` passes an unsigned one.

## Acceptance criteria

- [x] `Config` grows tags for the section and `LoadConfig` sets its defaults
- [x] `cmd/substrate/main.go` passes the registry through `ServerOptions`
- [x] `Validate` refuses a malformed entry rather than silently dropping it — four refusals, checked whether or not the section is enabled
- [x] The section left unwired is marked as such — `auth:` now states it is always on, with the mechanism
- [x] A test asserts a config file enabling the section produces a server that behaves accordingly — `emulator/config_credentials_test.go`, including properly signed requests so a 200 means the signature verified rather than that verification was skipped

## Verification

```
gofmt -l . && go build ./... && go vet ./... && golangci-lint run ./...   # 0 issues
make test                                                                 # exit 0, no FAIL
make coverage                                                             # emulator 83.4%, total 82.8%
make docs-reference docs-reference-check docs-versions                    # exit 0
npm --prefix docs run build                                              # exit 0, anchor diff empty
go vet -C test/e2e ./... && go test -C test/e2e ./...                     # ok 0.689s
```

## Compatibility

`credentials.enabled` ships `false`, which wires no registry, attributes every caller to `account.default` and checks no signature — nothing changes for an existing deployment. On turning it on *with* verification, expect one visible difference: a verified key IAM does not know names itself as the principal, so `GetCallerIdentity` reports `arn:aws:iam::111122223333:user/AKIAEXAMPLE00000001` rather than `…:root`. That is #630's rule, the ARN still resolves to no policies, and `verify_signatures: false` keeps the `…:root` answer.

Closes #736
