### PR TITLE
fix(iam): an IAM entity belongs to an account, not to the emulator (#737)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to no policies. With `verify_signatures: false` the answer stays `…:root`.
 
 ### Fixed
+- **An IAM entity belonged to the emulator rather than to an account** (#737). Every IAM state
+  key was account-blind — a user lived at `user:{name}`, a role's attachments at
+  `role_policies:{name}` — so one server held one IAM directory no matter how many accounts it
+  served. Three things followed, all of them reachable from the shipped binary now that a
+  `credentials:` block can put two access keys in two accounts (#736). Two accounts could not
+  both hold a role called `deploy`: the second `CreateRole` answered `EntityAlreadyExists`.
+  `ListUsers` in one account reported another account's users, and `ListPolicies` scanned every
+  account's policies even though a policy ARN already named its owner. And `resolveIAMEntity`
+  discarded the account in the principal ARN it was handed, so a cross-account principal was
+  authorized against whatever same-named entity the request's own account happened to hold.
+
+  Every key now reads `{kind}:{account}/{rest}` — the shape DynamoDB's `table:{account}/{name}`
+  and the other account-aware plugins already used, with the account *after* the kind so a
+  per-account listing is one prefix scan rather than a full sweep and filter. The account comes
+  from the ARN wherever an ARN is the authority: `resolveIAMEntity` and `SimulatePrincipalPolicy`
+  take it from the principal ARN, `AssumeRole` reads the role named by `RoleArn` from that ARN's
+  account rather than the caller's — which is the case cross-account assumption exists for — and
+  a policy record is addressed by the account inside its own ARN, so a caller holding only an
+  attachment's ARN can still reach it without knowing whose request it is.
+
+  The ~90 sites that used to concatenate these strings inline now go through builders in one
+  file, because a missed one is invisible: it compiles, it reads and writes state, and it simply
+  addresses a key nothing else uses. Two of them were invisible to a grep for `iamNamespace`
+  because they spelled the namespace `"iam"` as a literal, inside `StackDeployer`'s drift
+  comparison. One key deliberately keeps no account: `accesskey:{id}`, because an access key ID
+  is what *determines* an account and a signed request resolves the record before any account is
+  known. That account is a field on the record instead, and a record written before this release
+  has it empty and falls back to the account the request resolved to — which is the account it
+  always used.
+
 - **An EC2 operation naming several resources was decided against the first alone** (#744).
   `TerminateInstances` with three `InstanceId.N` was authorized against `InstanceId.1`'s ARN
   and `InstanceId.1`'s tags; the other two were not authorized at all. So a policy allowing

--- a/docs/services.md
+++ b/docs/services.md
@@ -302,14 +302,39 @@ because several plugins prefix their state keys with the account —
 under the old account is unreachable** after upgrading. Re-seed it, or set
 `account.default: "000000000000"` to read it back.
 
-### What is deliberately not covered
+### IAM entities belong to an account
 
-- **IAM's state keys are account-blind.** A user is stored under `user:{name}` with no
-  account in the key, so `resolveIAMEntity` resolves a principal by name across
-  accounts and two accounts cannot both hold a role of the same name. Filed as
-  [#737](https://github.com/scttfrdmn/substrate/issues/737). It is now reachable from
-  the shipped binary as well as in-process, since a `credentials:` block can put two
-  access keys in two accounts.
+Every IAM state key carries the account it belongs to —
+`user:{account}/{name}`, `role_policies:{account}/{name}`,
+`group_inline:{account}/{group}:{policy}` — the same `{kind}:{account}/{rest}` shape
+DynamoDB and the other account-aware plugins already used. Before
+[#737](https://github.com/scttfrdmn/substrate/issues/737) they did not, and an IAM
+entity belonged to the emulator rather than to an account. Three things follow, all of
+them now observable:
+
+- **Two accounts can hold the same name.** `CreateRole deploy` in a second account
+  answered `EntityAlreadyExists`; it now succeeds, and the two roles are distinct
+  records with distinct ARNs.
+- **A listing reports one account.** `ListUsers`, `ListRoles`, `ListGroups`,
+  `ListInstanceProfiles` and `ListPolicies` with `Scope=Local` scan the caller's
+  account only. `ListPolicies` in particular used to scan every account's policies.
+- **A principal resolves against its own account.** `resolveIAMEntity` takes the
+  account from the principal ARN, not from the request, so a cross-account principal
+  is evaluated against its own account's policies rather than a same-named entity in
+  the account the request resolved to. `AssumeRole` likewise reads the role named by
+  `RoleArn` from *that* ARN's account, which is the case cross-account role assumption
+  exists for.
+
+One IAM key has no account and cannot have one: `accesskey:{id}`. An access key ID is
+what *determines* an account, so a signed request looks the record up before any
+account is known. The owning account is a field on the record instead. A record written
+before this release has that field empty and falls back to the account the request
+resolved to — which is what it always used, so nothing that worked stops working.
+
+Because the keys changed shape, **IAM state written before this release is
+unreachable**: a snapshot or exported fixture holding `user:alice` is not read by a
+handler now looking for `user:123456789012/alice`. Re-seed it through the API. This is
+the same class of break as the account-default change above, for the same reason.
 
 ### Configuring the registry from `substrate.yaml`
 

--- a/emulator/authz.go
+++ b/emulator/authz.go
@@ -360,6 +360,14 @@ func (a *AuthController) checkEC2TagOnCreate(reqCtx *RequestContext, req *AWSReq
 // policies of its own: IAM resolves an assumed-role's permissions against the
 // role it assumed, so a session's Kind is "role" and its Name is the role's.
 type iamEntity struct {
+	// Account is the account the entity belongs to, taken from the principal ARN.
+	//
+	// It is part of the identity of the entity, not context about the request: two
+	// accounts may both hold a role called "deploy", and every key below is scoped by
+	// this (#737). Taking it from the ARN rather than from the request is what makes a
+	// cross-account principal resolve against its own account's policies.
+	Account string
+
 	// Kind is the entity type, matching the prefix IAM stores policies under.
 	Kind string
 
@@ -388,10 +396,13 @@ func resolveIAMEntity(ctx context.Context, state StateManager, principalARN stri
 	if entityName == "" {
 		return iamEntity{}, false, nil
 	}
+	// The account is in the ARN and was previously discarded, which is what made one
+	// account's policies apply to another account's principal of the same name (#737).
+	account := arnAccountID(principalARN)
 
 	switch entityType {
 	case "user", "role":
-		entity = iamEntity{Kind: entityType, Name: entityName}
+		entity = iamEntity{Account: account, Kind: entityType, Name: entityName}
 	case "assumed-role":
 		// arn:aws:sts::<acct>:assumed-role/<RoleName>/<SessionName>. Only the role
 		// carries policies, and parsePrincipalARN splits on the first slash — so
@@ -406,7 +417,7 @@ func resolveIAMEntity(ctx context.Context, state StateManager, principalARN stri
 		if roleName == "" {
 			return iamEntity{}, false, nil
 		}
-		entity = iamEntity{Kind: "role", Name: roleName}
+		entity = iamEntity{Account: account, Kind: "role", Name: roleName}
 	default:
 		// A principal substrate does not model as a policy-holding entity — a
 		// service principal, a federated user, the account root. Not enforced,
@@ -415,7 +426,7 @@ func resolveIAMEntity(ctx context.Context, state StateManager, principalARN stri
 		return iamEntity{}, false, nil
 	}
 
-	raw, err := state.Get(ctx, iamNamespace, entity.Kind+":"+entity.Name)
+	raw, err := state.Get(ctx, iamNamespace, iamEntityKey(entity.Account, entity.Kind, entity.Name))
 	if err != nil {
 		return entity, false, fmt.Errorf("load %s %q: %w", entity.Kind, entity.Name, err)
 	}
@@ -446,18 +457,18 @@ func (a *AuthController) loadPoliciesForPrincipal(entity iamEntity) ([]PolicyDoc
 	// for the callers that report them.
 	sources := []iamEntity{entity}
 	if entity.Kind == "user" {
-		groups, err := a.loadAuthzStringList(goCtx, iamUserGroupsKey(entity.Name))
+		groups, err := a.loadAuthzStringList(goCtx, iamUserGroupsKey(entity.Account, entity.Name))
 		if err != nil {
 			return nil, fmt.Errorf("load group memberships: %w", err)
 		}
 		for _, name := range groups {
-			sources = append(sources, iamEntity{Kind: "group", Name: name})
+			sources = append(sources, iamEntity{Account: entity.Account, Kind: "group", Name: name})
 		}
 	}
 
 	arnsBySource := make([][]string, 0, len(sources))
 	for _, source := range sources {
-		arns, err := a.loadAuthzStringList(goCtx, source.Kind+"_policies:"+source.Name)
+		arns, err := a.loadAuthzStringList(goCtx, iamAttachedPoliciesKey(source.Account, source.Kind, source.Name))
 		if err != nil {
 			return nil, fmt.Errorf("load policy list: %w", err)
 		}
@@ -520,7 +531,7 @@ func (a *AuthController) resolveManagedPolicyDoc(goCtx context.Context, arn stri
 	if mp, ok := GetManagedPolicy(arn); ok {
 		return mp.Document, true
 	}
-	polRaw, err := a.state.Get(goCtx, iamNamespace, "policy:"+arn)
+	polRaw, err := a.state.Get(goCtx, iamNamespace, iamPolicyKey(arn))
 	if err != nil || polRaw == nil {
 		return PolicyDocument{}, false
 	}
@@ -537,7 +548,7 @@ func (a *AuthController) resolveManagedPolicyDoc(goCtx context.Context, arn stri
 // behavior this replaced: an unreadable inline policy must not turn into a
 // blanket deny, and CheckAccess already fails open on the errors it does see.
 func (a *AuthController) loadInlinePolicyDocs(goCtx context.Context, entity iamEntity) []PolicyDocument {
-	namesRaw, err := a.state.Get(goCtx, iamNamespace, entity.Kind+"_inline_names:"+entity.Name)
+	namesRaw, err := a.state.Get(goCtx, iamNamespace, iamInlinePolicyNamesKey(entity.Account, entity.Kind, entity.Name))
 	if err != nil || namesRaw == nil {
 		return nil
 	}
@@ -547,7 +558,7 @@ func (a *AuthController) loadInlinePolicyDocs(goCtx context.Context, entity iamE
 	}
 	var docs []PolicyDocument
 	for _, name := range names {
-		docRaw, err := a.state.Get(goCtx, iamNamespace, entity.Kind+"_inline:"+entity.Name+":"+name)
+		docRaw, err := a.state.Get(goCtx, iamNamespace, iamInlinePolicyKey(entity.Account, entity.Kind, entity.Name, name))
 		if err != nil || docRaw == nil {
 			continue
 		}
@@ -570,7 +581,7 @@ func (a *AuthController) loadInlinePolicyDocs(goCtx context.Context, entity iamE
 func (a *AuthController) loadPermissionBoundary(entity iamEntity) (*PolicyDocument, error) {
 	goCtx := context.Background()
 
-	entityRaw, err := a.state.Get(goCtx, iamNamespace, entity.Kind+":"+entity.Name)
+	entityRaw, err := a.state.Get(goCtx, iamNamespace, iamEntityKey(entity.Account, entity.Kind, entity.Name))
 	if err != nil || entityRaw == nil {
 		return nil, err
 	}
@@ -590,7 +601,7 @@ func (a *AuthController) loadPermissionBoundary(entity iamEntity) (*PolicyDocume
 	if mp, ok := GetManagedPolicy(arn); ok {
 		return &mp.Document, nil
 	}
-	polRaw, err := a.state.Get(goCtx, iamNamespace, "policy:"+arn)
+	polRaw, err := a.state.Get(goCtx, iamNamespace, iamPolicyKey(arn))
 	if err != nil || polRaw == nil {
 		return nil, err
 	}
@@ -1028,9 +1039,13 @@ func (a *AuthController) resourceTagsFor(reqCtx *RequestContext, req *AWSRequest
 
 	case "iam":
 		entityType, entityName := parsePrincipalARN(reqCtx.Principal.ARN)
+		// The entity's own account, which is the one its ARN names rather than the one
+		// the request resolved to — the two agree for every call substrate routes today,
+		// and the ARN is the authority when they do not (#737).
+		entityAccount := arnAccountID(reqCtx.Principal.ARN)
 		switch entityType {
 		case "user":
-			raw, err := a.state.Get(goCtx, iamNamespace, "user:"+entityName)
+			raw, err := a.state.Get(goCtx, iamNamespace, iamUserKey(entityAccount, entityName))
 			if err != nil || raw == nil {
 				return nil
 			}
@@ -1040,7 +1055,7 @@ func (a *AuthController) resourceTagsFor(reqCtx *RequestContext, req *AWSRequest
 			}
 			tags = iamTagsToMap(u.Tags)
 		case "role":
-			raw, err := a.state.Get(goCtx, iamNamespace, "role:"+entityName)
+			raw, err := a.state.Get(goCtx, iamNamespace, iamRoleKey(entityAccount, entityName))
 			if err != nil || raw == nil {
 				return nil
 			}

--- a/emulator/authz_assumed_role_test.go
+++ b/emulator/authz_assumed_role_test.go
@@ -44,25 +44,25 @@ func newRoleAuthState(t *testing.T, roleName string, doc *emulator.PolicyDocumen
 			Document:   *boundary,
 		})
 		require.NoError(t, err)
-		require.NoError(t, state.Put(ctx, "iam", "policy:"+boundaryARN, polRaw))
+		require.NoError(t, state.Put(ctx, "iam", emulator.IAMPolicyKeyForTest(boundaryARN), polRaw))
 	}
 
 	roleRaw, err := json.Marshal(role)
 	require.NoError(t, err)
-	require.NoError(t, state.Put(ctx, "iam", "role:"+roleName, roleRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMRoleKeyForTest(authzTestAccount, roleName), roleRaw))
 
 	if doc != nil {
 		policyARN := "arn:aws:iam::123456789012:policy/RolePolicy"
 		arnsRaw, marshalErr := json.Marshal([]string{policyARN})
 		require.NoError(t, marshalErr)
-		require.NoError(t, state.Put(ctx, "iam", "role_policies:"+roleName, arnsRaw))
+		require.NoError(t, state.Put(ctx, "iam", emulator.IAMAttachedPoliciesKeyForTest(authzTestAccount, "role", roleName), arnsRaw))
 		polRaw, marshalErr := json.Marshal(emulator.IAMPolicy{
 			PolicyName: "RolePolicy",
 			ARN:        policyARN,
 			Document:   *doc,
 		})
 		require.NoError(t, marshalErr)
-		require.NoError(t, state.Put(ctx, "iam", "policy:"+policyARN, polRaw))
+		require.NoError(t, state.Put(ctx, "iam", emulator.IAMPolicyKeyForTest(policyARN), polRaw))
 	}
 
 	return state

--- a/emulator/authz_groups_test.go
+++ b/emulator/authz_groups_test.go
@@ -59,26 +59,26 @@ func newAuthzGroupState(t *testing.T, userName, groupName string, spec authzGrou
 		require.NoError(t, state.Put(ctx, "iam", key, raw))
 	}
 
-	put("user:"+userName, emulator.IAMUser{
+	put(emulator.IAMUserKeyForTest(authzTestAccount, userName), emulator.IAMUser{
 		UserName: userName,
 		UserID:   "AIDATEST",
 		ARN:      "arn:aws:iam::123456789012:user/" + userName,
 		Path:     "/",
 	})
-	put("group:"+groupName, emulator.IAMGroup{
+	put(emulator.IAMGroupKeyForTest(authzTestAccount, groupName), emulator.IAMGroup{
 		GroupName: groupName,
 		GroupID:   "AGPATEST",
 		ARN:       "arn:aws:iam::123456789012:group/" + groupName,
 		Path:      "/",
 	})
 	if !spec.OmitMembership {
-		put("group_users:"+groupName, []string{userName})
-		put("user_groups:"+userName, []string{groupName})
+		put(emulator.IAMGroupUsersKeyForTest(authzTestAccount, groupName), []string{userName})
+		put(emulator.IAMUserGroupsKeyForTest(authzTestAccount, userName), []string{groupName})
 	}
 	if spec.GroupManaged != "" {
-		put("group_policies:"+groupName, []string{spec.GroupManaged})
+		put(emulator.IAMAttachedPoliciesKeyForTest(authzTestAccount, "group", groupName), []string{spec.GroupManaged})
 		if spec.GroupManagedDoc != nil {
-			put("policy:"+spec.GroupManaged, emulator.IAMPolicy{
+			put(emulator.IAMPolicyKeyForTest(spec.GroupManaged), emulator.IAMPolicy{
 				PolicyName:       "grouppolicy",
 				ARN:              spec.GroupManaged,
 				Path:             "/",
@@ -89,12 +89,12 @@ func newAuthzGroupState(t *testing.T, userName, groupName string, spec authzGrou
 		}
 	}
 	if spec.GroupInline != nil {
-		put("group_inline:"+groupName+":inline", *spec.GroupInline)
-		put("group_inline_names:"+groupName, []string{"inline"})
+		put(emulator.IAMInlinePolicyKeyForTest(authzTestAccount, "group", groupName, "inline"), *spec.GroupInline)
+		put(emulator.IAMInlinePolicyNamesKeyForTest(authzTestAccount, "group", groupName), []string{"inline"})
 	}
 	if spec.UserInline != nil {
-		put("user_inline:"+userName+":inline", *spec.UserInline)
-		put("user_inline_names:"+userName, []string{"inline"})
+		put(emulator.IAMInlinePolicyKeyForTest(authzTestAccount, "user", userName, "inline"), *spec.UserInline)
+		put(emulator.IAMInlinePolicyNamesKeyForTest(authzTestAccount, "user", userName), []string{"inline"})
 	}
 	return state
 }
@@ -210,17 +210,17 @@ func TestAuthController_RoleIgnoresGroupMemberships(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, state.Put(ctx, "iam", key, raw))
 	}
-	put("role:worker", emulator.IAMRole{
+	put(emulator.IAMRoleKeyForTest(authzTestAccount, "worker"), emulator.IAMRole{
 		RoleName: "worker",
 		RoleID:   "AROATEST",
 		ARN:      "arn:aws:iam::123456789012:role/worker",
 		Path:     "/",
 	})
-	put("group:devs", emulator.IAMGroup{GroupName: "devs", ARN: "arn:aws:iam::123456789012:group/devs", Path: "/"})
-	put("group_inline:devs:inline", *authzDoc(emulator.IAMEffectAllow, "s3:GetObject", "*"))
-	put("group_inline_names:devs", []string{"inline"})
+	put(emulator.IAMGroupKeyForTest(authzTestAccount, "devs"), emulator.IAMGroup{GroupName: "devs", ARN: "arn:aws:iam::123456789012:group/devs", Path: "/"})
+	put(emulator.IAMInlinePolicyKeyForTest(authzTestAccount, "group", "devs", "inline"), *authzDoc(emulator.IAMEffectAllow, "s3:GetObject", "*"))
+	put(emulator.IAMInlinePolicyNamesKeyForTest(authzTestAccount, "group", "devs"), []string{"inline"})
 	// A membership keyed by the role's name, which nothing writes but state could hold.
-	put("user_groups:worker", []string{"devs"})
+	put(emulator.IAMUserGroupsKeyForTest(authzTestAccount, "worker"), []string{"devs"})
 
 	auth := emulator.NewAuthController(state, emulator.NewDefaultLogger(slog.LevelError, false))
 	err := auth.CheckAccess(

--- a/emulator/authz_test.go
+++ b/emulator/authz_test.go
@@ -12,6 +12,15 @@ import (
 	"github.com/scttfrdmn/substrate/emulator"
 )
 
+// authzTestAccount is the account every test in this package seeds IAM state for.
+//
+// It is [emulator]'s own default — the account a request with nothing naming one is
+// attributed to — so a record written under it is the record the request under test
+// reads. Since #737 an IAM state key carries the account, and a test that seeded a
+// different one would write a key the handler never looks at, so this is stated once
+// rather than repeated at each Put.
+const authzTestAccount = "123456789012"
+
 // newAuthTestState builds a MemoryStateManager with a pre-created user and
 // optionally an attached managed/custom policy.
 func newAuthTestState(t *testing.T, userName, policyARN string, policyDoc emulator.PolicyDocument) emulator.StateManager {
@@ -26,13 +35,13 @@ func newAuthTestState(t *testing.T, userName, policyARN string, policyDoc emulat
 		Path:     "/",
 	}
 	userRaw, _ := json.Marshal(user)
-	require.NoError(t, state.Put(ctx, "iam", "user:"+userName, userRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMUserKeyForTest(authzTestAccount, userName), userRaw))
 
 	if policyARN != "" {
 		// Attach the policy to the user.
 		arns := []string{policyARN}
 		arnsRaw, _ := json.Marshal(arns)
-		require.NoError(t, state.Put(ctx, "iam", "user_policies:"+userName, arnsRaw))
+		require.NoError(t, state.Put(ctx, "iam", emulator.IAMAttachedPoliciesKeyForTest(authzTestAccount, "user", userName), arnsRaw))
 
 		// Store the policy document if it's a custom (non-managed) ARN.
 		if len(policyDoc.Statement) > 0 {
@@ -46,7 +55,7 @@ func newAuthTestState(t *testing.T, userName, policyARN string, policyDoc emulat
 				Document:         policyDoc,
 			}
 			polRaw, _ := json.Marshal(pol)
-			require.NoError(t, state.Put(ctx, "iam", "policy:"+policyARN, polRaw))
+			require.NoError(t, state.Put(ctx, "iam", emulator.IAMPolicyKeyForTest(policyARN), polRaw))
 		}
 	}
 
@@ -174,7 +183,7 @@ func TestAuthController_InlinePolicy_Allow(t *testing.T) {
 		Path:     "/",
 	}
 	userRaw, _ := json.Marshal(user)
-	require.NoError(t, state.Put(ctx, "iam", "user:eve", userRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMUserKeyForTest(authzTestAccount, "eve"), userRaw))
 
 	// Inline policy document stored directly.
 	inlineDoc := emulator.PolicyDocument{
@@ -186,9 +195,9 @@ func TestAuthController_InlinePolicy_Allow(t *testing.T) {
 		}},
 	}
 	docRaw, _ := json.Marshal(inlineDoc)
-	require.NoError(t, state.Put(ctx, "iam", "user_inline:eve:ReadPolicy", docRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMInlinePolicyKeyForTest(authzTestAccount, "user", "eve", "ReadPolicy"), docRaw))
 	namesRaw, _ := json.Marshal([]string{"ReadPolicy"})
-	require.NoError(t, state.Put(ctx, "iam", "user_inline_names:eve", namesRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMInlinePolicyNamesKeyForTest(authzTestAccount, "user", "eve"), namesRaw))
 
 	logger := emulator.NewDefaultLogger(slog.LevelError, false)
 	auth := emulator.NewAuthController(state, logger)
@@ -225,7 +234,7 @@ func TestAuthController_PermissionBoundary_Deny(t *testing.T) {
 		Document:         boundaryDoc,
 	}
 	boundaryRaw, _ := json.Marshal(boundary)
-	require.NoError(t, state.Put(ctx, "iam", "policy:"+boundaryARN, boundaryRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMPolicyKeyForTest(boundaryARN), boundaryRaw))
 
 	// User has allow-all managed policy and the boundary set.
 	allowAllARN := "arn:aws:iam::aws:policy/AdministratorAccess"
@@ -240,8 +249,8 @@ func TestAuthController_PermissionBoundary_Deny(t *testing.T) {
 		PermissionsBoundary: boundaryRef,
 	}
 	userRaw, _ := json.Marshal(user)
-	require.NoError(t, state.Put(ctx, "iam", "user:frank", userRaw))
-	require.NoError(t, state.Put(ctx, "iam", "user_policies:frank", arnsRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMUserKeyForTest(authzTestAccount, "frank"), userRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMAttachedPoliciesKeyForTest(authzTestAccount, "user", "frank"), arnsRaw))
 
 	logger := emulator.NewDefaultLogger(slog.LevelError, false)
 	auth := emulator.NewAuthController(state, logger)
@@ -404,9 +413,9 @@ func TestABAC_IAMRole_ResourceTag(t *testing.T) {
 		Path:     "/",
 	}
 	userRaw, _ := json.Marshal(user)
-	require.NoError(t, state.Put(ctx, "iam", "user:frank", userRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMUserKeyForTest(authzTestAccount, "frank"), userRaw))
 	arnsRaw, _ := json.Marshal([]string{policyARN})
-	require.NoError(t, state.Put(ctx, "iam", "user_policies:frank", arnsRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMAttachedPoliciesKeyForTest(authzTestAccount, "user", "frank"), arnsRaw))
 
 	pol := emulator.IAMPolicy{
 		PolicyName:       "InfraTeam",
@@ -418,7 +427,7 @@ func TestABAC_IAMRole_ResourceTag(t *testing.T) {
 		Document:         policyDoc,
 	}
 	polRaw, _ := json.Marshal(pol)
-	require.NoError(t, state.Put(ctx, "iam", "policy:"+policyARN, polRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMPolicyKeyForTest(policyARN), polRaw))
 
 	// Role tagged Team=infra.
 	role := emulator.IAMRole{
@@ -429,7 +438,7 @@ func TestABAC_IAMRole_ResourceTag(t *testing.T) {
 		Tags:     []emulator.IAMTag{{Key: "Team", Value: "infra"}},
 	}
 	roleRaw, _ := json.Marshal(role)
-	require.NoError(t, state.Put(ctx, "iam", "role:my-role", roleRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMRoleKeyForTest(authzTestAccount, "my-role"), roleRaw))
 
 	logger := emulator.NewDefaultLogger(slog.LevelError, false)
 	auth := emulator.NewAuthController(state, logger)
@@ -446,7 +455,7 @@ func TestABAC_IAMRole_ResourceTag(t *testing.T) {
 		Metadata:  make(map[string]interface{}),
 	}
 	// Attach the policy list to the role too.
-	require.NoError(t, state.Put(ctx, "iam", "role_policies:my-role", arnsRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMAttachedPoliciesKeyForTest(authzTestAccount, "role", "my-role"), arnsRaw))
 
 	req := &emulator.AWSRequest{Service: "iam", Operation: "PassRole", Path: "/"}
 	err := auth.CheckAccess(reqCtx, req)

--- a/emulator/cfn_deployer.go
+++ b/emulator/cfn_deployer.go
@@ -2052,8 +2052,8 @@ var cfnDriftCheckers = map[string]func(d *StackDeployer, ctx context.Context, ac
 		data, _ := d.state.Get(ctx, "lambda", "function:"+physicalID)
 		return data != nil
 	},
-	"AWS::IAM::Role": func(d *StackDeployer, ctx context.Context, _, _, physicalID string) bool {
-		data, _ := d.state.Get(ctx, "iam", "role:"+physicalID)
+	"AWS::IAM::Role": func(d *StackDeployer, ctx context.Context, acct, _, physicalID string) bool {
+		data, _ := d.state.Get(ctx, iamNamespace, iamRoleKey(acct, physicalID))
 		return data != nil
 	},
 }
@@ -2226,7 +2226,7 @@ func compareIAMRoleDrift(ctx context.Context, d *StackDeployer, stack *CFNStackS
 	if !ok {
 		return nil
 	}
-	data, _ := d.state.Get(ctx, "iam", "role:"+dr.PhysicalID)
+	data, _ := d.state.Get(ctx, iamNamespace, iamRoleKey(stack.AccountID, dr.PhysicalID))
 	if data == nil {
 		return nil
 	}

--- a/emulator/cfn_deployer_test.go
+++ b/emulator/cfn_deployer_test.go
@@ -2688,7 +2688,7 @@ func TestCFN_DriftDetection_IAMRole_Modified(t *testing.T) {
 
 	// Reorder the stored trust-policy statements (semantically identical) and
 	// confirm this does NOT register as drift.
-	key := "role:drift-role"
+	key := emulator.IAMRoleKeyForTest(authzTestAccount, "drift-role")
 	raw, err := state.Get(context.Background(), "iam", key)
 	require.NoError(t, err)
 	require.NotNil(t, raw)

--- a/emulator/cfn_service_role_test.go
+++ b/emulator/cfn_service_role_test.go
@@ -81,7 +81,7 @@ func cfnSeedRole(t *testing.T, state emulator.StateManager, roleName string, act
 		Path:     "/",
 	})
 	require.NoError(t, err)
-	require.NoError(t, state.Put(ctx, "iam", "role:"+roleName, roleRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMRoleKeyForTest(authzTestAccount, roleName), roleRaw))
 
 	if len(actions) == 0 {
 		return
@@ -89,7 +89,7 @@ func cfnSeedRole(t *testing.T, state emulator.StateManager, roleName string, act
 	policyARN := "arn:aws:iam::123456789012:policy/" + roleName + "Policy"
 	arnsRaw, err := json.Marshal([]string{policyARN})
 	require.NoError(t, err)
-	require.NoError(t, state.Put(ctx, "iam", "role_policies:"+roleName, arnsRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMAttachedPoliciesKeyForTest(authzTestAccount, "role", roleName), arnsRaw))
 
 	polRaw, err := json.Marshal(emulator.IAMPolicy{
 		PolicyName: roleName + "Policy",
@@ -104,7 +104,7 @@ func cfnSeedRole(t *testing.T, state emulator.StateManager, roleName string, act
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, state.Put(ctx, "iam", "policy:"+policyARN, polRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMPolicyKeyForTest(policyARN), polRaw))
 }
 
 // cfnStackStatus reads a stack's status and RoleARN out of a DescribeStacks body.
@@ -452,12 +452,12 @@ func cfnSeedUserWithKey(t *testing.T, state emulator.StateManager, user, keyID s
 		Path:     "/",
 	})
 	require.NoError(t, err)
-	require.NoError(t, state.Put(ctx, "iam", "user:"+user, userRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMUserKeyForTest(authzTestAccount, user), userRaw))
 
 	policyARN := "arn:aws:iam::123456789012:policy/" + user + "Policy"
 	arnsRaw, err := json.Marshal([]string{policyARN})
 	require.NoError(t, err)
-	require.NoError(t, state.Put(ctx, "iam", "user_policies:"+user, arnsRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMAttachedPoliciesKeyForTest(authzTestAccount, "user", user), arnsRaw))
 
 	polRaw, err := json.Marshal(emulator.IAMPolicy{
 		PolicyName: user + "Policy",
@@ -472,7 +472,7 @@ func cfnSeedUserWithKey(t *testing.T, state emulator.StateManager, user, keyID s
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, state.Put(ctx, "iam", "policy:"+policyARN, polRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMPolicyKeyForTest(policyARN), polRaw))
 
 	keyRaw, err := json.Marshal(emulator.IAMAccessKey{
 		AccessKeyID: keyID,
@@ -480,7 +480,7 @@ func cfnSeedUserWithKey(t *testing.T, state emulator.StateManager, user, keyID s
 		Status:      "Active",
 	})
 	require.NoError(t, err)
-	require.NoError(t, state.Put(ctx, "iam", "accesskey:"+keyID, keyRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMAccessKeyKeyForTest(keyID), keyRaw))
 	return keyID
 }
 
@@ -555,12 +555,12 @@ func TestCFN_CreatorPrincipalDeploysWhenThereIsNoRole(t *testing.T) {
 		Path:     "/",
 	})
 	require.NoError(t, err)
-	require.NoError(t, state.Put(ctx, "iam", "user:deployer", userRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMUserKeyForTest(authzTestAccount, "deployer"), userRaw))
 
 	policyARN := "arn:aws:iam::123456789012:policy/CFNOnly"
 	arnsRaw, err := json.Marshal([]string{policyARN})
 	require.NoError(t, err)
-	require.NoError(t, state.Put(ctx, "iam", "user_policies:deployer", arnsRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMAttachedPoliciesKeyForTest(authzTestAccount, "user", "deployer"), arnsRaw))
 	polRaw, err := json.Marshal(emulator.IAMPolicy{
 		PolicyName: "CFNOnly",
 		ARN:        policyARN,
@@ -574,7 +574,7 @@ func TestCFN_CreatorPrincipalDeploysWhenThereIsNoRole(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, state.Put(ctx, "iam", "policy:"+policyARN, polRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMPolicyKeyForTest(policyARN), polRaw))
 
 	const keyID = "AKIADEPLOYER00000001"
 	keyRaw, err := json.Marshal(emulator.IAMAccessKey{
@@ -583,7 +583,7 @@ func TestCFN_CreatorPrincipalDeploysWhenThereIsNoRole(t *testing.T) {
 		Status:      "Active",
 	})
 	require.NoError(t, err)
-	require.NoError(t, state.Put(ctx, "iam", "accesskey:"+keyID, keyRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMAccessKeyKeyForTest(keyID), keyRaw))
 
 	client := &cfnRoleTestClient{t: t, baseURL: ts.URL, accessKey: keyID}
 

--- a/emulator/coverage_test.go
+++ b/emulator/coverage_test.go
@@ -453,7 +453,7 @@ func TestReplayEngine_InspectState(t *testing.T) {
 	store := emulator.NewEventStore(emulator.EventStoreConfig{Enabled: true, Backend: "memory"})
 	sm := newMemStateManager()
 
-	require.NoError(t, sm.Put(context.Background(), "iam", "user:alice", []byte(`{"name":"alice"}`)))
+	require.NoError(t, sm.Put(context.Background(), "iam", emulator.IAMUserKeyForTest(authzTestAccount, "alice"), []byte(`{"name":"alice"}`)))
 
 	tc := emulator.NewTimeController(time.Now())
 	engine := emulator.NewReplayEngine(store, sm, tc, emulator.NewPluginRegistry(),
@@ -461,7 +461,7 @@ func TestReplayEngine_InspectState(t *testing.T) {
 
 	state, err := engine.InspectState(context.Background(), "iam")
 	require.NoError(t, err)
-	assert.Contains(t, state, "user:alice")
+	assert.Contains(t, state, emulator.IAMUserKeyForTest(authzTestAccount, "alice"))
 }
 
 func TestReplayEngine_StopRecording_WithEvents(t *testing.T) {
@@ -610,7 +610,7 @@ func TestIAMPlugin_Authorize_WithInlinePolicy(t *testing.T) {
 		Path:     "/",
 	}
 	userRaw, _ := json.Marshal(user)
-	require.NoError(t, state.Put(ctx, "iam", "user:inlined", userRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMUserKeyForTest(authzTestAccount, "inlined"), userRaw))
 
 	// Inline policy: allow s3:GetObject.
 	doc := emulator.PolicyDocument{
@@ -622,9 +622,9 @@ func TestIAMPlugin_Authorize_WithInlinePolicy(t *testing.T) {
 		}},
 	}
 	docRaw, _ := json.Marshal(doc)
-	require.NoError(t, state.Put(ctx, "iam", "user_inline:inlined:ReadPolicy", docRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMInlinePolicyKeyForTest(authzTestAccount, "user", "inlined", "ReadPolicy"), docRaw))
 	namesRaw, _ := json.Marshal([]string{"ReadPolicy"})
-	require.NoError(t, state.Put(ctx, "iam", "user_inline_names:inlined", namesRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMInlinePolicyNamesKeyForTest(authzTestAccount, "user", "inlined"), namesRaw))
 
 	plugin := &emulator.IAMPlugin{}
 	require.NoError(t, plugin.Initialize(context.Background(), emulator.PluginConfig{State: state, Logger: logger}))
@@ -669,7 +669,7 @@ func TestIAMPlugin_Authorize_WithBoundary(t *testing.T) {
 		Document:         boundaryDoc,
 	}
 	bRaw, _ := json.Marshal(boundaryPolicy)
-	require.NoError(t, state.Put(ctx, "iam", "policy:"+boundaryARN, bRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMPolicyKeyForTest(boundaryARN), bRaw))
 
 	// User with AdministratorAccess + boundary set.
 	boundaryRef := &emulator.IAMAttachedPolicy{PolicyARN: boundaryARN, PolicyName: "ReadOnlyBoundary"}
@@ -681,11 +681,11 @@ func TestIAMPlugin_Authorize_WithBoundary(t *testing.T) {
 		PermissionsBoundary: boundaryRef,
 	}
 	uRaw, _ := json.Marshal(user)
-	require.NoError(t, state.Put(ctx, "iam", "user:bounded", uRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMUserKeyForTest(authzTestAccount, "bounded"), uRaw))
 
 	// Attach AdministratorAccess.
 	arnsRaw, _ := json.Marshal([]string{"arn:aws:iam::aws:policy/AdministratorAccess"})
-	require.NoError(t, state.Put(ctx, "iam", "user_policies:bounded", arnsRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMAttachedPoliciesKeyForTest(authzTestAccount, "user", "bounded"), arnsRaw))
 
 	plugin := &emulator.IAMPlugin{}
 	require.NoError(t, plugin.Initialize(context.Background(), emulator.PluginConfig{State: state, Logger: logger}))

--- a/emulator/credentials.go
+++ b/emulator/credentials.go
@@ -154,10 +154,11 @@ func buildCallerARN(accountID, accessKeyID string) string {
 // the principal, so a caller who never touched IAM is unaffected.
 //
 // The second return is an account ID to adopt, or "" to keep the one already
-// resolved. Only an STS session supplies one, and it is the only thing that can:
-// a temporary credential's account is recorded when the session is minted and
-// appears nowhere on the wire, so a cross-account AssumeRole would otherwise
-// leave the caller in the server's own account rather than the role's.
+// resolved. Both arms supply one, for the same reason: a credential's account is
+// recorded when the credential is minted and appears nowhere on the wire, so a
+// cross-account AssumeRole — or a long-term key belonging to another account's
+// user — would otherwise leave the caller in the server's own account rather
+// than the credential's (#737).
 func resolvePrincipal(ctx context.Context, state StateManager, accountID, accessKeyID string) (*Principal, string) {
 	if state == nil || accessKeyID == "" {
 		return nil, ""
@@ -165,13 +166,20 @@ func resolvePrincipal(ctx context.Context, state StateManager, accountID, access
 
 	// A long-term key: IAMPlugin.CreateAccessKey stores the owning user's name
 	// beside it, which is the link from a signed request to a set of policies.
-	if raw, err := state.Get(ctx, iamNamespace, "accesskey:"+accessKeyID); err == nil && raw != nil {
+	if raw, err := state.Get(ctx, iamNamespace, iamAccessKeyKey(accessKeyID)); err == nil && raw != nil {
 		var key IAMAccessKey
 		if unmarshalErr := json.Unmarshal(raw, &key); unmarshalErr == nil && key.UserName != "" {
+			// The key's own account, when it has one. A record written before #737 does
+			// not, and falls back to the account the request resolved to — which is what
+			// it always used, so nothing that worked stops working.
+			account, adopt := key.AccountID, key.AccountID
+			if account == "" {
+				account, adopt = accountID, ""
+			}
 			return &Principal{
-				ARN:  fmt.Sprintf("arn:aws:iam::%s:user/%s", accountID, key.UserName),
+				ARN:  fmt.Sprintf("arn:aws:iam::%s:user/%s", account, key.UserName),
 				Type: "IAMUser",
-			}, ""
+			}, adopt
 		}
 	}
 

--- a/emulator/ec2_authz_test.go
+++ b/emulator/ec2_authz_test.go
@@ -197,7 +197,7 @@ func (f *ec2AuthzFixture) setPolicy(t *testing.T, statements ...emulator.PolicyS
 	if err != nil {
 		t.Fatalf("marshal policy: %v", err)
 	}
-	if err := f.state.Put(context.Background(), "iam", "policy:"+arn, raw); err != nil { //nolint:contextcheck
+	if err := f.state.Put(context.Background(), "iam", emulator.IAMPolicyKeyForTest(arn), raw); err != nil { //nolint:contextcheck
 		t.Fatalf("store policy: %v", err)
 	}
 }
@@ -423,7 +423,7 @@ func TestEC2_Authz_PermissionBoundaryCoversEveryResource(t *testing.T) {
 	}
 	raw, err := json.Marshal(boundary)
 	require.NoError(t, err)
-	require.NoError(t, f.state.Put(context.Background(), "iam", "policy:"+boundaryARN, raw))
+	require.NoError(t, f.state.Put(context.Background(), "iam", emulator.IAMPolicyKeyForTest(boundaryARN), raw))
 
 	user := emulator.IAMUser{
 		UserName:            "nina",
@@ -434,7 +434,7 @@ func TestEC2_Authz_PermissionBoundaryCoversEveryResource(t *testing.T) {
 	}
 	userRaw, err := json.Marshal(user)
 	require.NoError(t, err)
-	require.NoError(t, f.state.Put(context.Background(), "iam", "user:nina", userRaw))
+	require.NoError(t, f.state.Put(context.Background(), "iam", emulator.IAMUserKeyForTest(authzTestAccount, "nina"), userRaw))
 
 	launchErr := f.launch(t, nominalLaunch())
 	if !ec2AuthzDenied(t, launchErr) {

--- a/emulator/ec2_createtags_authz_test.go
+++ b/emulator/ec2_createtags_authz_test.go
@@ -129,7 +129,7 @@ func (f *ec2AuthzFixture) setBoundary(t *testing.T, doc emulator.PolicyDocument)
 	if err != nil {
 		t.Fatalf("marshal boundary: %v", err)
 	}
-	if err := f.state.Put(context.Background(), "iam", "policy:"+arn, raw); err != nil { //nolint:contextcheck
+	if err := f.state.Put(context.Background(), "iam", emulator.IAMPolicyKeyForTest(arn), raw); err != nil { //nolint:contextcheck
 		t.Fatalf("store boundary: %v", err)
 	}
 	user := emulator.IAMUser{
@@ -143,7 +143,7 @@ func (f *ec2AuthzFixture) setBoundary(t *testing.T, doc emulator.PolicyDocument)
 	if err != nil {
 		t.Fatalf("marshal user: %v", err)
 	}
-	if err := f.state.Put(context.Background(), "iam", "user:"+f.user, userRaw); err != nil { //nolint:contextcheck
+	if err := f.state.Put(context.Background(), "iam", emulator.IAMUserKeyForTest(authzTestAccount, f.user), userRaw); err != nil { //nolint:contextcheck
 		t.Fatalf("store user: %v", err)
 	}
 }

--- a/emulator/ec2_tag_authz_test.go
+++ b/emulator/ec2_tag_authz_test.go
@@ -543,7 +543,7 @@ func TestEC2_TagAuthz_PermissionBoundaryCoversEveryResource(t *testing.T) {
 	}
 	raw, err := json.Marshal(boundary)
 	require.NoError(t, err)
-	require.NoError(t, f.state.Put(context.Background(), "iam", "policy:"+boundaryARN, raw))
+	require.NoError(t, f.state.Put(context.Background(), "iam", emulator.IAMPolicyKeyForTest(boundaryARN), raw))
 
 	user := emulator.IAMUser{
 		UserName:            "opal",
@@ -554,7 +554,7 @@ func TestEC2_TagAuthz_PermissionBoundaryCoversEveryResource(t *testing.T) {
 	}
 	userRaw, err := json.Marshal(user)
 	require.NoError(t, err)
-	require.NoError(t, f.state.Put(context.Background(), "iam", "user:opal", userRaw))
+	require.NoError(t, f.state.Put(context.Background(), "iam", emulator.IAMUserKeyForTest(authzTestAccount, "opal"), userRaw))
 
 	callErr := f.call(t, "CreateTags", ec2TagAuthzParams())
 	if !ec2AuthzDenied(t, callErr) {

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -766,3 +766,68 @@ func AddRequestTagsForTest(req *AWSRequest) (map[string]string, []string) {
 	addRequestTags(tags, req)
 	return tags, requestTagKeys(tags)
 }
+
+// --- IAM state keys (#737) -------------------------------------------------
+//
+// A test that seeds IAM state directly needs to spell the same key the plugin
+// does, and since #737 that key carries an account. Exporting the builders is
+// what keeps a test from hardcoding the layout: when the layout changes again,
+// the tests move with the production code instead of drifting into addressing
+// keys nothing reads.
+
+// IAMUserKeyForTest wraps iamUserKey for external tests.
+func IAMUserKeyForTest(accountID, userName string) string { return iamUserKey(accountID, userName) }
+
+// IAMRoleKeyForTest wraps iamRoleKey for external tests.
+func IAMRoleKeyForTest(accountID, roleName string) string { return iamRoleKey(accountID, roleName) }
+
+// IAMGroupKeyForTest wraps iamGroupKey for external tests.
+func IAMGroupKeyForTest(accountID, groupName string) string {
+	return iamGroupKey(accountID, groupName)
+}
+
+// IAMPolicyKeyForTest wraps iamPolicyKey for external tests. The account comes from
+// the ARN, as it does in production.
+func IAMPolicyKeyForTest(arn string) string { return iamPolicyKey(arn) }
+
+// IAMPolicyPrefixForTest wraps iamPolicyPrefix for external tests.
+func IAMPolicyPrefixForTest(accountID string) string { return iamPolicyPrefix(accountID) }
+
+// IAMAttachedPoliciesKeyForTest wraps iamAttachedPoliciesKey for external tests.
+func IAMAttachedPoliciesKeyForTest(accountID, kind, name string) string {
+	return iamAttachedPoliciesKey(accountID, kind, name)
+}
+
+// IAMAttachedPoliciesPrefixForTest wraps iamAttachedPoliciesPrefix for external tests.
+func IAMAttachedPoliciesPrefixForTest(accountID, kind string) string {
+	return iamAttachedPoliciesPrefix(accountID, kind)
+}
+
+// IAMInlinePolicyKeyForTest wraps iamInlinePolicyKey for external tests.
+func IAMInlinePolicyKeyForTest(accountID, kind, entityName, policyName string) string {
+	return iamInlinePolicyKey(accountID, kind, entityName, policyName)
+}
+
+// IAMInlinePolicyNamesKeyForTest wraps iamInlinePolicyNamesKey for external tests.
+func IAMInlinePolicyNamesKeyForTest(accountID, kind, entityName string) string {
+	return iamInlinePolicyNamesKey(accountID, kind, entityName)
+}
+
+// IAMGroupUsersKeyForTest wraps iamGroupUsersKey for external tests.
+func IAMGroupUsersKeyForTest(accountID, groupName string) string {
+	return iamGroupUsersKey(accountID, groupName)
+}
+
+// IAMUserGroupsKeyForTest wraps iamUserGroupsKey for external tests.
+func IAMUserGroupsKeyForTest(accountID, userName string) string {
+	return iamUserGroupsKey(accountID, userName)
+}
+
+// IAMAccessKeyKeyForTest wraps iamAccessKeyKey for external tests. It takes no
+// account: an access key ID determines one, so the record carries it instead.
+func IAMAccessKeyKeyForTest(accessKeyID string) string { return iamAccessKeyKey(accessKeyID) }
+
+// IAMInstanceProfileKeyForTest wraps iamInstanceProfileKey for external tests.
+func IAMInstanceProfileKeyForTest(accountID, name string) string {
+	return iamInstanceProfileKey(accountID, name)
+}

--- a/emulator/iam_account_scope_test.go
+++ b/emulator/iam_account_scope_test.go
@@ -1,0 +1,307 @@
+package emulator_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// This file is #737: IAM state was keyed by name alone, so every account shared one
+// IAM. Two accounts could not both hold a role called "deploy" — the second create
+// answered EntityAlreadyExists — and a listing made by one account returned the
+// other's entities. Nothing on the wire says which account an IAM entity belongs
+// to except its ARN, which is exactly why a single-account suite could not see it.
+//
+// Each test signs as a specific account, because that is the only way to be a
+// second caller (see signed_request_test.go).
+
+// The two accounts these tests are. Neither is the default account, so a test that
+// accidentally resolved to it would fail rather than pass by coincidence.
+const (
+	iamScopeAccountA = "111122223333"
+	iamScopeAccountB = "444455556666"
+)
+
+// iamSignedForm posts an IAM query-protocol request signed as the given account.
+//
+// IAM is a query-protocol service, so the operation travels in the Action
+// parameter of a form body, which is what a real client sends — the same shape
+// iam_query_wire_test.go uses, plus a signature.
+func iamSignedForm(t *testing.T, ts *emulator.TestServer, account, operation string,
+	params map[string]string,
+) *http.Response {
+	t.Helper()
+
+	creds, ok := ts.CredentialsFor(account)
+	if !ok {
+		t.Fatalf("no credential registered for account %s", account)
+	}
+
+	form := url.Values{}
+	form.Set("Action", operation)
+	form.Set("Version", "2010-05-08")
+	for k, v := range params {
+		form.Set(k, v)
+	}
+	body := []byte(form.Encode())
+
+	const host = "iam.amazonaws.com"
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+"/", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Host = host
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Amz-Date", sigV4TestDateTime)
+	req.Header.Set("Authorization", sigV4Header(http.MethodPost, "/", host, "iam", "us-east-1",
+		sigV4TestDateTime, body, creds.AccessKeyID, creds.SecretAccessKey))
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err, "%s as %s", operation, account)
+	return resp
+}
+
+// iamScopeResult runs an IAM operation as an account and returns the status, the
+// error code a refusal carries, and the decoded response.
+func iamScopeResult(t *testing.T, ts *emulator.TestServer, account, operation string,
+	params map[string]string,
+) (int, string, map[string]any) {
+	t.Helper()
+
+	resp := iamSignedForm(t, ts, account, operation, params)
+	status := resp.StatusCode
+	var decoded map[string]any
+	decodeIAMXML(t, resp, &decoded)
+	require.NoError(t, resp.Body.Close())
+
+	code, _ := decoded["__type"].(string)
+	return status, code, decoded
+}
+
+// iamScopeServer starts a server both accounts can sign as.
+func iamScopeServer(t *testing.T) *emulator.TestServer {
+	t.Helper()
+	return emulator.StartTestServerWithAccounts(t, iamScopeAccountA, iamScopeAccountB)
+}
+
+// TestIAM_TwoAccountsHoldTheSameNames is #737's repro. Before the fix the second
+// account's create answered EntityAlreadyExists 409 for every entity kind, because
+// the state key was the bare name.
+func TestIAM_TwoAccountsHoldTheSameNames(t *testing.T) {
+	tests := []struct {
+		operation string
+		params    map[string]string
+		arnPath   string // the response member holding the created entity's ARN
+	}{
+		{
+			operation: "CreateUser",
+			params:    map[string]string{"UserName": "deploy"},
+			arnPath:   "User",
+		},
+		{
+			operation: "CreateRole",
+			params: map[string]string{
+				"RoleName":                 "deploy",
+				"AssumeRolePolicyDocument": `{"Version":"2012-10-17","Statement":[]}`,
+			},
+			arnPath: "Role",
+		},
+		{
+			operation: "CreateGroup",
+			params:    map[string]string{"GroupName": "deploy"},
+			arnPath:   "Group",
+		},
+		{
+			operation: "CreateInstanceProfile",
+			params:    map[string]string{"InstanceProfileName": "deploy"},
+			arnPath:   "InstanceProfile",
+		},
+		{
+			operation: "CreatePolicy",
+			params: map[string]string{
+				"PolicyName":     "deploy",
+				"PolicyDocument": `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}`,
+			},
+			arnPath: "Policy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.operation, func(t *testing.T) {
+			ts := iamScopeServer(t)
+
+			for _, account := range []string{iamScopeAccountA, iamScopeAccountB} {
+				status, code, decoded := iamScopeResult(t, ts, account, tt.operation, tt.params)
+				require.Equalf(t, http.StatusOK, status,
+					"%s in account %s: %s — the name belongs to the account, not to the emulator",
+					tt.operation, account, code)
+
+				entity, ok := decoded[tt.arnPath].(map[string]any)
+				require.Truef(t, ok, "%s response has no %s member: %v", tt.operation, tt.arnPath, decoded)
+				arn, _ := entity["Arn"].(string)
+				assert.Truef(t, strings.Contains(arn, ":"+account+":"),
+					"created in account %s but its ARN is %q", account, arn)
+			}
+		})
+	}
+}
+
+// TestIAM_ListsSeeOnlyTheCallersAccount covers the prefix scans. A scan over a
+// name-keyed prefix returned every account's entities, so an account that had
+// created nothing still listed another account's.
+func TestIAM_ListsSeeOnlyTheCallersAccount(t *testing.T) {
+	ts := iamScopeServer(t)
+
+	// Account A creates one of everything the listings walk.
+	for _, seed := range []struct {
+		operation string
+		params    map[string]string
+	}{
+		{"CreateUser", map[string]string{"UserName": "a-user"}},
+		{"CreateRole", map[string]string{
+			"RoleName":                 "a-role",
+			"AssumeRolePolicyDocument": `{"Version":"2012-10-17","Statement":[]}`,
+		}},
+		{"CreateGroup", map[string]string{"GroupName": "a-group"}},
+		{"CreateInstanceProfile", map[string]string{"InstanceProfileName": "a-profile"}},
+		{"CreatePolicy", map[string]string{
+			"PolicyName":     "a-policy",
+			"PolicyDocument": `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}`,
+		}},
+	} {
+		status, code, _ := iamScopeResult(t, ts, iamScopeAccountA, seed.operation, seed.params)
+		require.Equalf(t, http.StatusOK, status, "seeding %s: %s", seed.operation, code)
+	}
+
+	tests := []struct {
+		operation string
+		params    map[string]string
+		member    string
+	}{
+		{"ListUsers", nil, "Users"},
+		{"ListRoles", nil, "Roles"},
+		{"ListGroups", nil, "Groups"},
+		{"ListInstanceProfiles", nil, "InstanceProfiles"},
+		// Local scope excludes the bundled AWS-managed catalog, so what comes back
+		// is exactly what an account created.
+		{"ListPolicies", map[string]string{"Scope": "Local"}, "Policies"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.operation, func(t *testing.T) {
+			status, code, decoded := iamScopeResult(t, ts, iamScopeAccountA, tt.operation, tt.params)
+			require.Equalf(t, http.StatusOK, status, "%s as A: %s", tt.operation, code)
+			assert.Lenf(t, iamScopeList(decoded, tt.member), 1,
+				"account A created one; %s reported %v", tt.operation, decoded[tt.member])
+
+			status, code, decoded = iamScopeResult(t, ts, iamScopeAccountB, tt.operation, tt.params)
+			require.Equalf(t, http.StatusOK, status, "%s as B: %s", tt.operation, code)
+			assert.Emptyf(t, iamScopeList(decoded, tt.member),
+				"account B created nothing; %s reported %v — the scan crossed accounts",
+				tt.operation, decoded[tt.member])
+		})
+	}
+}
+
+// iamScopeList returns the members of a list-shaped response member, tolerating the
+// XML decoder's single-element and absent forms.
+func iamScopeList(decoded map[string]any, member string) []any {
+	switch v := decoded[member].(type) {
+	case []any:
+		return v
+	case map[string]any:
+		return []any{v}
+	default:
+		return nil
+	}
+}
+
+// TestIAM_ReadsDoNotCrossAccounts is the other half of the isolation: an entity
+// account A created must be absent for account B, rather than readable.
+func TestIAM_ReadsDoNotCrossAccounts(t *testing.T) {
+	ts := iamScopeServer(t)
+
+	status, code, _ := iamScopeResult(t, ts, iamScopeAccountA, "CreateRole", map[string]string{
+		"RoleName":                 "shared-name",
+		"AssumeRolePolicyDocument": `{"Version":"2012-10-17","Statement":[]}`,
+	})
+	require.Equalf(t, http.StatusOK, status, "CreateRole as A: %s", code)
+
+	status, code, _ = iamScopeResult(t, ts, iamScopeAccountA, "GetRole",
+		map[string]string{"RoleName": "shared-name"})
+	require.Equalf(t, http.StatusOK, status, "GetRole as its own account: %s", code)
+
+	status, code, _ = iamScopeResult(t, ts, iamScopeAccountB, "GetRole",
+		map[string]string{"RoleName": "shared-name"})
+	assert.Equal(t, http.StatusNotFound, status,
+		"account B read account A's role")
+	assert.Equal(t, "NoSuchEntity", code)
+
+	// A delete must not reach across either, or one account could remove another's
+	// role by name.
+	status, code, _ = iamScopeResult(t, ts, iamScopeAccountB, "DeleteRole",
+		map[string]string{"RoleName": "shared-name"})
+	assert.Equal(t, http.StatusNotFound, status, "account B deleted account A's role")
+	assert.Equal(t, "NoSuchEntity", code)
+
+	status, code, _ = iamScopeResult(t, ts, iamScopeAccountA, "GetRole",
+		map[string]string{"RoleName": "shared-name"})
+	assert.Equalf(t, http.StatusOK, status, "account A's role survived B's delete: %s", code)
+}
+
+// TestIAM_InlineAndAttachedPoliciesAreScoped covers the per-entity index keys —
+// "<kind>_inline:", "<kind>_inline_names:" and "<kind>_policies:" — which are keyed
+// by entity name and so were also shared.
+func TestIAM_InlineAndAttachedPoliciesAreScoped(t *testing.T) {
+	ts := iamScopeServer(t)
+
+	for _, account := range []string{iamScopeAccountA, iamScopeAccountB} {
+		status, code, _ := iamScopeResult(t, ts, account, "CreateUser",
+			map[string]string{"UserName": "worker"})
+		require.Equalf(t, http.StatusOK, status, "CreateUser in %s: %s", account, code)
+	}
+
+	// Only account A gives its user an inline policy and an attachment.
+	status, code, _ := iamScopeResult(t, ts, iamScopeAccountA, "PutUserPolicy", map[string]string{
+		"UserName":       "worker",
+		"PolicyName":     "inline-read",
+		"PolicyDocument": `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}`,
+	})
+	require.Equalf(t, http.StatusOK, status, "PutUserPolicy: %s", code)
+
+	status, code, _ = iamScopeResult(t, ts, iamScopeAccountA, "AttachUserPolicy", map[string]string{
+		"UserName":  "worker",
+		"PolicyArn": "arn:aws:iam::aws:policy/ReadOnlyAccess",
+	})
+	require.Equalf(t, http.StatusOK, status, "AttachUserPolicy: %s", code)
+
+	status, code, decoded := iamScopeResult(t, ts, iamScopeAccountA, "ListUserPolicies",
+		map[string]string{"UserName": "worker"})
+	require.Equalf(t, http.StatusOK, status, "ListUserPolicies as A: %s", code)
+	assert.Len(t, iamScopeList(decoded, "PolicyNames"), 1)
+
+	status, code, decoded = iamScopeResult(t, ts, iamScopeAccountB, "ListUserPolicies",
+		map[string]string{"UserName": "worker"})
+	require.Equalf(t, http.StatusOK, status, "ListUserPolicies as B: %s", code)
+	assert.Emptyf(t, iamScopeList(decoded, "PolicyNames"),
+		"account B's user reports account A's inline policy: %v", decoded["PolicyNames"])
+
+	status, code, decoded = iamScopeResult(t, ts, iamScopeAccountB, "ListAttachedUserPolicies",
+		map[string]string{"UserName": "worker"})
+	require.Equalf(t, http.StatusOK, status, "ListAttachedUserPolicies as B: %s", code)
+	assert.Emptyf(t, iamScopeList(decoded, "AttachedPolicies"),
+		"account B's user reports account A's attachment: %v", decoded["AttachedPolicies"])
+
+	// And the inline document itself must not be readable across the accounts.
+	status, code, _ = iamScopeResult(t, ts, iamScopeAccountB, "GetUserPolicy", map[string]string{
+		"UserName":   "worker",
+		"PolicyName": "inline-read",
+	})
+	assert.Equal(t, http.StatusNotFound, status, "account B read account A's inline policy")
+	assert.Equal(t, "NoSuchEntity", code)
+}

--- a/emulator/iam_groups.go
+++ b/emulator/iam_groups.go
@@ -50,11 +50,11 @@ func (p *IAMPlugin) addUserToGroup(ctx *RequestContext, req *AWSRequest) (*AWSRe
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	if resp, err := p.requireGroupAndUser(goCtx, params.GroupName, params.UserName); resp != nil || err != nil {
+	if resp, err := p.requireGroupAndUser(goCtx, ctx.AccountID, params.GroupName, params.UserName); resp != nil || err != nil {
 		return resp, err
 	}
 
-	if err := p.addGroupMembership(goCtx, params.GroupName, params.UserName); err != nil {
+	if err := p.addGroupMembership(goCtx, ctx.AccountID, params.GroupName, params.UserName); err != nil {
 		return nil, err
 	}
 
@@ -79,14 +79,14 @@ func (p *IAMPlugin) removeUserFromGroup(ctx *RequestContext, req *AWSRequest) (*
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	if resp, err := p.requireGroupAndUser(goCtx, params.GroupName, params.UserName); resp != nil || err != nil {
+	if resp, err := p.requireGroupAndUser(goCtx, ctx.AccountID, params.GroupName, params.UserName); resp != nil || err != nil {
 		return resp, err
 	}
 
 	// AWS declares only NoSuchEntity for the group and the user, not for the
 	// membership: removing a user who is not a member is not an error, so the write
 	// is idempotent in both directions.
-	if err := p.removeGroupMembership(goCtx, params.GroupName, params.UserName); err != nil {
+	if err := p.removeGroupMembership(goCtx, ctx.AccountID, params.GroupName, params.UserName); err != nil {
 		return nil, err
 	}
 
@@ -112,7 +112,7 @@ func (p *IAMPlugin) listGroupsForUser(ctx *RequestContext, req *AWSRequest) (*AW
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	user, err := p.loadUser(goCtx, params.UserName)
+	user, err := p.loadUser(goCtx, ctx.AccountID, params.UserName)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (p *IAMPlugin) listGroupsForUser(ctx *RequestContext, req *AWSRequest) (*AW
 			http.StatusNotFound), nil
 	}
 
-	names, err := p.loadStringList(goCtx, iamUserGroupsKey(params.UserName))
+	names, err := p.loadStringList(goCtx, iamUserGroupsKey(ctx.AccountID, params.UserName))
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func (p *IAMPlugin) listGroupsForUser(ctx *RequestContext, req *AWSRequest) (*AW
 
 	groups := make([]*IAMGroup, 0, len(page))
 	for _, name := range page {
-		group, err := p.loadGroup(goCtx, name)
+		group, err := p.loadGroup(goCtx, ctx.AccountID, name)
 		if err != nil {
 			return nil, err
 		}
@@ -176,7 +176,7 @@ func (p *IAMPlugin) attachGroupPolicy(ctx *RequestContext, req *AWSRequest) (*AW
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	group, err := p.loadGroup(goCtx, params.GroupName)
+	group, err := p.loadGroup(goCtx, ctx.AccountID, params.GroupName)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +190,7 @@ func (p *IAMPlugin) attachGroupPolicy(ctx *RequestContext, req *AWSRequest) (*AW
 	// after the group lookup so an attach that is going to fail anyway does not also warn.
 	p.iamWarnUnresolvedPolicyARN(goCtx, "AttachGroupPolicy", params.PolicyArn)
 
-	listKey := iamGroupPoliciesKey(params.GroupName)
+	listKey := iamGroupPoliciesKey(ctx.AccountID, params.GroupName)
 	arns, err := p.loadPolicyList(goCtx, listKey)
 	if err != nil {
 		return nil, err
@@ -226,7 +226,7 @@ func (p *IAMPlugin) detachGroupPolicy(ctx *RequestContext, req *AWSRequest) (*AW
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	listKey := iamGroupPoliciesKey(params.GroupName)
+	listKey := iamGroupPoliciesKey(ctx.AccountID, params.GroupName)
 	arns, err := p.loadPolicyList(goCtx, listKey)
 	if err != nil {
 		return nil, err
@@ -272,7 +272,7 @@ func (p *IAMPlugin) listAttachedGroupPolicies(ctx *RequestContext, req *AWSReque
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	arns, err := p.loadPolicyList(goCtx, iamGroupPoliciesKey(params.GroupName))
+	arns, err := p.loadPolicyList(goCtx, iamGroupPoliciesKey(ctx.AccountID, params.GroupName))
 	if err != nil {
 		return nil, err
 	}
@@ -306,20 +306,12 @@ func (p *IAMPlugin) listGroupPolicies(ctx *RequestContext, req *AWSRequest) (*AW
 
 // --- State helpers ---------------------------------------------------------
 
-// iamGroupUsersKey is the state key holding a group's member user names.
-func iamGroupUsersKey(groupName string) string { return "group_users:" + groupName }
-
-// iamUserGroupsKey is the state key holding the group names a user belongs to.
-func iamUserGroupsKey(userName string) string { return "user_groups:" + userName }
-
-// iamGroupPoliciesKey is the state key holding a group's attached managed policy
-// ARNs. It follows the "<kind>_policies:<name>" form the user and role keys use,
-// which is what lets loadPoliciesForPrincipal read it with the same code.
-func iamGroupPoliciesKey(groupName string) string { return "group_policies:" + groupName }
+// The three group key builders live in iam_state_keys.go with every other IAM key,
+// since #737 gave all of them an account.
 
 // loadGroup returns the stored group, or nil when it does not exist.
-func (p *IAMPlugin) loadGroup(goCtx context.Context, name string) (*IAMGroup, error) {
-	raw, err := p.state.Get(goCtx, iamNamespace, "group:"+name)
+func (p *IAMPlugin) loadGroup(goCtx context.Context, accountID, name string) (*IAMGroup, error) {
+	raw, err := p.state.Get(goCtx, iamNamespace, iamGroupKey(accountID, name))
 	if err != nil {
 		return nil, fmt.Errorf("load group %s: %w", name, err)
 	}
@@ -338,8 +330,8 @@ func (p *IAMPlugin) loadGroup(goCtx context.Context, name string) (*IAMGroup, er
 //
 // The group is checked first because it is the operation's first parameter, so a
 // call naming two unknown entities reports the one a caller reads first.
-func (p *IAMPlugin) requireGroupAndUser(goCtx context.Context, groupName, userName string) (*AWSResponse, error) {
-	group, err := p.loadGroup(goCtx, groupName)
+func (p *IAMPlugin) requireGroupAndUser(goCtx context.Context, accountID, groupName, userName string) (*AWSResponse, error) {
+	group, err := p.loadGroup(goCtx, accountID, groupName)
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +340,7 @@ func (p *IAMPlugin) requireGroupAndUser(goCtx context.Context, groupName, userNa
 			fmt.Sprintf("The group with name %s cannot be found.", groupName),
 			http.StatusNotFound), nil
 	}
-	user, err := p.loadUser(goCtx, userName)
+	user, err := p.loadUser(goCtx, accountID, userName)
 	if err != nil {
 		return nil, err
 	}
@@ -367,20 +359,20 @@ func (p *IAMPlugin) requireGroupAndUser(goCtx context.Context, groupName, userNa
 // A membership visible to GetGroup but not to ListGroupsForUser — or worse, one
 // that grants the group's policies through CheckAccess while the API reports the
 // user as not a member — would be a state invariant broken by a missing line.
-func (p *IAMPlugin) addGroupMembership(goCtx context.Context, groupName, userName string) error {
-	if err := p.addToSortedList(goCtx, iamGroupUsersKey(groupName), userName); err != nil {
+func (p *IAMPlugin) addGroupMembership(goCtx context.Context, accountID, groupName, userName string) error {
+	if err := p.addToSortedList(goCtx, iamGroupUsersKey(accountID, groupName), userName); err != nil {
 		return err
 	}
-	return p.addToSortedList(goCtx, iamUserGroupsKey(userName), groupName)
+	return p.addToSortedList(goCtx, iamUserGroupsKey(accountID, userName), groupName)
 }
 
 // removeGroupMembership drops the membership from both sides of the index. It is
 // idempotent: removing a non-member changes nothing.
-func (p *IAMPlugin) removeGroupMembership(goCtx context.Context, groupName, userName string) error {
-	if err := p.removeFromList(goCtx, iamGroupUsersKey(groupName), userName); err != nil {
+func (p *IAMPlugin) removeGroupMembership(goCtx context.Context, accountID, groupName, userName string) error {
+	if err := p.removeFromList(goCtx, iamGroupUsersKey(accountID, groupName), userName); err != nil {
 		return err
 	}
-	return p.removeFromList(goCtx, iamUserGroupsKey(userName), groupName)
+	return p.removeFromList(goCtx, iamUserGroupsKey(accountID, userName), groupName)
 }
 
 // addToSortedList adds value to the string list at key, keeping it sorted and

--- a/emulator/iam_list_policies.go
+++ b/emulator/iam_list_policies.go
@@ -87,7 +87,7 @@ func (p *IAMPlugin) listPolicies(ctx *RequestContext, req *AWSRequest) (*AWSResp
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	candidates, err := p.iamPolicyCandidates(goCtx, scope)
+	candidates, err := p.iamPolicyCandidates(goCtx, ctx.AccountID, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (p *IAMPlugin) listPolicies(ctx *RequestContext, req *AWSRequest) (*AWSResp
 	// The attachment counts are computed once for the whole listing rather than per policy,
 	// because they come from walking the same state: one pass over the attachment lists
 	// reaches every ARN. Counting per policy would re-read every list 52 times.
-	attachments, err := p.iamPolicyAttachmentCounts(goCtx)
+	attachments, err := p.iamPolicyAttachmentCounts(goCtx, ctx.AccountID)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +147,7 @@ func (p *IAMPlugin) listPolicies(ctx *RequestContext, req *AWSRequest) (*AWSResp
 // ambiguous and a page could repeat or skip. A bundled ARN is under "::aws:" and
 // CreatePolicy builds a "::<account>:" one, so the two arms cannot collide through the API —
 // only a state key written directly could.
-func (p *IAMPlugin) iamPolicyCandidates(goCtx context.Context, scope string) ([]*IAMPolicy, error) {
+func (p *IAMPlugin) iamPolicyCandidates(goCtx context.Context, accountID, scope string) ([]*IAMPolicy, error) {
 	seen := make(map[string]bool)
 	candidates := make([]*IAMPolicy, 0, len(ListManagedPolicies()))
 
@@ -161,7 +161,7 @@ func (p *IAMPlugin) iamPolicyCandidates(goCtx context.Context, scope string) ([]
 		}
 	}
 	if scope == "All" || scope == "Local" {
-		keys, err := p.state.List(goCtx, iamNamespace, "policy:")
+		keys, err := p.state.List(goCtx, iamNamespace, iamPolicyPrefix(accountID))
 		if err != nil {
 			return nil, fmt.Errorf("list policies: %w", err)
 		}
@@ -196,13 +196,14 @@ func (p *IAMPlugin) iamPolicyCandidates(goCtx context.Context, scope string) ([]
 // on the entity's list and never touch a count on the policy, and the bundled catalog is
 // immutable — so a stored count would be zero for a bundled policy and could go stale for a
 // created one. Deriving it means an attach and a detach are both immediately visible.
-func (p *IAMPlugin) iamPolicyAttachmentCounts(goCtx context.Context) (map[string]int, error) {
+func (p *IAMPlugin) iamPolicyAttachmentCounts(goCtx context.Context, accountID string) (map[string]int, error) {
 	counts := make(map[string]int)
 
 	// Read from the attachment lists themselves rather than by enumerating entities:
 	// "<kind>_policies:<name>" is where every attach writes, so three prefixes reach users,
 	// groups and roles without loading a single entity record.
-	for _, prefix := range []string{"user_policies:", "group_policies:", "role_policies:"} {
+	for _, kind := range []string{"user", "group", "role"} {
+		prefix := iamAttachedPoliciesPrefix(accountID, kind)
 		keys, err := p.state.List(goCtx, iamNamespace, prefix)
 		if err != nil {
 			return nil, fmt.Errorf("list %s: %w", prefix, err)

--- a/emulator/iam_list_policies_test.go
+++ b/emulator/iam_list_policies_test.go
@@ -535,21 +535,25 @@ func TestListPolicies_StateFailureIsNotAnEmptyList(t *testing.T) {
 		{
 			// The Local arm's own listing.
 			name: "the policy listing fails",
-			arm:  func(s *iamFaultState) { s.listErrPrefix = "policy:" },
+			arm:  func(s *iamFaultState) { s.listErrPrefix = emulator.IAMPolicyPrefixForTest(authzTestAccount) },
 		},
 		{
 			name: "a policy record cannot be read",
-			arm:  func(s *iamFaultState) { s.getErrKeySubstr = "policy:arn:" },
+			arm:  func(s *iamFaultState) { s.getErrKeySubstr = "/arn:aws:iam:" },
 		},
 		{
 			// The attachment counts walk their own prefixes, so a failure there is a
 			// separate arm from the policy listing.
 			name: "the attachment listing fails",
-			arm:  func(s *iamFaultState) { s.listErrPrefix = "user_policies:" },
+			arm: func(s *iamFaultState) {
+				s.listErrPrefix = emulator.IAMAttachedPoliciesPrefixForTest(authzTestAccount, "user")
+			},
 		},
 		{
 			name: "an attachment list cannot be read",
-			arm:  func(s *iamFaultState) { s.getErrKeySubstr = "user_policies:" },
+			arm: func(s *iamFaultState) {
+				s.getErrKeySubstr = emulator.IAMAttachedPoliciesPrefixForTest(authzTestAccount, "user")
+			},
 		},
 	}
 
@@ -596,7 +600,7 @@ func TestListPolicies_ACorruptRecordDoesNotHideTheRest(t *testing.T) {
 		"PolicyName":     "mine",
 		"PolicyDocument": iamPolicyJSON(t, "Allow", []string{"s3:GetObject"}, "*"),
 	})
-	state.corruptKeySubstr = "policy:arn:"
+	state.corruptKeySubstr = "/arn:aws:iam:"
 
 	got := iamListPolicies(t, srv, map[string]any{"MaxItems": 1000})
 	assert.Len(t, got.Policies, len(emulator.ListManagedPolicies()),

--- a/emulator/iam_plugin.go
+++ b/emulator/iam_plugin.go
@@ -231,7 +231,7 @@ func (p *IAMPlugin) createUser(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	key := "user:" + params.UserName
+	key := iamUserKey(ctx.AccountID, params.UserName)
 	existing, err := p.state.Get(goCtx, iamNamespace, key)
 	if err != nil {
 		return nil, fmt.Errorf("get user: %w", err)
@@ -290,7 +290,7 @@ func (p *IAMPlugin) getUser(ctx *RequestContext, req *AWSRequest) (*AWSResponse,
 		return iamErrorResponse("ValidationError", "UserName is required", http.StatusBadRequest), nil
 	}
 
-	user, err := p.loadUser(goCtx, userName)
+	user, err := p.loadUser(goCtx, ctx.AccountID, userName)
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +320,7 @@ func (p *IAMPlugin) deleteUser(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	user, err := p.loadUser(goCtx, params.UserName)
+	user, err := p.loadUser(goCtx, ctx.AccountID, params.UserName)
 	if err != nil {
 		return nil, err
 	}
@@ -331,7 +331,7 @@ func (p *IAMPlugin) deleteUser(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 	}
 
 	// Check for attached policies.
-	arns, err := p.loadPolicyList(goCtx, "user_policies:"+params.UserName)
+	arns, err := p.loadPolicyList(goCtx, iamAttachedPoliciesKey(ctx.AccountID, "user", params.UserName))
 	if err != nil {
 		return nil, err
 	}
@@ -345,7 +345,7 @@ func (p *IAMPlugin) deleteUser(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 	// memberships (RemoveUserFromGroup)" — the DeleteUser reference. Deleting a
 	// member would otherwise leave the group's side of the index naming a user that
 	// no longer exists, and GetGroup would silently skip it.
-	groups, err := p.loadStringList(goCtx, iamUserGroupsKey(params.UserName))
+	groups, err := p.loadStringList(goCtx, iamUserGroupsKey(ctx.AccountID, params.UserName))
 	if err != nil {
 		return nil, err
 	}
@@ -358,7 +358,7 @@ func (p *IAMPlugin) deleteUser(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 			http.StatusConflict), nil
 	}
 
-	if err := p.state.Delete(goCtx, iamNamespace, "user:"+params.UserName); err != nil {
+	if err := p.state.Delete(goCtx, iamNamespace, iamUserKey(ctx.AccountID, params.UserName)); err != nil {
 		return nil, fmt.Errorf("delete user: %w", err)
 	}
 
@@ -381,7 +381,7 @@ func (p *IAMPlugin) listUsers(ctx *RequestContext, req *AWSRequest) (*AWSRespons
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	keys, err := p.state.List(goCtx, iamNamespace, "user:")
+	keys, err := p.state.List(goCtx, iamNamespace, iamUserPrefix(ctx.AccountID))
 	if err != nil {
 		return nil, fmt.Errorf("list users: %w", err)
 	}
@@ -440,7 +440,7 @@ func (p *IAMPlugin) createRole(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	key := "role:" + params.RoleName
+	key := iamRoleKey(ctx.AccountID, params.RoleName)
 	existing, err := p.state.Get(goCtx, iamNamespace, key)
 	if err != nil {
 		return nil, fmt.Errorf("get role: %w", err)
@@ -508,7 +508,7 @@ func (p *IAMPlugin) getRole(ctx *RequestContext, req *AWSRequest) (*AWSResponse,
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	role, err := p.loadRole(goCtx, params.RoleName)
+	role, err := p.loadRole(goCtx, ctx.AccountID, params.RoleName)
 	if err != nil {
 		return nil, err
 	}
@@ -553,7 +553,7 @@ func (p *IAMPlugin) updateAssumeRolePolicy(ctx *RequestContext, req *AWSRequest)
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	role, err := p.loadRole(goCtx, params.RoleName)
+	role, err := p.loadRole(goCtx, ctx.AccountID, params.RoleName)
 	if err != nil {
 		return nil, err
 	}
@@ -577,7 +577,7 @@ func (p *IAMPlugin) updateAssumeRolePolicy(ctx *RequestContext, req *AWSRequest)
 	if err != nil {
 		return nil, fmt.Errorf("marshal role: %w", err)
 	}
-	if err := p.state.Put(goCtx, iamNamespace, "role:"+params.RoleName, raw); err != nil {
+	if err := p.state.Put(goCtx, iamNamespace, iamRoleKey(ctx.AccountID, params.RoleName), raw); err != nil {
 		return nil, fmt.Errorf("put role: %w", err)
 	}
 
@@ -601,7 +601,7 @@ func (p *IAMPlugin) deleteRole(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	role, err := p.loadRole(goCtx, params.RoleName)
+	role, err := p.loadRole(goCtx, ctx.AccountID, params.RoleName)
 	if err != nil {
 		return nil, err
 	}
@@ -611,7 +611,7 @@ func (p *IAMPlugin) deleteRole(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 			http.StatusNotFound), nil
 	}
 
-	arns, err := p.loadPolicyList(goCtx, "role_policies:"+params.RoleName)
+	arns, err := p.loadPolicyList(goCtx, iamAttachedPoliciesKey(ctx.AccountID, "role", params.RoleName))
 	if err != nil {
 		return nil, err
 	}
@@ -628,7 +628,7 @@ func (p *IAMPlugin) deleteRole(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 	// profile listing a role that no longer exists, and DeleteInstanceProfile then
 	// refused with DeleteConflict — so the failure surfaced on the resource that was
 	// still present rather than on the one that broke the invariant (#581).
-	holders, err := p.instanceProfilesHoldingRole(goCtx, params.RoleName)
+	holders, err := p.instanceProfilesHoldingRole(goCtx, ctx.AccountID, params.RoleName)
 	if err != nil {
 		return nil, err
 	}
@@ -642,7 +642,7 @@ func (p *IAMPlugin) deleteRole(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 			http.StatusConflict), nil
 	}
 
-	if err := p.state.Delete(goCtx, iamNamespace, "role:"+params.RoleName); err != nil {
+	if err := p.state.Delete(goCtx, iamNamespace, iamRoleKey(ctx.AccountID, params.RoleName)); err != nil {
 		return nil, fmt.Errorf("delete role: %w", err)
 	}
 
@@ -665,7 +665,7 @@ func (p *IAMPlugin) listRoles(ctx *RequestContext, req *AWSRequest) (*AWSRespons
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	keys, err := p.state.List(goCtx, iamNamespace, "role:")
+	keys, err := p.state.List(goCtx, iamNamespace, iamRolePrefix(ctx.AccountID))
 	if err != nil {
 		return nil, fmt.Errorf("list roles: %w", err)
 	}
@@ -715,7 +715,7 @@ func (p *IAMPlugin) createGroup(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	key := "group:" + params.GroupName
+	key := iamGroupKey(ctx.AccountID, params.GroupName)
 	existing, err := p.state.Get(goCtx, iamNamespace, key)
 	if err != nil {
 		return nil, fmt.Errorf("get group: %w", err)
@@ -767,7 +767,7 @@ func (p *IAMPlugin) getGroup(ctx *RequestContext, req *AWSRequest) (*AWSResponse
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	raw, err := p.state.Get(goCtx, iamNamespace, "group:"+params.GroupName)
+	raw, err := p.state.Get(goCtx, iamNamespace, iamGroupKey(ctx.AccountID, params.GroupName))
 	if err != nil {
 		return nil, fmt.Errorf("get group: %w", err)
 	}
@@ -785,7 +785,7 @@ func (p *IAMPlugin) getGroup(ctx *RequestContext, req *AWSRequest) (*AWSResponse
 	// that are in the specified IAM group" — and this passed iamUserListXML(nil)
 	// unconditionally, so every group was observably empty. Nothing noticed because
 	// no operation could add a member until now.
-	memberNames, err := p.loadStringList(goCtx, iamGroupUsersKey(params.GroupName))
+	memberNames, err := p.loadStringList(goCtx, iamGroupUsersKey(ctx.AccountID, params.GroupName))
 	if err != nil {
 		return nil, err
 	}
@@ -793,7 +793,7 @@ func (p *IAMPlugin) getGroup(ctx *RequestContext, req *AWSRequest) (*AWSResponse
 
 	users := make([]*IAMUser, 0, len(page))
 	for _, name := range page {
-		user, err := p.loadUser(goCtx, name)
+		user, err := p.loadUser(goCtx, ctx.AccountID, name)
 		if err != nil {
 			return nil, err
 		}
@@ -830,7 +830,7 @@ func (p *IAMPlugin) deleteGroup(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	existing, err := p.state.Get(goCtx, iamNamespace, "group:"+params.GroupName)
+	existing, err := p.state.Get(goCtx, iamNamespace, iamGroupKey(ctx.AccountID, params.GroupName))
 	if err != nil {
 		return nil, fmt.Errorf("get group: %w", err)
 	}
@@ -845,7 +845,7 @@ func (p *IAMPlugin) deleteGroup(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 	// and DeleteRole. Without them a delete would leave a user_groups entry naming a
 	// group that no longer exists, and that membership would still be read by
 	// loadPoliciesForPrincipal.
-	members, err := p.loadStringList(goCtx, iamGroupUsersKey(params.GroupName))
+	members, err := p.loadStringList(goCtx, iamGroupUsersKey(ctx.AccountID, params.GroupName))
 	if err != nil {
 		return nil, err
 	}
@@ -855,7 +855,7 @@ func (p *IAMPlugin) deleteGroup(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 				"Users in %s: %s", params.GroupName, strings.Join(members, ", ")),
 			http.StatusConflict), nil
 	}
-	arns, err := p.loadPolicyList(goCtx, iamGroupPoliciesKey(params.GroupName))
+	arns, err := p.loadPolicyList(goCtx, iamGroupPoliciesKey(ctx.AccountID, params.GroupName))
 	if err != nil {
 		return nil, err
 	}
@@ -865,7 +865,7 @@ func (p *IAMPlugin) deleteGroup(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 			http.StatusConflict), nil
 	}
 
-	if err := p.state.Delete(goCtx, iamNamespace, "group:"+params.GroupName); err != nil {
+	if err := p.state.Delete(goCtx, iamNamespace, iamGroupKey(ctx.AccountID, params.GroupName)); err != nil {
 		return nil, fmt.Errorf("delete group: %w", err)
 	}
 
@@ -888,7 +888,7 @@ func (p *IAMPlugin) listGroups(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	keys, err := p.state.List(goCtx, iamNamespace, "group:")
+	keys, err := p.state.List(goCtx, iamNamespace, iamGroupPrefix(ctx.AccountID))
 	if err != nil {
 		return nil, fmt.Errorf("list groups: %w", err)
 	}
@@ -939,7 +939,7 @@ func (p *IAMPlugin) attachUserPolicy(ctx *RequestContext, req *AWSRequest) (*AWS
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	user, err := p.loadUser(goCtx, params.UserName)
+	user, err := p.loadUser(goCtx, ctx.AccountID, params.UserName)
 	if err != nil {
 		return nil, err
 	}
@@ -953,7 +953,7 @@ func (p *IAMPlugin) attachUserPolicy(ctx *RequestContext, req *AWSRequest) (*AWS
 	// after the user lookup so an attach that is going to fail anyway does not also warn.
 	p.iamWarnUnresolvedPolicyARN(goCtx, "AttachUserPolicy", params.PolicyArn)
 
-	listKey := "user_policies:" + params.UserName
+	listKey := iamAttachedPoliciesKey(ctx.AccountID, "user", params.UserName)
 	arns, err := p.loadPolicyList(goCtx, listKey)
 	if err != nil {
 		return nil, err
@@ -989,7 +989,7 @@ func (p *IAMPlugin) detachUserPolicy(ctx *RequestContext, req *AWSRequest) (*AWS
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	listKey := "user_policies:" + params.UserName
+	listKey := iamAttachedPoliciesKey(ctx.AccountID, "user", params.UserName)
 	arns, err := p.loadPolicyList(goCtx, listKey)
 	if err != nil {
 		return nil, err
@@ -1035,7 +1035,7 @@ func (p *IAMPlugin) listAttachedUserPolicies(ctx *RequestContext, req *AWSReques
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	arns, err := p.loadPolicyList(goCtx, "user_policies:"+params.UserName)
+	arns, err := p.loadPolicyList(goCtx, iamAttachedPoliciesKey(ctx.AccountID, "user", params.UserName))
 	if err != nil {
 		return nil, err
 	}
@@ -1073,7 +1073,7 @@ func (p *IAMPlugin) attachRolePolicy(ctx *RequestContext, req *AWSRequest) (*AWS
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	role, err := p.loadRole(goCtx, params.RoleName)
+	role, err := p.loadRole(goCtx, ctx.AccountID, params.RoleName)
 	if err != nil {
 		return nil, err
 	}
@@ -1087,7 +1087,7 @@ func (p *IAMPlugin) attachRolePolicy(ctx *RequestContext, req *AWSRequest) (*AWS
 	// after the role lookup so an attach that is going to fail anyway does not also warn.
 	p.iamWarnUnresolvedPolicyARN(goCtx, "AttachRolePolicy", params.PolicyArn)
 
-	listKey := "role_policies:" + params.RoleName
+	listKey := iamAttachedPoliciesKey(ctx.AccountID, "role", params.RoleName)
 	arns, err := p.loadPolicyList(goCtx, listKey)
 	if err != nil {
 		return nil, err
@@ -1123,7 +1123,7 @@ func (p *IAMPlugin) detachRolePolicy(ctx *RequestContext, req *AWSRequest) (*AWS
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	listKey := "role_policies:" + params.RoleName
+	listKey := iamAttachedPoliciesKey(ctx.AccountID, "role", params.RoleName)
 	arns, err := p.loadPolicyList(goCtx, listKey)
 	if err != nil {
 		return nil, err
@@ -1169,7 +1169,7 @@ func (p *IAMPlugin) listAttachedRolePolicies(ctx *RequestContext, req *AWSReques
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	arns, err := p.loadPolicyList(goCtx, "role_policies:"+params.RoleName)
+	arns, err := p.loadPolicyList(goCtx, iamAttachedPoliciesKey(ctx.AccountID, "role", params.RoleName))
 	if err != nil {
 		return nil, err
 	}
@@ -1210,7 +1210,7 @@ func (p *IAMPlugin) createPolicy(ctx *RequestContext, req *AWSRequest) (*AWSResp
 	}
 	arn := iamPolicyARN(ctx.AccountID, params.Path, params.PolicyName)
 
-	existing, err := p.state.Get(goCtx, iamNamespace, "policy:"+arn)
+	existing, err := p.state.Get(goCtx, iamNamespace, iamPolicyKey(arn))
 	if err != nil {
 		return nil, fmt.Errorf("get policy: %w", err)
 	}
@@ -1249,7 +1249,7 @@ func (p *IAMPlugin) createPolicy(ctx *RequestContext, req *AWSRequest) (*AWSResp
 	if err != nil {
 		return nil, fmt.Errorf("marshal policy: %w", err)
 	}
-	if err := p.state.Put(goCtx, iamNamespace, "policy:"+arn, raw); err != nil {
+	if err := p.state.Put(goCtx, iamNamespace, iamPolicyKey(arn), raw); err != nil {
 		return nil, fmt.Errorf("put policy: %w", err)
 	}
 
@@ -1278,7 +1278,7 @@ func (p *IAMPlugin) getPolicy(ctx *RequestContext, req *AWSRequest) (*AWSRespons
 		return iamXMLResponse(http.StatusOK, "GetPolicy", iamSinglePolicyXML(mp))
 	}
 
-	raw, err := p.state.Get(goCtx, iamNamespace, "policy:"+params.PolicyArn)
+	raw, err := p.state.Get(goCtx, iamNamespace, iamPolicyKey(params.PolicyArn))
 	if err != nil {
 		return nil, fmt.Errorf("get policy: %w", err)
 	}
@@ -1312,7 +1312,7 @@ func (p *IAMPlugin) deletePolicy(ctx *RequestContext, req *AWSRequest) (*AWSResp
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	raw, err := p.state.Get(goCtx, iamNamespace, "policy:"+params.PolicyArn)
+	raw, err := p.state.Get(goCtx, iamNamespace, iamPolicyKey(params.PolicyArn))
 	if err != nil {
 		return nil, fmt.Errorf("get policy: %w", err)
 	}
@@ -1322,7 +1322,7 @@ func (p *IAMPlugin) deletePolicy(ctx *RequestContext, req *AWSRequest) (*AWSResp
 			http.StatusNotFound), nil
 	}
 
-	if err := p.state.Delete(goCtx, iamNamespace, "policy:"+params.PolicyArn); err != nil {
+	if err := p.state.Delete(goCtx, iamNamespace, iamPolicyKey(params.PolicyArn)); err != nil {
 		return nil, fmt.Errorf("delete policy: %w", err)
 	}
 
@@ -1357,7 +1357,7 @@ func (p *IAMPlugin) createAccessKey(ctx *RequestContext, req *AWSRequest) (*AWSR
 		return iamErrorResponse("ValidationError", "UserName is required", http.StatusBadRequest), nil
 	}
 
-	user, err := p.loadUser(goCtx, userName)
+	user, err := p.loadUser(goCtx, ctx.AccountID, userName)
 	if err != nil {
 		return nil, err
 	}
@@ -1373,18 +1373,21 @@ func (p *IAMPlugin) createAccessKey(ctx *RequestContext, req *AWSRequest) (*AWSR
 		Status:          "Active",
 		UserName:        userName,
 		CreateDate:      p.now().UTC(),
+		// The account is on the record because it cannot be in the key — an access key
+		// ID is resolved before any account is known (#737).
+		AccountID: ctx.AccountID,
 	}
 
 	raw, err := json.Marshal(accessKey)
 	if err != nil {
 		return nil, fmt.Errorf("marshal access key: %w", err)
 	}
-	if err := p.state.Put(goCtx, iamNamespace, "accesskey:"+accessKey.AccessKeyID, raw); err != nil {
+	if err := p.state.Put(goCtx, iamNamespace, iamAccessKeyKey(accessKey.AccessKeyID), raw); err != nil {
 		return nil, fmt.Errorf("put access key: %w", err)
 	}
 
 	// Update user's key index.
-	indexKey := "user_accesskeys:" + userName
+	indexKey := iamUserAccessKeysKey(ctx.AccountID, userName)
 	keyIDs, err := p.loadStringList(goCtx, indexKey)
 	if err != nil {
 		return nil, err
@@ -1415,7 +1418,7 @@ func (p *IAMPlugin) deleteAccessKey(ctx *RequestContext, req *AWSRequest) (*AWSR
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	raw, err := p.state.Get(goCtx, iamNamespace, "accesskey:"+params.AccessKeyID)
+	raw, err := p.state.Get(goCtx, iamNamespace, iamAccessKeyKey(params.AccessKeyID))
 	if err != nil {
 		return nil, fmt.Errorf("get access key: %w", err)
 	}
@@ -1429,12 +1432,12 @@ func (p *IAMPlugin) deleteAccessKey(ctx *RequestContext, req *AWSRequest) (*AWSR
 		return nil, fmt.Errorf("unmarshal access key: %w", err)
 	}
 
-	if err := p.state.Delete(goCtx, iamNamespace, "accesskey:"+params.AccessKeyID); err != nil {
+	if err := p.state.Delete(goCtx, iamNamespace, iamAccessKeyKey(params.AccessKeyID)); err != nil {
 		return nil, fmt.Errorf("delete access key: %w", err)
 	}
 
 	// Remove from user index.
-	indexKey := "user_accesskeys:" + key.UserName
+	indexKey := iamUserAccessKeysKey(ctx.AccountID, key.UserName)
 	keyIDs, err := p.loadStringList(goCtx, indexKey)
 	if err != nil {
 		return nil, err
@@ -1478,7 +1481,7 @@ func (p *IAMPlugin) listAccessKeys(ctx *RequestContext, req *AWSRequest) (*AWSRe
 		return iamErrorResponse("ValidationError", "UserName is required", http.StatusBadRequest), nil
 	}
 
-	keyIDs, err := p.loadStringList(goCtx, "user_accesskeys:"+userName)
+	keyIDs, err := p.loadStringList(goCtx, iamUserAccessKeysKey(ctx.AccountID, userName))
 	if err != nil {
 		return nil, err
 	}
@@ -1486,7 +1489,7 @@ func (p *IAMPlugin) listAccessKeys(ctx *RequestContext, req *AWSRequest) (*AWSRe
 	// Build metadata-only list (no SecretAccessKey).
 	keys := make([]map[string]any, 0, len(keyIDs))
 	for _, id := range keyIDs {
-		raw, err := p.state.Get(goCtx, iamNamespace, "accesskey:"+id)
+		raw, err := p.state.Get(goCtx, iamNamespace, iamAccessKeyKey(id))
 		if err != nil || raw == nil {
 			continue
 		}
@@ -1547,12 +1550,12 @@ func (p *IAMPlugin) authorize(goCtx context.Context, reqCtx *RequestContext, act
 	// there. That is the #411 split exactly: one ARN, two loaders, two answers.
 	sources := []iamEntity{entity}
 	if entityType == "user" {
-		groups, err := p.loadStringList(goCtx, iamUserGroupsKey(entityName))
+		groups, err := p.loadStringList(goCtx, iamUserGroupsKey(entity.Account, entityName))
 		if err != nil {
 			return fmt.Errorf("load group memberships for authorization: %w", err)
 		}
 		for _, name := range groups {
-			sources = append(sources, iamEntity{Kind: "group", Name: name})
+			sources = append(sources, iamEntity{Account: entity.Account, Kind: "group", Name: name})
 		}
 	}
 
@@ -1561,7 +1564,7 @@ func (p *IAMPlugin) authorize(goCtx context.Context, reqCtx *RequestContext, act
 	arnsBySource := make([][]string, 0, len(sources))
 	hasAdminAccess := false
 	for _, source := range sources {
-		arns, err := p.loadPolicyList(goCtx, source.Kind+"_policies:"+source.Name)
+		arns, err := p.loadPolicyList(goCtx, iamAttachedPoliciesKey(source.Account, source.Kind, source.Name))
 		if err != nil {
 			return fmt.Errorf("load policies for authorization: %w", err)
 		}
@@ -1591,7 +1594,7 @@ func (p *IAMPlugin) authorize(goCtx context.Context, reqCtx *RequestContext, act
 				docs = append(docs, mp.Document)
 				continue
 			}
-			raw, err := p.state.Get(goCtx, iamNamespace, "policy:"+arn)
+			raw, err := p.state.Get(goCtx, iamNamespace, iamPolicyKey(arn))
 			if err != nil || raw == nil {
 				continue
 			}
@@ -1603,9 +1606,9 @@ func (p *IAMPlugin) authorize(goCtx context.Context, reqCtx *RequestContext, act
 		}
 
 		// Also load inline policies for the entity.
-		inlineNames, _ := p.loadInlinePolicyNames(goCtx, source.Kind, source.Name)
+		inlineNames, _ := p.loadInlinePolicyNames(goCtx, source.Account, source.Kind, source.Name)
 		for _, name := range inlineNames {
-			doc, _ := p.loadInlinePolicyDoc(goCtx, source.Kind, source.Name, name)
+			doc, _ := p.loadInlinePolicyDoc(goCtx, source.Account, source.Kind, source.Name, name)
 			if doc != nil {
 				docs = append(docs, *doc)
 			}
@@ -1644,7 +1647,7 @@ func (p *IAMPlugin) authorize(goCtx context.Context, reqCtx *RequestContext, act
 	// above guarantees Kind is "user" or "role" and that the record exists, so this
 	// is one read rather than a switch that had to repeat the same entity-type
 	// decision a third time.
-	entityRaw, _ := p.state.Get(goCtx, iamNamespace, entityType+":"+entityName)
+	entityRaw, _ := p.state.Get(goCtx, iamNamespace, iamEntityKey(entity.Account, entityType, entityName))
 	if entityRaw != nil {
 		var stored struct {
 			PermissionsBoundary *IAMAttachedPolicy `json:"PermissionsBoundary,omitempty"`
@@ -1755,7 +1758,7 @@ func (p *IAMPlugin) putInlinePolicy(ctx *RequestContext, req *AWSRequest, entity
 	// Verify the entity exists. The key prefix is the entity type itself, so a new
 	// type needs no arm here — the previous form branched on "user" with a default
 	// arm reading "role:", which would have silently looked a group up as a role.
-	entityRaw, getErr := p.state.Get(goCtx, iamNamespace, entityType+":"+entityName)
+	entityRaw, getErr := p.state.Get(goCtx, iamNamespace, iamEntityKey(ctx.AccountID, entityType, entityName))
 	if getErr != nil {
 		return nil, fmt.Errorf("get %s: %w", entityType, getErr)
 	}
@@ -1779,13 +1782,13 @@ func (p *IAMPlugin) putInlinePolicy(ctx *RequestContext, req *AWSRequest, entity
 	if err != nil {
 		return nil, fmt.Errorf("marshal inline policy: %w", err)
 	}
-	stateKey := entityType + "_inline:" + entityName + ":" + params.PolicyName
+	stateKey := iamInlinePolicyKey(ctx.AccountID, entityType, entityName, params.PolicyName)
 	if err := p.state.Put(goCtx, iamNamespace, stateKey, docRaw); err != nil {
 		return nil, fmt.Errorf("put inline policy: %w", err)
 	}
 
 	// Update the names list.
-	namesKey := entityType + "_inline_names:" + entityName
+	namesKey := iamInlinePolicyNamesKey(ctx.AccountID, entityType, entityName)
 	names, err := p.loadStringList(goCtx, namesKey)
 	if err != nil {
 		return nil, err
@@ -1831,7 +1834,7 @@ func (p *IAMPlugin) getInlinePolicy(ctx *RequestContext, req *AWSRequest, entity
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	raw, err := p.state.Get(goCtx, iamNamespace, entityType+"_inline:"+entityName+":"+params.PolicyName)
+	raw, err := p.state.Get(goCtx, iamNamespace, iamInlinePolicyKey(ctx.AccountID, entityType, entityName, params.PolicyName))
 	if err != nil {
 		return nil, fmt.Errorf("get inline policy: %w", err)
 	}
@@ -1872,7 +1875,7 @@ func (p *IAMPlugin) deleteInlinePolicy(ctx *RequestContext, req *AWSRequest, ent
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	stateKey := entityType + "_inline:" + entityName + ":" + params.PolicyName
+	stateKey := iamInlinePolicyKey(ctx.AccountID, entityType, entityName, params.PolicyName)
 	existing, err := p.state.Get(goCtx, iamNamespace, stateKey)
 	if err != nil {
 		return nil, fmt.Errorf("check inline policy: %w", err)
@@ -1887,7 +1890,7 @@ func (p *IAMPlugin) deleteInlinePolicy(ctx *RequestContext, req *AWSRequest, ent
 	}
 
 	// Remove from names list.
-	namesKey := entityType + "_inline_names:" + entityName
+	namesKey := iamInlinePolicyNamesKey(ctx.AccountID, entityType, entityName)
 	names, err := p.loadStringList(goCtx, namesKey)
 	if err != nil {
 		return nil, err
@@ -1929,7 +1932,7 @@ func (p *IAMPlugin) listInlinePolicies(ctx *RequestContext, req *AWSRequest, ent
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	names, err := p.loadStringList(goCtx, entityType+"_inline_names:"+entityName)
+	names, err := p.loadStringList(goCtx, iamInlinePolicyNamesKey(ctx.AccountID, entityType, entityName))
 	if err != nil {
 		return nil, err
 	}
@@ -1993,10 +1996,10 @@ func (p *IAMPlugin) putPermissionsBoundary(ctx *RequestContext, req *AWSRequest,
 		PolicyName: arnPolicyName(params.PermissionsBoundary),
 	}
 
-	stateKey := entityType + ":" + entityName
+	stateKey := iamEntityKey(ctx.AccountID, entityType, entityName)
 	switch entityType {
 	case "user":
-		user, err := p.loadUser(goCtx, entityName)
+		user, err := p.loadUser(goCtx, ctx.AccountID, entityName)
 		if err != nil {
 			return nil, err
 		}
@@ -2014,7 +2017,7 @@ func (p *IAMPlugin) putPermissionsBoundary(ctx *RequestContext, req *AWSRequest,
 			return nil, fmt.Errorf("put user: %w", err)
 		}
 	default:
-		role, err := p.loadRole(goCtx, entityName)
+		role, err := p.loadRole(goCtx, ctx.AccountID, entityName)
 		if err != nil {
 			return nil, err
 		}
@@ -2061,10 +2064,10 @@ func (p *IAMPlugin) deletePermissionsBoundary(ctx *RequestContext, req *AWSReque
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	stateKey := entityType + ":" + entityName
+	stateKey := iamEntityKey(ctx.AccountID, entityType, entityName)
 	switch entityType {
 	case "user":
-		user, err := p.loadUser(goCtx, entityName)
+		user, err := p.loadUser(goCtx, ctx.AccountID, entityName)
 		if err != nil {
 			return nil, err
 		}
@@ -2082,7 +2085,7 @@ func (p *IAMPlugin) deletePermissionsBoundary(ctx *RequestContext, req *AWSReque
 			return nil, fmt.Errorf("put user: %w", err)
 		}
 	default:
-		role, err := p.loadRole(goCtx, entityName)
+		role, err := p.loadRole(goCtx, ctx.AccountID, entityName)
 		if err != nil {
 			return nil, err
 		}
@@ -2132,7 +2135,7 @@ func (p *IAMPlugin) tagUser(ctx *RequestContext, req *AWSRequest) (*AWSResponse,
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	user, err := p.loadUser(goCtx, params.UserName)
+	user, err := p.loadUser(goCtx, ctx.AccountID, params.UserName)
 	if err != nil {
 		return nil, err
 	}
@@ -2161,7 +2164,7 @@ func (p *IAMPlugin) tagUser(ctx *RequestContext, req *AWSRequest) (*AWSResponse,
 	if err != nil {
 		return nil, fmt.Errorf("tagUser marshal: %w", err)
 	}
-	if err := p.state.Put(goCtx, iamNamespace, "user:"+params.UserName, raw); err != nil {
+	if err := p.state.Put(goCtx, iamNamespace, iamUserKey(ctx.AccountID, params.UserName), raw); err != nil {
 		return nil, fmt.Errorf("tagUser put: %w", err)
 	}
 
@@ -2190,7 +2193,7 @@ func (p *IAMPlugin) untagUser(ctx *RequestContext, req *AWSRequest) (*AWSRespons
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	user, err := p.loadUser(goCtx, params.UserName)
+	user, err := p.loadUser(goCtx, ctx.AccountID, params.UserName)
 	if err != nil {
 		return nil, err
 	}
@@ -2216,7 +2219,7 @@ func (p *IAMPlugin) untagUser(ctx *RequestContext, req *AWSRequest) (*AWSRespons
 	if err != nil {
 		return nil, fmt.Errorf("untagUser marshal: %w", err)
 	}
-	if err := p.state.Put(goCtx, iamNamespace, "user:"+params.UserName, raw); err != nil {
+	if err := p.state.Put(goCtx, iamNamespace, iamUserKey(ctx.AccountID, params.UserName), raw); err != nil {
 		return nil, fmt.Errorf("untagUser put: %w", err)
 	}
 
@@ -2242,7 +2245,7 @@ func (p *IAMPlugin) listUserTags(ctx *RequestContext, req *AWSRequest) (*AWSResp
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	user, err := p.loadUser(goCtx, params.UserName)
+	user, err := p.loadUser(goCtx, ctx.AccountID, params.UserName)
 	if err != nil {
 		return nil, err
 	}
@@ -2311,7 +2314,7 @@ func (p *IAMPlugin) tagRole(ctx *RequestContext, req *AWSRequest) (*AWSResponse,
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	role, err := p.loadRole(goCtx, params.RoleName)
+	role, err := p.loadRole(goCtx, ctx.AccountID, params.RoleName)
 	if err != nil {
 		return nil, err
 	}
@@ -2340,7 +2343,7 @@ func (p *IAMPlugin) tagRole(ctx *RequestContext, req *AWSRequest) (*AWSResponse,
 	if err != nil {
 		return nil, fmt.Errorf("tagRole marshal: %w", err)
 	}
-	if err := p.state.Put(goCtx, iamNamespace, "role:"+params.RoleName, raw); err != nil {
+	if err := p.state.Put(goCtx, iamNamespace, iamRoleKey(ctx.AccountID, params.RoleName), raw); err != nil {
 		return nil, fmt.Errorf("tagRole put: %w", err)
 	}
 
@@ -2369,7 +2372,7 @@ func (p *IAMPlugin) untagRole(ctx *RequestContext, req *AWSRequest) (*AWSRespons
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	role, err := p.loadRole(goCtx, params.RoleName)
+	role, err := p.loadRole(goCtx, ctx.AccountID, params.RoleName)
 	if err != nil {
 		return nil, err
 	}
@@ -2395,7 +2398,7 @@ func (p *IAMPlugin) untagRole(ctx *RequestContext, req *AWSRequest) (*AWSRespons
 	if err != nil {
 		return nil, fmt.Errorf("untagRole marshal: %w", err)
 	}
-	if err := p.state.Put(goCtx, iamNamespace, "role:"+params.RoleName, raw); err != nil {
+	if err := p.state.Put(goCtx, iamNamespace, iamRoleKey(ctx.AccountID, params.RoleName), raw); err != nil {
 		return nil, fmt.Errorf("untagRole put: %w", err)
 	}
 
@@ -2421,7 +2424,7 @@ func (p *IAMPlugin) listRoleTags(ctx *RequestContext, req *AWSRequest) (*AWSResp
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	role, err := p.loadRole(goCtx, params.RoleName)
+	role, err := p.loadRole(goCtx, ctx.AccountID, params.RoleName)
 	if err != nil {
 		return nil, err
 	}
@@ -2469,8 +2472,8 @@ func (p *IAMPlugin) listRoleTags(ctx *RequestContext, req *AWSRequest) (*AWSResp
 
 // --- State helpers ---------------------------------------------------------
 
-func (p *IAMPlugin) loadUser(goCtx context.Context, name string) (*IAMUser, error) {
-	raw, err := p.state.Get(goCtx, iamNamespace, "user:"+name)
+func (p *IAMPlugin) loadUser(goCtx context.Context, accountID, name string) (*IAMUser, error) {
+	raw, err := p.state.Get(goCtx, iamNamespace, iamUserKey(accountID, name))
 	if err != nil {
 		return nil, fmt.Errorf("load user %s: %w", name, err)
 	}
@@ -2484,8 +2487,8 @@ func (p *IAMPlugin) loadUser(goCtx context.Context, name string) (*IAMUser, erro
 	return &u, nil
 }
 
-func (p *IAMPlugin) loadRole(goCtx context.Context, name string) (*IAMRole, error) {
-	raw, err := p.state.Get(goCtx, iamNamespace, "role:"+name)
+func (p *IAMPlugin) loadRole(goCtx context.Context, accountID, name string) (*IAMRole, error) {
+	raw, err := p.state.Get(goCtx, iamNamespace, iamRoleKey(accountID, name))
 	if err != nil {
 		return nil, fmt.Errorf("load role %s: %w", name, err)
 	}
@@ -2505,14 +2508,14 @@ func (p *IAMPlugin) loadPolicyList(goCtx context.Context, key string) ([]string,
 
 // loadInlinePolicyNames returns the sorted list of inline policy names for the
 // given entity (entityType = "user" or "role").
-func (p *IAMPlugin) loadInlinePolicyNames(goCtx context.Context, entityType, entityName string) ([]string, error) {
-	return p.loadStringList(goCtx, entityType+"_inline_names:"+entityName)
+func (p *IAMPlugin) loadInlinePolicyNames(goCtx context.Context, accountID, entityType, entityName string) ([]string, error) {
+	return p.loadStringList(goCtx, iamInlinePolicyNamesKey(accountID, entityType, entityName))
 }
 
 // loadInlinePolicyDoc loads and parses an inline policy document. Returns nil
 // when the key is not found.
-func (p *IAMPlugin) loadInlinePolicyDoc(goCtx context.Context, entityType, entityName, policyName string) (*PolicyDocument, error) {
-	raw, err := p.state.Get(goCtx, iamNamespace, entityType+"_inline:"+entityName+":"+policyName)
+func (p *IAMPlugin) loadInlinePolicyDoc(goCtx context.Context, accountID, entityType, entityName, policyName string) (*PolicyDocument, error) {
+	raw, err := p.state.Get(goCtx, iamNamespace, iamInlinePolicyKey(accountID, entityType, entityName, policyName))
 	if err != nil {
 		return nil, fmt.Errorf("load inline policy %s/%s/%s: %w", entityType, entityName, policyName, err)
 	}
@@ -2532,7 +2535,7 @@ func (p *IAMPlugin) loadBoundaryPolicyDocs(goCtx context.Context, arn string) []
 	if mp, ok := GetManagedPolicy(arn); ok {
 		return []PolicyDocument{mp.Document}
 	}
-	raw, err := p.state.Get(goCtx, iamNamespace, "policy:"+arn)
+	raw, err := p.state.Get(goCtx, iamNamespace, iamPolicyKey(arn))
 	if err != nil || raw == nil {
 		return nil
 	}
@@ -2677,7 +2680,7 @@ func (p *IAMPlugin) createInstanceProfile(ctx *RequestContext, req *AWSRequest) 
 	}
 
 	goCtx := context.Background()
-	key := "instance_profile:" + params.InstanceProfileName
+	key := iamInstanceProfileKey(ctx.AccountID, params.InstanceProfileName)
 	existing, err := p.state.Get(goCtx, iamNamespace, key)
 	if err != nil {
 		return nil, fmt.Errorf("get instance profile: %w", err)
@@ -2707,7 +2710,7 @@ func (p *IAMPlugin) createInstanceProfile(ctx *RequestContext, req *AWSRequest) 
 	return iamXMLResponse(http.StatusOK, "CreateInstanceProfile", iamSingleInstanceProfileXML(profile))
 }
 
-func (p *IAMPlugin) getInstanceProfile(_ *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *IAMPlugin) getInstanceProfile(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	var params struct {
 		InstanceProfileName string `json:"InstanceProfileName"`
 	}
@@ -2719,7 +2722,7 @@ func (p *IAMPlugin) getInstanceProfile(_ *RequestContext, req *AWSRequest) (*AWS
 	}
 
 	goCtx := context.Background()
-	data, err := p.state.Get(goCtx, iamNamespace, "instance_profile:"+params.InstanceProfileName)
+	data, err := p.state.Get(goCtx, iamNamespace, iamInstanceProfileKey(ctx.AccountID, params.InstanceProfileName))
 	if err != nil {
 		return nil, fmt.Errorf("get instance profile: %w", err)
 	}
@@ -2735,7 +2738,7 @@ func (p *IAMPlugin) getInstanceProfile(_ *RequestContext, req *AWSRequest) (*AWS
 	return iamXMLResponse(http.StatusOK, "GetInstanceProfile", iamSingleInstanceProfileXML(&profile))
 }
 
-func (p *IAMPlugin) deleteInstanceProfile(_ *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *IAMPlugin) deleteInstanceProfile(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	var params struct {
 		InstanceProfileName string `json:"InstanceProfileName"`
 	}
@@ -2747,7 +2750,7 @@ func (p *IAMPlugin) deleteInstanceProfile(_ *RequestContext, req *AWSRequest) (*
 	}
 
 	goCtx := context.Background()
-	data, err := p.state.Get(goCtx, iamNamespace, "instance_profile:"+params.InstanceProfileName)
+	data, err := p.state.Get(goCtx, iamNamespace, iamInstanceProfileKey(ctx.AccountID, params.InstanceProfileName))
 	if err != nil {
 		return nil, fmt.Errorf("get instance profile: %w", err)
 	}
@@ -2765,13 +2768,13 @@ func (p *IAMPlugin) deleteInstanceProfile(_ *RequestContext, req *AWSRequest) (*
 			"Cannot delete entity, must detach all roles first.",
 			http.StatusConflict), nil
 	}
-	if err := p.state.Delete(goCtx, iamNamespace, "instance_profile:"+params.InstanceProfileName); err != nil {
+	if err := p.state.Delete(goCtx, iamNamespace, iamInstanceProfileKey(ctx.AccountID, params.InstanceProfileName)); err != nil {
 		return nil, fmt.Errorf("delete instance profile: %w", err)
 	}
 	return iamXMLEmptyResponse("DeleteInstanceProfile"), nil
 }
 
-func (p *IAMPlugin) addRoleToInstanceProfile(_ *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *IAMPlugin) addRoleToInstanceProfile(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	var params struct {
 		InstanceProfileName string `json:"InstanceProfileName"`
 		RoleName            string `json:"RoleName"`
@@ -2784,7 +2787,7 @@ func (p *IAMPlugin) addRoleToInstanceProfile(_ *RequestContext, req *AWSRequest)
 	}
 
 	goCtx := context.Background()
-	profData, err := p.state.Get(goCtx, iamNamespace, "instance_profile:"+params.InstanceProfileName)
+	profData, err := p.state.Get(goCtx, iamNamespace, iamInstanceProfileKey(ctx.AccountID, params.InstanceProfileName))
 	if err != nil {
 		return nil, fmt.Errorf("get instance profile: %w", err)
 	}
@@ -2803,7 +2806,7 @@ func (p *IAMPlugin) addRoleToInstanceProfile(_ *RequestContext, req *AWSRequest)
 			http.StatusConflict), nil
 	}
 
-	roleData, err := p.state.Get(goCtx, iamNamespace, "role:"+params.RoleName)
+	roleData, err := p.state.Get(goCtx, iamNamespace, iamRoleKey(ctx.AccountID, params.RoleName))
 	if err != nil {
 		return nil, fmt.Errorf("get role: %w", err)
 	}
@@ -2822,13 +2825,13 @@ func (p *IAMPlugin) addRoleToInstanceProfile(_ *RequestContext, req *AWSRequest)
 	if err != nil {
 		return nil, fmt.Errorf("marshal instance profile: %w", err)
 	}
-	if err := p.state.Put(goCtx, iamNamespace, "instance_profile:"+params.InstanceProfileName, raw); err != nil {
+	if err := p.state.Put(goCtx, iamNamespace, iamInstanceProfileKey(ctx.AccountID, params.InstanceProfileName), raw); err != nil {
 		return nil, fmt.Errorf("put instance profile: %w", err)
 	}
 	return iamXMLEmptyResponse("AddRoleToInstanceProfile"), nil
 }
 
-func (p *IAMPlugin) removeRoleFromInstanceProfile(_ *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *IAMPlugin) removeRoleFromInstanceProfile(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	var params struct {
 		InstanceProfileName string `json:"InstanceProfileName"`
 		RoleName            string `json:"RoleName"`
@@ -2841,7 +2844,7 @@ func (p *IAMPlugin) removeRoleFromInstanceProfile(_ *RequestContext, req *AWSReq
 	}
 
 	goCtx := context.Background()
-	profData, err := p.state.Get(goCtx, iamNamespace, "instance_profile:"+params.InstanceProfileName)
+	profData, err := p.state.Get(goCtx, iamNamespace, iamInstanceProfileKey(ctx.AccountID, params.InstanceProfileName))
 	if err != nil {
 		return nil, fmt.Errorf("get instance profile: %w", err)
 	}
@@ -2870,7 +2873,7 @@ func (p *IAMPlugin) removeRoleFromInstanceProfile(_ *RequestContext, req *AWSReq
 	if err != nil {
 		return nil, fmt.Errorf("marshal instance profile: %w", err)
 	}
-	if err := p.state.Put(goCtx, iamNamespace, "instance_profile:"+params.InstanceProfileName, raw); err != nil {
+	if err := p.state.Put(goCtx, iamNamespace, iamInstanceProfileKey(ctx.AccountID, params.InstanceProfileName), raw); err != nil {
 		return nil, fmt.Errorf("put instance profile: %w", err)
 	}
 	return iamXMLEmptyResponse("RemoveRoleFromInstanceProfile"), nil
@@ -2886,9 +2889,9 @@ func (p *IAMPlugin) removeRoleFromInstanceProfile(_ *RequestContext, req *AWSReq
 // skipped, matching listInstanceProfiles — one corrupt record must not make a role
 // undeletable.
 func (p *IAMPlugin) instanceProfilesHoldingRole(
-	ctx context.Context, roleName string,
+	ctx context.Context, accountID, roleName string,
 ) ([]string, error) {
-	keys, err := p.state.List(ctx, iamNamespace, "instance_profile:")
+	keys, err := p.state.List(ctx, iamNamespace, iamInstanceProfilePrefix(accountID))
 	if err != nil {
 		return nil, fmt.Errorf("list instance profiles: %w", err)
 	}
@@ -2914,9 +2917,9 @@ func (p *IAMPlugin) instanceProfilesHoldingRole(
 }
 
 // listInstanceProfiles returns persisted IAM instance profiles.
-func (p *IAMPlugin) listInstanceProfiles(_ *RequestContext, _ *AWSRequest) (*AWSResponse, error) {
+func (p *IAMPlugin) listInstanceProfiles(ctx *RequestContext, _ *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
-	keys, err := p.state.List(goCtx, iamNamespace, "instance_profile:")
+	keys, err := p.state.List(goCtx, iamNamespace, iamInstanceProfilePrefix(ctx.AccountID))
 	if err != nil {
 		return nil, fmt.Errorf("list instance profiles: %w", err)
 	}

--- a/emulator/iam_policy_arn.go
+++ b/emulator/iam_policy_arn.go
@@ -93,7 +93,7 @@ func (p *IAMPlugin) iamWarnUnresolvedPolicyARN(goCtx context.Context, operation,
 	}
 	// A state failure is treated as "does not resolve": the warning is advisory and the attach
 	// proceeds either way, so a read error must not turn an accepted call into an error.
-	raw, err := p.state.Get(goCtx, iamNamespace, "policy:"+arn)
+	raw, err := p.state.Get(goCtx, iamNamespace, iamPolicyKey(arn))
 	if err == nil && raw != nil {
 		return
 	}

--- a/emulator/iam_policy_versions.go
+++ b/emulator/iam_policy_versions.go
@@ -143,7 +143,7 @@ func (p *IAMPlugin) resolveManagedPolicy(goCtx context.Context, arn string) (*IA
 	if mp, ok := GetManagedPolicy(arn); ok {
 		return mp, nil, nil
 	}
-	raw, err := p.state.Get(goCtx, iamNamespace, "policy:"+arn)
+	raw, err := p.state.Get(goCtx, iamNamespace, iamPolicyKey(arn))
 	if err != nil {
 		return nil, nil, fmt.Errorf("get policy: %w", err)
 	}

--- a/emulator/iam_simulate.go
+++ b/emulator/iam_simulate.go
@@ -316,6 +316,9 @@ func (p *IAMPlugin) simulationPolicySet(goCtx context.Context, params *iamSimula
 	docs, boundaryDocs []SourcedPolicyDocument, errResp *AWSResponse, err error,
 ) {
 	entityType, entityName := parsePrincipalARN(params.PolicySourceArn)
+	// The simulated entity belongs to the account its own ARN names, which is what
+	// lets a caller simulate a principal in another account (#737).
+	entityAccount := arnAccountID(params.PolicySourceArn)
 	switch entityType {
 	case "user", "group", "role":
 		// "The entity can be an IAM user, group, or role."
@@ -330,7 +333,7 @@ func (p *IAMPlugin) simulationPolicySet(goCtx context.Context, params *iamSimula
 			http.StatusBadRequest), nil
 	}
 
-	raw, err := p.state.Get(goCtx, iamNamespace, entityType+":"+entityName)
+	raw, err := p.state.Get(goCtx, iamNamespace, iamEntityKey(entityAccount, entityType, entityName))
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("load %s %s: %w", entityType, entityName, err)
 	}
@@ -340,7 +343,7 @@ func (p *IAMPlugin) simulationPolicySet(goCtx context.Context, params *iamSimula
 			http.StatusNotFound), nil
 	}
 
-	docs, err = p.simulationIdentityDocs(goCtx, iamEntity{Kind: entityType, Name: entityName})
+	docs, err = p.simulationIdentityDocs(goCtx, iamEntity{Account: entityAccount, Kind: entityType, Name: entityName})
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -421,18 +424,18 @@ func simulationResourcePolicyDocs(resourcePolicy string) ([]SourcedPolicyDocumen
 func (p *IAMPlugin) simulationIdentityDocs(goCtx context.Context, entity iamEntity) ([]SourcedPolicyDocument, error) {
 	sources := []iamEntity{entity}
 	if entity.Kind == "user" {
-		groups, err := p.loadStringList(goCtx, iamUserGroupsKey(entity.Name))
+		groups, err := p.loadStringList(goCtx, iamUserGroupsKey(entity.Account, entity.Name))
 		if err != nil {
 			return nil, fmt.Errorf("load group memberships for simulation: %w", err)
 		}
 		for _, name := range groups {
-			sources = append(sources, iamEntity{Kind: "group", Name: name})
+			sources = append(sources, iamEntity{Account: entity.Account, Kind: "group", Name: name})
 		}
 	}
 
 	var docs []SourcedPolicyDocument
 	for _, source := range sources {
-		arns, err := p.loadPolicyList(goCtx, source.Kind+"_policies:"+source.Name)
+		arns, err := p.loadPolicyList(goCtx, iamAttachedPoliciesKey(source.Account, source.Kind, source.Name))
 		if err != nil {
 			return nil, fmt.Errorf("load attached policies for simulation: %w", err)
 		}
@@ -452,12 +455,12 @@ func (p *IAMPlugin) simulationIdentityDocs(goCtx context.Context, entity iamEnti
 			})
 		}
 
-		names, err := p.loadInlinePolicyNames(goCtx, source.Kind, source.Name)
+		names, err := p.loadInlinePolicyNames(goCtx, source.Account, source.Kind, source.Name)
 		if err != nil {
 			return nil, fmt.Errorf("load inline policy names for simulation: %w", err)
 		}
 		for _, name := range names {
-			doc, err := p.loadInlinePolicyDoc(goCtx, source.Kind, source.Name, name)
+			doc, err := p.loadInlinePolicyDoc(goCtx, source.Account, source.Kind, source.Name, name)
 			if err != nil {
 				return nil, fmt.Errorf("load inline policy for simulation: %w", err)
 			}
@@ -481,7 +484,7 @@ func (p *IAMPlugin) resolveSimulationManagedDoc(goCtx context.Context, arn strin
 	if mp, ok := GetManagedPolicy(arn); ok {
 		return mp.Document, true
 	}
-	raw, err := p.state.Get(goCtx, iamNamespace, "policy:"+arn)
+	raw, err := p.state.Get(goCtx, iamNamespace, iamPolicyKey(arn))
 	if err != nil || raw == nil {
 		return PolicyDocument{}, false
 	}

--- a/emulator/iam_state_keys.go
+++ b/emulator/iam_state_keys.go
@@ -1,0 +1,156 @@
+package emulator
+
+// IAM state keys are account-scoped: every key reads `<kind>:<account>/<rest>`,
+// which is the shape DynamoDB (`table:<account>/<name>`) and every other
+// account-aware plugin already uses, with the account after the kind so a
+// `List(iamNamespace, iam…Prefix(account))` is a single-shot per-account scan.
+//
+// Until #737 the account was absent, so an IAM entity belonged to the emulator
+// rather than to an account: two accounts could not both hold a role called
+// "deploy" (the second create answered EntityAlreadyExists), a listing returned
+// every account's entities, and resolveIAMEntity attached one account's policies
+// to another account's principal of the same name.
+//
+// The builders below are the only place these strings are spelled. They exist
+// because ~90 call sites used to concatenate them inline, where a missed one is
+// invisible: it still compiles, still reads and writes state, and simply addresses
+// a key nothing else uses.
+
+// iamStateKey returns the state key for a record of the given kind in one account.
+//
+// The separator between the account and the name is "/" rather than ":" so a key
+// stays readable — `user:111122223333/alice` — and so the composed keys below can
+// keep ":" for the boundary they already used before the account existed.
+func iamStateKey(kind, accountID, name string) string {
+	return kind + ":" + accountID + "/" + name
+}
+
+// iamStatePrefix returns the List prefix that reaches every record of the given
+// kind in one account, and nothing outside it.
+func iamStatePrefix(kind, accountID string) string {
+	return kind + ":" + accountID + "/"
+}
+
+// iamUserKey returns the state key for an IAM user.
+func iamUserKey(accountID, userName string) string {
+	return iamStateKey("user", accountID, userName)
+}
+
+// iamUserPrefix returns the List prefix reaching every user in one account.
+func iamUserPrefix(accountID string) string { return iamStatePrefix("user", accountID) }
+
+// iamRoleKey returns the state key for an IAM role.
+func iamRoleKey(accountID, roleName string) string {
+	return iamStateKey("role", accountID, roleName)
+}
+
+// iamRolePrefix returns the List prefix reaching every role in one account.
+func iamRolePrefix(accountID string) string { return iamStatePrefix("role", accountID) }
+
+// iamGroupKey returns the state key for an IAM group.
+func iamGroupKey(accountID, groupName string) string {
+	return iamStateKey("group", accountID, groupName)
+}
+
+// iamGroupPrefix returns the List prefix reaching every group in one account.
+func iamGroupPrefix(accountID string) string { return iamStatePrefix("group", accountID) }
+
+// iamEntityKey returns the state key for a policy-holding entity of the given kind
+// — "user", "role" or "group" — which is how the operations that take an entity
+// type as a parameter (PutUserPolicy and its role and group siblings) address it.
+func iamEntityKey(accountID, kind, name string) string {
+	return iamStateKey(kind, accountID, name)
+}
+
+// iamInstanceProfileKey returns the state key for an instance profile.
+func iamInstanceProfileKey(accountID, name string) string {
+	return iamStateKey("instance_profile", accountID, name)
+}
+
+// iamInstanceProfilePrefix returns the List prefix reaching every instance profile
+// in one account.
+func iamInstanceProfilePrefix(accountID string) string {
+	return iamStatePrefix("instance_profile", accountID)
+}
+
+// iamPolicyKey returns the state key for a customer-managed policy, taking the
+// account from the ARN.
+//
+// The account is in the ARN already, so the key does carry it twice. That is
+// deliberate: a caller holding only an attachment's ARN — every policy read in the
+// authorization path is one — can address the record without knowing whose request
+// it is, while ListPolicies still reaches exactly one account's policies with a
+// single prefix. IAM does not let one account attach another's customer-managed
+// policy, so the ARN's account is the owning account by construction.
+//
+// A bundled AWS-managed ARN yields "policy:aws/arn:aws:iam::aws:policy/…", a key
+// nothing writes: the catalog is consulted before state everywhere, and a policy
+// under "::aws:" is never stored.
+func iamPolicyKey(arn string) string {
+	return iamStateKey("policy", arnAccountID(arn), arn)
+}
+
+// iamPolicyPrefix returns the List prefix reaching every customer-managed policy in
+// one account.
+func iamPolicyPrefix(accountID string) string { return iamStatePrefix("policy", accountID) }
+
+// iamAttachedPoliciesKey returns the state key holding the ARNs of the managed
+// policies attached to one entity — "<kind>_policies:<account>/<name>".
+func iamAttachedPoliciesKey(accountID, kind, name string) string {
+	return iamStateKey(kind+"_policies", accountID, name)
+}
+
+// iamAttachedPoliciesPrefix returns the List prefix reaching every attachment list
+// of the given entity kind in one account.
+func iamAttachedPoliciesPrefix(accountID, kind string) string {
+	return iamStatePrefix(kind+"_policies", accountID)
+}
+
+// iamInlinePolicyKey returns the state key holding one inline policy document.
+//
+// The policy name keeps the ":" boundary it had before the account was part of the
+// key. Neither an entity name nor a policy name may contain ":" or "/", so the key
+// is unambiguous either way.
+func iamInlinePolicyKey(accountID, kind, entityName, policyName string) string {
+	return iamStateKey(kind+"_inline", accountID, entityName+":"+policyName)
+}
+
+// iamInlinePolicyNamesKey returns the state key holding the names of one entity's
+// inline policies.
+func iamInlinePolicyNamesKey(accountID, kind, entityName string) string {
+	return iamStateKey(kind+"_inline_names", accountID, entityName)
+}
+
+// iamUserAccessKeysKey returns the state key holding the IDs of one user's access
+// keys.
+func iamUserAccessKeysKey(accountID, userName string) string {
+	return iamStateKey("user_accesskeys", accountID, userName)
+}
+
+// iamAccessKeyKey returns the state key for an access key record.
+//
+// This is the one IAM key with no account in it, and it cannot have one: an access
+// key ID is what *determines* the account, so [resolvePrincipal] looks a key up
+// before any account is known. The owning account is a field on the record
+// ([IAMAccessKey.AccountID]) instead, which is also why #737 is a schema change
+// here rather than a key rename. Access key IDs are unique across accounts, so
+// nothing collides.
+func iamAccessKeyKey(accessKeyID string) string {
+	return "accesskey:" + accessKeyID
+}
+
+// iamGroupUsersKey returns the state key holding the user names in one group.
+func iamGroupUsersKey(accountID, groupName string) string {
+	return iamStateKey("group_users", accountID, groupName)
+}
+
+// iamUserGroupsKey returns the state key holding the group names one user belongs to.
+func iamUserGroupsKey(accountID, userName string) string {
+	return iamStateKey("user_groups", accountID, userName)
+}
+
+// iamGroupPoliciesKey returns the state key holding the managed policy ARNs
+// attached to one group.
+func iamGroupPoliciesKey(accountID, groupName string) string {
+	return iamAttachedPoliciesKey(accountID, "group", groupName)
+}

--- a/emulator/iam_types.go
+++ b/emulator/iam_types.go
@@ -73,6 +73,17 @@ type IAMAccessKey struct {
 	Status          string    `json:"Status"`
 	UserName        string    `json:"UserName"`
 	CreateDate      time.Time `json:"CreateDate"`
+
+	// AccountID is the account owning the user this key belongs to.
+	//
+	// Every other IAM record carries its account in the state key, but an access key
+	// cannot: its ID is what *determines* the account, so [resolvePrincipal] looks the
+	// record up before any account is known (#737). The account is a field here
+	// instead. It is absent from the wire in both directions — AWS's CreateAccessKey
+	// and ListAccessKeys responses publish no account member — so it is stored and
+	// never rendered. A record written before #737 has it empty, and the reader falls
+	// back to the account the request resolved to.
+	AccountID string `json:"AccountId,omitempty"`
 }
 
 // IAMTag represents an AWS resource tag key-value pair.

--- a/emulator/operation_names_test.go
+++ b/emulator/operation_names_test.go
@@ -286,12 +286,12 @@ func seedUserWithPolicy(t *testing.T, state emulator.StateManager, user string, 
 		Path:     "/",
 	})
 	require.NoError(t, err)
-	require.NoError(t, state.Put(ctx, "iam", "user:"+user, userRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMUserKeyForTest(authzTestAccount, user), userRaw))
 
 	policyARN := "arn:aws:iam::123456789012:policy/" + user + "Policy"
 	arnsRaw, err := json.Marshal([]string{policyARN})
 	require.NoError(t, err)
-	require.NoError(t, state.Put(ctx, "iam", "user_policies:"+user, arnsRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMAttachedPoliciesKeyForTest(authzTestAccount, "user", user), arnsRaw))
 
 	polRaw, err := json.Marshal(emulator.IAMPolicy{
 		PolicyName: user + "Policy",
@@ -306,7 +306,7 @@ func seedUserWithPolicy(t *testing.T, state emulator.StateManager, user string, 
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, state.Put(ctx, "iam", "policy:"+policyARN, polRaw))
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMPolicyKeyForTest(policyARN), polRaw))
 }
 
 func TestFaultRule_CanNameARESTOperation(t *testing.T) {

--- a/emulator/organizations_tags_test.go
+++ b/emulator/organizations_tags_test.go
@@ -1054,7 +1054,7 @@ func (f *orgAuthzFixture) setResourcePolicy(t *testing.T, user, action string, r
 	if err != nil {
 		t.Fatalf("marshal policy: %v", err)
 	}
-	if err := f.state.Put(context.Background(), "iam", "policy:"+pol.ARN, raw); err != nil { //nolint:contextcheck
+	if err := f.state.Put(context.Background(), "iam", emulator.IAMPolicyKeyForTest(pol.ARN), raw); err != nil { //nolint:contextcheck
 		t.Fatalf("store policy: %v", err)
 	}
 }
@@ -1246,7 +1246,7 @@ func TestOrganizations_Authz_ResourceScopedStatementNarrows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal policy: %v", err)
 	}
-	if err := f.state.Put(context.Background(), "iam", "policy:"+pol.ARN, raw); err != nil { //nolint:contextcheck
+	if err := f.state.Put(context.Background(), "iam", emulator.IAMPolicyKeyForTest(pol.ARN), raw); err != nil { //nolint:contextcheck
 		t.Fatalf("store policy: %v", err)
 	}
 
@@ -1342,7 +1342,7 @@ func TestOrganizations_Authz_ARNsMatchWhatTheAPIReports(t *testing.T) {
 			if err != nil {
 				t.Fatalf("marshal policy: %v", err)
 			}
-			if err := f.state.Put(context.Background(), "iam", "policy:"+pol.ARN, polRaw); err != nil { //nolint:contextcheck
+			if err := f.state.Put(context.Background(), "iam", emulator.IAMPolicyKeyForTest(pol.ARN), polRaw); err != nil { //nolint:contextcheck
 				t.Fatalf("store policy: %v", err)
 			}
 			reqCtx := newAuthTestReqCtx("arn:aws:iam::123456789012:user/orgarns")
@@ -1576,7 +1576,7 @@ func TestOrganizations_Authz_MoveAccountParentScopedDenyBlocks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal policy: %v", err)
 	}
-	if err := f.state.Put(context.Background(), "iam", "policy:"+pol.ARN, raw); err != nil { //nolint:contextcheck
+	if err := f.state.Put(context.Background(), "iam", emulator.IAMPolicyKeyForTest(pol.ARN), raw); err != nil { //nolint:contextcheck
 		t.Fatalf("store policy: %v", err)
 	}
 
@@ -1633,7 +1633,7 @@ func TestOrganizations_Authz_MoveAccountTagsPairWithTheirOwnResource(t *testing.
 	if err != nil {
 		t.Fatalf("marshal policy: %v", err)
 	}
-	if err := f.state.Put(context.Background(), "iam", "policy:"+pol.ARN, raw); err != nil { //nolint:contextcheck
+	if err := f.state.Put(context.Background(), "iam", emulator.IAMPolicyKeyForTest(pol.ARN), raw); err != nil { //nolint:contextcheck
 		t.Fatalf("store policy: %v", err)
 	}
 
@@ -1797,7 +1797,7 @@ func TestOrganizations_Authz_MoveAccountBoundaryCoversEveryResource(t *testing.T
 		t.Fatalf("marshal boundary: %v", err)
 	}
 	ctx := context.Background()
-	if err := f.state.Put(ctx, "iam", "policy:"+boundaryARN, boundaryRaw); err != nil { //nolint:contextcheck
+	if err := f.state.Put(ctx, "iam", emulator.IAMPolicyKeyForTest(boundaryARN), boundaryRaw); err != nil { //nolint:contextcheck
 		t.Fatalf("store boundary: %v", err)
 	}
 	// Attach it to the user, which is what makes CheckAccess load it.
@@ -1814,7 +1814,7 @@ func TestOrganizations_Authz_MoveAccountBoundaryCoversEveryResource(t *testing.T
 	if err != nil {
 		t.Fatalf("marshal user: %v", err)
 	}
-	if err := f.state.Put(ctx, "iam", "user:orgbounded", userRaw); err != nil { //nolint:contextcheck
+	if err := f.state.Put(ctx, "iam", emulator.IAMUserKeyForTest(authzTestAccount, "orgbounded"), userRaw); err != nil { //nolint:contextcheck
 		t.Fatalf("store user: %v", err)
 	}
 
@@ -1850,7 +1850,7 @@ func TestOrganizations_Authz_MoveAccountBoundaryCoversEveryResource(t *testing.T
 	if err != nil {
 		t.Fatalf("re-marshal boundary: %v", err)
 	}
-	if err := f.state.Put(ctx, "iam", "policy:"+boundaryARN, boundaryRaw); err != nil { //nolint:contextcheck
+	if err := f.state.Put(ctx, "iam", emulator.IAMPolicyKeyForTest(boundaryARN), boundaryRaw); err != nil { //nolint:contextcheck
 		t.Fatalf("re-store boundary: %v", err)
 	}
 	if err := f.move(t, "orgbounded", f.ouID, otherOU); err != nil {

--- a/emulator/sts_plugin.go
+++ b/emulator/sts_plugin.go
@@ -167,7 +167,7 @@ func (p *STSPlugin) assumeRole(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 
 	goCtx := context.Background()
 
-	raw, err := p.state.Get(goCtx, iamNamespace, "role:"+roleName)
+	raw, err := p.state.Get(goCtx, iamNamespace, iamRoleKey(arnAccountID(roleARN), roleName))
 	if err != nil {
 		return nil, fmt.Errorf("get role: %w", err)
 	}

--- a/emulator/tagging_plugin.go
+++ b/emulator/tagging_plugin.go
@@ -389,19 +389,22 @@ func (p *TaggingPlugin) scanEC2Instances(_ context.Context, reqCtx *RequestConte
 	return out, nil
 }
 
-func (p *TaggingPlugin) scanIAMEntities(_ context.Context, _ *RequestContext) ([]resourceTagMapping, error) {
+// scanIAMEntities returns the users and roles of the caller's own account.
+//
+// The two scans are per-account since #737: an IAM key carries the account it
+// belongs to, so a resource listing made by one account no longer reports another's
+// entities. Nothing filters index keys out of either sweep because nothing has to —
+// "user_policies:" and its siblings do not begin with "user:", so the prefix has
+// always excluded them, and the guard that claimed to do it never fired.
+func (p *TaggingPlugin) scanIAMEntities(_ context.Context, reqCtx *RequestContext) ([]resourceTagMapping, error) {
 	goCtx := context.Background()
 	var out []resourceTagMapping
 
-	userKeys, err := p.state.List(goCtx, iamNamespace, "user:")
+	userKeys, err := p.state.List(goCtx, iamNamespace, iamUserPrefix(reqCtx.AccountID))
 	if err != nil {
 		return nil, fmt.Errorf("list iam users: %w", err)
 	}
 	for _, k := range userKeys {
-		// Skip index keys (user_policies:, user_inline:, etc.).
-		if !strings.HasPrefix(k, "user:") || strings.ContainsAny(strings.TrimPrefix(k, "user:"), ":") {
-			continue
-		}
 		raw, err := p.state.Get(goCtx, iamNamespace, k)
 		if err != nil || raw == nil {
 			continue
@@ -416,14 +419,11 @@ func (p *TaggingPlugin) scanIAMEntities(_ context.Context, _ *RequestContext) ([
 		})
 	}
 
-	roleKeys, err := p.state.List(goCtx, iamNamespace, "role:")
+	roleKeys, err := p.state.List(goCtx, iamNamespace, iamRolePrefix(reqCtx.AccountID))
 	if err != nil {
 		return nil, fmt.Errorf("list iam roles: %w", err)
 	}
 	for _, k := range roleKeys {
-		if !strings.HasPrefix(k, "role:") || strings.ContainsAny(strings.TrimPrefix(k, "role:"), ":") {
-			continue
-		}
 		raw, err := p.state.Get(goCtx, iamNamespace, k)
 		if err != nil || raw == nil {
 			continue
@@ -837,13 +837,16 @@ func (p *TaggingPlugin) resolveARN(arn string, reqCtx *RequestContext) (ns, key 
 		return "", "", fmt.Errorf("unsupported EC2 resource type in ARN: %q", resource)
 
 	case "iam":
+		// The account comes from the ARN, as it does for every other arm here: an IAM
+		// key carries the account it belongs to since #737, and the ARN is what names it.
+		acct := parts[4]
 		if strings.HasPrefix(resource, "user/") {
 			name := strings.TrimPrefix(resource, "user/")
-			return iamNamespace, "user:" + name, nil
+			return iamNamespace, iamUserKey(acct, name), nil
 		}
 		if strings.HasPrefix(resource, "role/") {
 			name := strings.TrimPrefix(resource, "role/")
-			return iamNamespace, "role:" + name, nil
+			return iamNamespace, iamRoleKey(acct, name), nil
 		}
 		return "", "", fmt.Errorf("unsupported IAM resource type in ARN: %q", resource)
 

--- a/emulator/tagging_plugin_test.go
+++ b/emulator/tagging_plugin_test.go
@@ -569,7 +569,7 @@ func TestTagging_GetResources_IAMUser(t *testing.T) {
 		Tags:     []emulator.IAMTag{{Key: "Dept", Value: "eng"}},
 	}
 	raw, _ := json.Marshal(user)
-	require.NoError(t, state.Put(context.Background(), "iam", "user:alice", raw))
+	require.NoError(t, state.Put(context.Background(), "iam", emulator.IAMUserKeyForTest(authzTestAccount, "alice"), raw))
 
 	resp := taggingRequest(t, ts, "GetResources", map[string]any{
 		"TagFilters": []map[string]any{
@@ -597,7 +597,7 @@ func TestTagging_TagResources_IAMUser(t *testing.T) {
 		Path:     "/",
 	}
 	raw, _ := json.Marshal(user)
-	require.NoError(t, state.Put(context.Background(), "iam", "user:bob", raw))
+	require.NoError(t, state.Put(context.Background(), "iam", emulator.IAMUserKeyForTest(authzTestAccount, "bob"), raw))
 
 	resp := taggingRequest(t, ts, "TagResources", map[string]any{
 		"ResourceARNList": []string{"arn:aws:iam::123456789012:user/bob"},
@@ -610,7 +610,7 @@ func TestTagging_TagResources_IAMUser(t *testing.T) {
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
 	assert.Empty(t, out["FailedResourcesMap"])
 
-	updated, err := state.Get(context.Background(), "iam", "user:bob")
+	updated, err := state.Get(context.Background(), "iam", emulator.IAMUserKeyForTest(authzTestAccount, "bob"))
 	require.NoError(t, err)
 	var u emulator.IAMUser
 	require.NoError(t, json.Unmarshal(updated, &u))
@@ -633,7 +633,7 @@ func TestTagging_TagResources_IAMRole(t *testing.T) {
 		Path:     "/",
 	}
 	raw, _ := json.Marshal(role)
-	require.NoError(t, state.Put(context.Background(), "iam", "role:deploy-role", raw))
+	require.NoError(t, state.Put(context.Background(), "iam", emulator.IAMRoleKeyForTest(authzTestAccount, "deploy-role"), raw))
 
 	resp := taggingRequest(t, ts, "TagResources", map[string]any{
 		"ResourceARNList": []string{"arn:aws:iam::123456789012:role/deploy-role"},
@@ -646,7 +646,7 @@ func TestTagging_TagResources_IAMRole(t *testing.T) {
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
 	assert.Empty(t, out["FailedResourcesMap"])
 
-	updated, err := state.Get(context.Background(), "iam", "role:deploy-role")
+	updated, err := state.Get(context.Background(), "iam", emulator.IAMRoleKeyForTest(authzTestAccount, "deploy-role"))
 	require.NoError(t, err)
 	var r emulator.IAMRole
 	require.NoError(t, json.Unmarshal(updated, &r))


### PR DESCRIPTION
## What

Every IAM state key was account-blind — a user at `user:{name}`, a role's attachments at `role_policies:{name}` — so one server held one IAM directory no matter how many accounts it served. Every key now reads `{kind}:{account}/{rest}`, the shape `table:{account}/{name}` and the other account-aware plugins already used.

The account goes *after* the kind so a per-account listing stays one prefix scan (`List("user:111122223333/")`) rather than a full sweep and filter, and so a `HasPrefix(key, "user:")` test on the kind keeps working unchanged.

## Three observable defects, all fixed

Confirmed live against a two-account `credentials:` block (#736), before and after:

| | before | after |
|---|---|---|
| `CreateRole deploy` in a second account | `EntityAlreadyExists` | `arn:aws:iam::444455556666:role/deploy` |
| `ListUsers` as B after A creates `alice` | `["alice"]` | `[]` |
| `ListPolicies --scope Local` as B after A creates `p1` | A's ARN | `[]` |

The third was a standalone bug: `ListPolicies` scanned `"policy:"` across every account although a policy ARN already named its owner.

## Where the account comes from

The ARN, wherever an ARN is the authority — never the request:

- `resolveIAMEntity` and `SimulatePrincipalPolicy` take it from the principal ARN, so a cross-account principal resolves against its own account's policies rather than a same-named entity in the account the request resolved to.
- `AssumeRole` reads the role named by `RoleArn` from *that* ARN's account. Keying it on the caller's account would have broken the exact case cross-account assumption exists for.
- A policy record is addressed by the account inside its own ARN, so a caller holding only an attachment's ARN reaches it without knowing whose request it is.

`iamEntity` gained an `Account` field for this: it is part of the entity's identity, not context about the request.

## The one key with no account

`accesskey:{id}` keeps none, and cannot have one: an access key ID is what *determines* an account, so `resolvePrincipal` looks the record up before any account is known. The account is a field on `IAMAccessKey` instead — which makes this a schema change rather than a key rename — and `resolvePrincipal` now returns it as an account to adopt, the same way the STS-session arm already did with `sess.AccountID`. A record written before this release has the field empty and falls back to the account the request resolved to, which is the account it always used.

## Why the builders

The ~90 sites that concatenated these strings inline now go through `emulator/iam_state_keys.go`. A missed site is invisible — it compiles, it reads and writes state, and it simply addresses a key nothing else uses — so every conversion was an exact literal match with a required occurrence count, and two mismatches caught sites an earlier grep had missed.

Two sites were invisible to a grep for `iamNamespace` at all, because they spelled the namespace `"iam"` as a literal inside `StackDeployer`'s drift comparison.

One thing the plan flagged as a hazard turned out to be dead code: `scanIAMEntities`' `ContainsAny(TrimPrefix(k, "user:"), ":")` guard claimed to filter index keys out of a `List("user:")`, but `"user_policies:"` never had the `user:` prefix, so it never fired. Deleted with a comment saying so, rather than "fixed".

## Tests

`emulator/iam_account_scope_test.go` is new and is the fail-before proof — all four tests fail on `main`:

- `TestIAM_TwoAccountsHoldTheSameNames` — user, role, group, instance profile and policy created in both accounts
- `TestIAM_ListsSeeOnlyTheCallersAccount` — five listings, 1 for A and empty for B
- `TestIAM_ReadsDoNotCrossAccounts` — `GetRole`/`DeleteRole` from B answer `NoSuchEntity` and A's role survives
- `TestIAM_InlineAndAttachedPoliciesAreScoped`

The ~30 existing test sites that hardcoded a key now call `Xxx…ForTest` builders exported from `export_test.go`, so when the layout changes again the tests move with the production code instead of drifting into addressing keys nothing reads.

## Compatibility

**IAM state written before this release is unreachable.** A snapshot or exported fixture holding `user:alice` is not read by a handler now looking for `user:123456789012/alice`. Re-seed it through the API. This is the same class of break as v0.108.0's account-default change, for the same reason, and is recorded in `docs/services.md`.

The `Marker` a paginated IAM listing returns is base64 of a state key, so a marker captured before this release does not match after it. It is opaque and per-listing, so nothing carries one across an upgrade.

## Verification

```
gofmt -l . && go build ./... && go vet ./... && golangci-lint run ./...   # 0 issues
make test                                                                 # green, race on
make coverage                                                             # emulator 83.4%, total 82.8%
make docs-reference docs-reference-check docs-versions                    # green
npm --prefix docs run build                                               # green; no dangling anchors
go vet -C test/e2e ./... && go test -C test/e2e ./...                      # green
```

Closes #737
