### PR TITLE
fix(iam): substitute a policy variable before comparing it (#745)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to no policies. With `verify_signatures: false` the answer stays `…:root`.
 
 ### Fixed
+- **A `${aws:username}` in a policy was compared as literal text** (#745). AWS substitutes a
+  policy variable before it compares, so `arn:aws:s3:::home/${aws:username}/*` is the documented
+  shape for "a prefix per user". Substrate compared the fifteen characters `${aws:username}`
+  against the ARN in hand, which matched nothing — so a policy of exactly that shape granted
+  nothing at all, including the bundled `IAMUserChangePassword`, the one bundled policy that uses
+  a variable. Under the positive forms that is a false deny; under the negated ones it is a false
+  **allow**, because `StringNotEquals` comparing a tag against `${aws:ResourceTag/Team}` is false
+  on AWS when the two agree and true here, which makes such a statement inert on a `Deny` and
+  granting on an `Allow`. That was reachable with no new producer at all, since
+  `SimulateCustomPolicy` copies a caller's `ContextEntries` into the context the same evaluator
+  reads.
+
+  Substitution now runs in the elements AWS names and nowhere else: `Resource`, `NotResource`,
+  and condition values under the string and ARN operators. AWS's sentence on the rest is
+  exhaustive — "You can't use a policy variable with other operators, such as Numeric, Date,
+  Boolean, Binary, IP Address, or Null operators" — so the test is the operator family's prefix
+  rather than a name list that would drift from the evaluator's own switch, and a `${…}` under a
+  `Numeric` operator stays the text it was. `Action` is not on AWS's list either and keeps its
+  plain glob.
+
+  Four rules decide the edges, each from AWS's *Variables and tags* page. The `Version` element
+  gates the feature: "If you don't include the `Version` element and set it to an appropriate
+  version date, variables like `${aws:username}` are treated as literal strings in the policy",
+  so a document with an older version — or none — reads exactly as it did before. Key names are
+  case-insensitive, so resolution goes through the same lookup a condition key uses rather than a
+  raw map index. `${key, 'default'}` resolves to the default when the key has no value. And only
+  the single-valued context is consulted, per "You can use any single-valued condition key as a
+  variable. You can't use a multivalued condition key as a variable".
+
+  `${*}`, `${?}` and `${$}` are AWS's escapes for characters the glob would otherwise read as
+  pattern, and substituting them into a plain string and handing it to the matcher would turn an
+  escape for a literal asterisk into a wildcard — widening a statement, the one direction a
+  deliberate escape must never take. A resolved value carries a per-byte record of which of its
+  characters are pattern and which are text, so an escape stays literal and **a `*` inside a
+  resolved value is literal too**: a tag value is data the request carried, not pattern the policy
+  author wrote. AWS documents no rule for that second case; it is substrate's reading, and it is
+  the reading that cannot widen a statement on behalf of whoever set the tag. The recursive glob
+  matcher was replaced by an iterative one that consults the mask, so there is one matcher rather
+  than two that could disagree.
+
+  A variable with no value voids what contains it, which is one AWS rule stated for two element
+  kinds: a `Resource` entry "will not match any resource", and the same sentence names
+  `NotResource`, where excluding nothing means the statement matches everything. In a condition
+  value "there is no equal or like value", so a positive operator finds no match and a negated one
+  is satisfied — "Inverted condition operators like `StringNotEquals` or `StringNotLike` do match
+  against a null value". Substrate reached all four answers correctly while comparing literally,
+  because an ARN never contains a `${…}`; they are now reached by the rule instead of by
+  coincidence, which matters because a resolved value can contain a wildcard and coincidence does
+  not survive that.
+
+  `aws:username` is the producer this needed, and it is recorded rather than derived. `Principal`
+  gained a `UserName` carried from the credential lookup, which had the IAM user's name in hand
+  and spent it into an ARN. Deriving it back out of that ARN would have been wrong twice over: a
+  registry hit with no IAM entity behind it synthesizes `…:user/<access-key-id>`, so the last
+  segment is a credential ID, and an assumed role's is a session name where AWS publishes no
+  `aws:username` at all. Presence is keyed off the recorded name and not off `Principal.Type`,
+  because a `GetSessionToken` session and an `AssumeRole` session are both typed `AssumedRole`
+  while AWS publishes the key for the first and not the second — so `STSSessionCredentials` gained
+  the field too. A stack's own resource calls carry the creator's name, recorded on the stack so a
+  rollback's deletes authorize as the create did. The simulator is the one place a name is read out
+  of an ARN, because there `CallerArn` is the caller's own assertion of who to simulate as. IAM's
+  second authorization door — the one that passes `"*"` and builds its own two-key context — now
+  publishes `aws:username` as well, for the reason it was taught `aws:PrincipalArn` in #714: an
+  `iam:` statement scoped to `${aws:username}`, the shape of "let a user manage their own
+  credentials", resolved at one door and matched nothing at the other.
+
+  Substitution alone does not make `IAMUserChangePassword` grant anything. Its `Resource` now
+  correctly reads `arn:aws:iam::*:user/alice`, but every IAM request's resource is built as
+  `arn:aws:iam::<account>:*`, so there is nothing user-shaped to match. That is a separate gap in
+  how IAM's request resource is derived, filed as #770. The two caller keys that still have no
+  producer, `aws:userid` and `aws:PrincipalTag/`, are #771 — each needs the same shape of
+  prerequisite `aws:username` needed, which is to record the value where it exists rather than
+  parse it back out of an ARN.
 - **An IAM entity belonged to the emulator rather than to an account** (#737). Every IAM state
   key was account-blind — a user lived at `user:{name}`, a role's attachments at
   `role_policies:{name}` — so one server held one IAM directory no matter how many accounts it

--- a/docs/services.md
+++ b/docs/services.md
@@ -1404,6 +1404,7 @@ nothing else:
 | `ec2:Subnet`, `ec2:Vpc` | [A launch's networking resources](#a-launch-s-networking-resources-carry-ec2-subnet-and-ec2-vpc) |
 | `sts:ExternalId` | An `AssumeRole` that supplied one |
 | `aws:PrincipalArn` | The caller, at every gate — identity policy, permission boundary, [tag-on-create](#a-tagged-create-is-authorized-twice), the IAM control plane and a role's trust policy |
+| `aws:username` | The caller's IAM user name, at the same gates — **absent** for every principal that has none; see [policy variables](#policy-variables-resolve-from-the-request-context) |
 | `aws:ResourceAccount` | A **simulation** only, from `ResourceOwner` |
 | Anything at all | A simulation's `ContextEntries` |
 
@@ -1422,18 +1423,27 @@ everyone.
 
 What has **no** producer, and therefore never matches on the enforcement path:
 
-- `aws:SecureTransport`, `aws:username`, `aws:userid`, `aws:MultiFactorAuthPresent`,
+- `aws:SecureTransport`, `aws:userid`, `aws:MultiFactorAuthPresent`,
   `aws:MultiFactorAuthAge`, `aws:SourceIp`, `aws:SourceVpc`, `aws:PrincipalOrgID` and
   every other key not in the table above. The IP family is therefore correct but
   satisfiable only through a simulation's `ContextEntries`. (S3's
   [public-access analysis](#block-public-access) reads an `aws:SourceIp` condition out of a
   *bucket policy* to judge how broad it is, which is a different question from evaluating
   one against a request.)
-- `aws:PrincipalAccount`, `aws:userid` and `aws:username`, even though `aws:PrincipalArn`
-  is populated beside them. Each needs a derivation substrate cannot make honestly for
-  every principal kind — it mints no unique ID, and a role session's user name is not the
-  last component of its ARN — and a key guessed wrong is worse than one a policy can test
-  for with `Null`.
+- `aws:PrincipalAccount` and `aws:userid`, even though `aws:PrincipalArn` and `aws:username`
+  are populated beside them. Each needs a derivation substrate cannot make honestly for
+  every principal kind — it mints no unique ID, and a cross-account credential makes the
+  account ambiguous — and a key guessed wrong is worse than one a policy can test for with
+  `Null`. `aws:username` was in this list until
+  [#745](https://github.com/scttfrdmn/substrate/issues/745), and the reason it left is worth
+  keeping: the derivation that made it honest was to *record* the name at the credential
+  lookup, not to parse it back out of an ARN. The same shape of prerequisite is what the
+  other two still need, and what
+  [#771](https://github.com/scttfrdmn/substrate/issues/771) tracks: `aws:userid` needs a
+  unique ID minted at create time, since substrate stores none and deriving one from a name
+  would make it stable per-name rather than per-entity; `aws:PrincipalTag/` needs the
+  principal's tags read where the credential is resolved, which is the cheaper of the two
+  because `TagUser`/`TagRole` already record them.
 - Six of the seven keys the bundled AWS managed policies condition on, each for its own
   reason rather than as one omission:
 
@@ -1453,46 +1463,82 @@ What has **no** producer, and therefore never matches on the enforcement path:
   the bundled catalog sit on an `Allow`, so such a statement grants nothing rather than a
   `Deny` going inert.
 
-**Substrate performs no policy-variable substitution**, deliberately rather than by
-omission. A `${aws:username}` in a resource ARN or a condition value is compared literally.
+### Policy variables resolve from the request context
 
-For the one bundled policy that uses a variable — the `${aws:username}` in
-`IAMUserChangePassword`, the only `${` across all 47 — that is not observable: AWS's rule is
-that an unresolved variable in `Resource` "will not match any resource", `aws:username` has
-no producer, and substrate's literal comparison reaches the same answer by a different
-route. The statement matches nothing either way.
+**A `${…}` in a policy is substituted before the comparison**
+([#745](https://github.com/scttfrdmn/substrate/issues/745)), so
+`arn:aws:s3:::home/${aws:username}/*` grants alice her own prefix and refuses bob's. Until
+that release it was compared as literal text, which matched no ARN at all — a policy of that
+shape, the shape AWS's own documentation gives for "a prefix per user", granted nothing.
 
-**An unresolved variable diverges nowhere**, in either element and under either polarity —
-which corrects a rule this page previously published backwards
-([#744](https://github.com/scttfrdmn/substrate/issues/744)). AWS
-applies one sentence to both elements: "If a variable that has no value in the authorization
-context is used as part of the `Resource` **or** `NotResource` element of a policy, the
-resource that includes a policy variable with no value will not match any resource." An ARN
-still carrying a literal `${…}` matches no resource under either element here either, so
-both routes reach the same answer. Under a negated *condition operator* AWS is equally
-explicit that the comparison **does** match — "Inverted condition operators like
-`StringNotEquals` or `StringNotLike` do match against a null value, as the value of the
-condition key they are testing against is not equal to or like the effectively null value" —
-and substrate's literal comparison matches too, because no context value equals the string
-`${aws:PrincipalTag/Team}`. The one way to tell them apart is to pass that literal string
-*as* a context value, which only a hand-written `SimulateCustomPolicy` `ContextEntry` can do.
+Substitution runs in exactly the elements AWS names, and nowhere else:
 
-**What does diverge is a variable that would have resolved**, which is what
-[#745](https://github.com/scttfrdmn/substrate/issues/745) tracks. Under the positive forms —
-`Resource`, `StringEquals`, `ArnLike` — the literal matches nothing where AWS would have
-matched, so the statement grants less than it says: a false deny, and the safe direction.
-Under the negated forms it is the reverse and it is not safe. A
-`StringNotEquals` comparing `s3:ExistingObjectTag/Team` against `${aws:ResourceTag/Team}`
-is *false* on AWS when the two agree, and *true* here, because "red" does not equal the
-un-substituted literal — so such a statement is inert on a `Deny` and grants on an `Allow`.
-That is reachable today with no new producer at all, since `SimulateCustomPolicy` copies a
-caller's `ContextEntries` straight into the context the same evaluator reads.
+| Element | Substituted? | Rule |
+|---|---|---|
+| `Resource`, `NotResource` | Yes | AWS names both, in the resource portion of the ARN |
+| `Condition` values under `String*` and `Arn*` | Yes | "any condition that involves the string operators or the ARN operators" |
+| `Condition` values under `Numeric`, `Date`, `Bool`, `Binary`, `IpAddress`, `Null` | **No** | "You can't use a policy variable with other operators" — the text is compared as written, which for those types is a comparison that cannot be made |
+| `Action`, `NotAction`, `Principal`, `Sid` | **No** | Not on AWS's list |
 
-An honest `aws:username` is what the request-signing path still owes, and the two obvious
-candidates are both wrong: the ARN's last component is the *session* name for an assumed
-role, where AWS documents `aws:username` as absent altogether, and the value the caller ARN
-is built from is an access key ID. The honest producer is the resolved IAM user name, set
-where the credential lookup already has it in hand and currently discards it.
+Four rules that decide the edge cases, each taken from AWS's *IAM policy elements: Variables
+and tags* page:
+
+- **The `Version` element gates the whole feature.** "Variables were introduced in version
+  `2012-10-17`… If you don't include the `Version` element and set it to an appropriate
+  version date, variables like `${aws:username}` are treated as literal strings in the
+  policy." A document with an older `Version`, or none, is read exactly as it was before this
+  release. All 52 bundled AWS managed policies declare `2012-10-17`, so nothing bundled
+  changed meaning by accident.
+- **Key names are case-insensitive**, so `${aws:userName}` and `${AWS:USERNAME}` resolve the
+  same key a producer wrote as `aws:username`.
+- **Defaults are honoured**: `${aws:PrincipalTag/team, 'company-wide'}` resolves to
+  `company-wide` when the tag has no value, so a variable with a default is never unresolved.
+- **`${*}`, `${?}` and `${$}` stay literal.** They are AWS's escapes for those characters, so
+  substrate tracks per byte whether a `*` was written by the policy author or arrived from a
+  substitution. **A wildcard inside a resolved value is text too** — a tag value is data the
+  request carried, not pattern the author wrote. AWS documents no rule for that case; reading
+  it as text is substrate's choice, and it is the reading that cannot widen a statement on
+  behalf of whoever set the tag.
+
+**A variable with no value voids what contains it**, which is one AWS rule stated twice for
+the two element kinds:
+
+| Where | AWS's rule | Effect |
+|---|---|---|
+| `Resource` | "the resource that includes a policy variable with no value will not match any resource" | The entry grants nothing |
+| `NotResource` | the same sentence names both elements | The entry excludes nothing — so the statement matches **every** resource |
+| Condition value, positive operator | "the value is effectively null. There is no equal or like value" | No match |
+| Condition value, negated operator | "Inverted condition operators like `StringNotEquals` or `StringNotLike` do match against a null value" | Match |
+
+This page published the `NotResource` half of that backwards before
+[#744](https://github.com/scttfrdmn/substrate/issues/744) corrected it. Substrate reached all
+four answers correctly even while comparing literally, because an ARN never contains a
+`${…}` — but by coincidence rather than by the rule, which is why the rule is now applied
+deliberately: a resolved value can itself contain a wildcard, and coincidence does not
+survive that.
+
+`aws:username` is the producer this needed, and it is recorded rather than derived:
+
+| Caller | `aws:username` |
+|---|---|
+| A long-term access key | The IAM user that holds it |
+| `GetSessionToken` | The **same** user — its principal is unchanged, and AWS publishes the key |
+| `AssumeRole` | **Absent.** The session name is not a user name |
+| A registered credential with no IAM entity behind it | **Absent.** That ARN's last segment is the access key ID |
+| A CloudFormation stack's own resource calls | The stack's creator, carried in the stack record so a rollback's deletes are authorized as the create was |
+| `SimulateCustomPolicy` / `SimulatePrincipalPolicy` | Derived from `CallerArn` when it names a user — the one place substrate reads a name out of an ARN, because there the ARN is the caller's own assertion of who to simulate as |
+
+Substitution reads only the single-valued context, per AWS's "You can use any single-valued
+condition key as a variable. You can't use a multivalued condition key as a variable" — so
+`${aws:TagKeys}` never resolves.
+
+One consequence worth stating, because it looks like a bug: substitution alone does not make
+the bundled `IAMUserChangePassword` grant anything. Its `Resource` is now correctly
+`arn:aws:iam::*:user/alice`, but every IAM request's resource is built as
+`arn:aws:iam::<account>:*`, so there is nothing user-shaped to match. That is a separate
+gap in how IAM's request resource is derived
+([#770](https://github.com/scttfrdmn/substrate/issues/770)), not something substitution
+could have fixed.
 
 ### Multivalued condition keys: `ForAllValues` and `ForAnyValue`
 

--- a/emulator/authz.go
+++ b/emulator/authz.go
@@ -73,7 +73,7 @@ func (a *AuthController) authzTimeContext(ctx map[string]string, now time.Time, 
 	ctx["aws:EpochTime"] = strconv.FormatInt(now.Unix(), 10)
 }
 
-// authzPrincipalContext writes the condition key that names the caller.
+// authzPrincipalContext writes the condition keys that name the caller.
 //
 // AWS documents aws:PrincipalArn as "the ARN of the principal that made the request",
 // present in the context of every request a principal signs. Substrate knows it with
@@ -89,15 +89,34 @@ func (a *AuthController) authzTimeContext(ctx map[string]string, now time.Time, 
 // herself, and as an Allow it granted everyone. The absence turned an exemption into its
 // opposite, which is why the producer lands with the operators rather than after them.
 //
-// aws:PrincipalAccount, aws:userid and aws:username are deliberately still absent: each
-// needs a derivation this function cannot do honestly for every principal kind — a unique
-// ID substrate does not mint, a name that is not the last ARN component for a role
-// session — and a key guessed wrong is worse than one a policy can test for with Null.
-func authzPrincipalContext(ctx map[string]string, principalARN string) {
-	if principalARN == "" {
+// aws:username is written only when the caller *has* a user name, which is the second
+// half of #745: a policy naming ${aws:username} — the shape of AWS's own
+// IAMUserChangePassword, and of every "let a user manage their own things" statement —
+// resolved to nothing, so the statement matched no resource and every such grant was a
+// false deny. The name comes from [Principal.UserName], recorded when the credential was
+// resolved, and never from the ARN: [Server.resolveCallerPrincipal] synthesizes
+// `…:user/<access-key-id>` for a registry hit with no IAM entity behind it, so parsing
+// this ARN would publish a credential ID as a user name.
+//
+// It is absent, not empty, for every principal for which AWS's own table reads
+// "(not present)" — the account root, an assumed role, an EC2 instance role, and a
+// federated or SAML/OIDC caller. Absent is what makes the negated forms answer as AWS
+// specifies, since [condKeyPresent] reads an empty value as absent anyway; writing "" and
+// omitting the key are the same observation, and omitting it is the honest one.
+//
+// aws:PrincipalAccount and aws:userid are deliberately still absent: each needs a
+// derivation this function cannot do honestly for every principal kind — a unique ID
+// substrate does not mint, an account that a cross-account credential makes ambiguous —
+// and a key guessed wrong is worse than one a policy can test for with Null. Tracked as
+// its own issue rather than left as an unstated gap.
+func authzPrincipalContext(ctx map[string]string, principal *Principal) {
+	if principal == nil || principal.ARN == "" {
 		return
 	}
-	ctx["aws:PrincipalArn"] = principalARN
+	ctx["aws:PrincipalArn"] = principal.ARN
+	if principal.UserName != "" {
+		ctx["aws:username"] = principal.UserName
+	}
 }
 
 // now reports the controlled time, and whether there is a clock to read it from.
@@ -216,7 +235,7 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 			condCtx[k] = v
 		}
 		a.authzTimeContext(condCtx, now, haveClock)
-		authzPrincipalContext(condCtx, reqCtx.Principal.ARN)
+		authzPrincipalContext(condCtx, reqCtx.Principal)
 
 		result := Evaluate(docs, EvaluationRequest{
 			Principal:    reqCtx.Principal.ARN,
@@ -309,7 +328,7 @@ func (a *AuthController) checkEC2TagOnCreate(reqCtx *RequestContext, req *AWSReq
 	// The same caller signed the same request, so this gate must name the same principal
 	// as the primary decision — a request authorized twice against two different answers
 	// for aws:PrincipalArn would deny on one door and allow on the other (#714).
-	authzPrincipalContext(condCtx, reqCtx.Principal.ARN)
+	authzPrincipalContext(condCtx, reqCtx.Principal)
 
 	// Derived from the merged map above rather than reused from the primary decision, so
 	// a template-supplied key is in aws:TagKeys too — AWS's combined example conditions

--- a/emulator/cfn_deployer.go
+++ b/emulator/cfn_deployer.go
@@ -321,6 +321,17 @@ type CFNStackState struct {
 	// reintroduce exactly the blind spot #411 exists to remove, since a rollback
 	// would then be able to delete what the creator could not.
 	CreatorPrincipalARN string `json:"CreatorPrincipalARN,omitempty"`
+
+	// CreatorUserName is the creating principal's IAM user name, empty when it had
+	// none.
+	//
+	// Persisted beside the ARN rather than derived from it, for the reason
+	// [Principal.UserName] gives: the ARN may have been synthesized from an access key
+	// ID, so parsing it back would publish a credential ID as `aws:username`. Without
+	// this, a rollback's deletes ran with the key absent while the create that made the
+	// resources ran with it present — so a policy naming ${aws:username} authorized the
+	// create and refused to clean up after it (#745).
+	CreatorUserName string `json:"CreatorUserName,omitempty"`
 }
 
 // attribution returns who the stack's resource calls are made as, from what was
@@ -333,8 +344,9 @@ func (s CFNStackState) attribution() cfnAttribution {
 	att := cfnAttribution{roleARN: s.RoleARN}
 	if s.CreatorPrincipalARN != "" {
 		att.creator = &Principal{
-			ARN:  s.CreatorPrincipalARN,
-			Type: cfnPrincipalType(s.CreatorPrincipalARN),
+			ARN:      s.CreatorPrincipalARN,
+			Type:     cfnPrincipalType(s.CreatorPrincipalARN),
+			UserName: s.CreatorUserName,
 		}
 	}
 	return att
@@ -350,6 +362,7 @@ func (s *CFNStackState) setAttribution(att cfnAttribution) {
 	s.RoleARN = att.roleARN
 	if att.creator != nil {
 		s.CreatorPrincipalARN = att.creator.ARN
+		s.CreatorUserName = att.creator.UserName
 	}
 }
 

--- a/emulator/credentials.go
+++ b/emulator/credentials.go
@@ -179,6 +179,9 @@ func resolvePrincipal(ctx context.Context, state StateManager, accountID, access
 			return &Principal{
 				ARN:  fmt.Sprintf("arn:aws:iam::%s:user/%s", account, key.UserName),
 				Type: "IAMUser",
+				// The name AWS publishes as aws:username, taken from the record rather
+				// than re-derived from the ARN above (#745). See [Principal.UserName].
+				UserName: key.UserName,
 			}, adopt
 		}
 	}
@@ -190,7 +193,16 @@ func resolvePrincipal(ctx context.Context, state StateManager, accountID, access
 	if raw, err := state.Get(ctx, stsNamespace, "session:"+accessKeyID); err == nil && raw != nil {
 		var sess STSSessionCredentials
 		if unmarshalErr := json.Unmarshal(raw, &sess); unmarshalErr == nil && sess.PrincipalARN != "" {
-			return &Principal{ARN: sess.PrincipalARN, Type: "AssumedRole"}, sess.AccountID
+			// UserName is set only for a GetSessionToken session, whose principal *is*
+			// an IAM user and for which AWS does publish aws:username; assumeRole
+			// leaves it empty, because an assumed role has no user name. Type is
+			// "AssumedRole" for both, which is why presence is keyed off the recorded
+			// name rather than off Type (#745).
+			return &Principal{
+				ARN:      sess.PrincipalARN,
+				Type:     "AssumedRole",
+				UserName: sess.UserName,
+			}, sess.AccountID
 		}
 	}
 

--- a/emulator/iam_condition_operators.go
+++ b/emulator/iam_condition_operators.go
@@ -39,25 +39,30 @@ import (
 // negated one, on the reasoning that a comparison that cannot be made has not been
 // satisfied. AWS documents neither case, on the policy side or the request side; both
 // are substrate's recorded choices (#714).
-func condEvaluate(base, ctxVal string, condValues StringOrSlice) (matched, recognized bool) {
+//
+// condValues are the policy's values with their ${…} variables already resolved by
+// [condPolicyValues], which is also where a value whose variable had no value was
+// dropped. So a list this function sees is one every element of which AWS would
+// compare (#745).
+func condEvaluate(base, ctxVal string, condValues []policyPattern) (matched, recognized bool) {
 	switch base {
 	case "StringEquals":
-		return condAnyValue(condValues, func(v string) bool { return ctxVal == v }), true
+		return condAnyValue(condValues, func(v policyPattern) bool { return ctxVal == v.text }), true
 	case "StringNotEquals":
-		return !condAnyValue(condValues, func(v string) bool { return ctxVal == v }), true
+		return !condAnyValue(condValues, func(v policyPattern) bool { return ctxVal == v.text }), true
 	case "StringEqualsIgnoreCase":
-		return condAnyValue(condValues, func(v string) bool { return strings.EqualFold(ctxVal, v) }), true
+		return condAnyValue(condValues, func(v policyPattern) bool { return strings.EqualFold(ctxVal, v.text) }), true
 	case "StringNotEqualsIgnoreCase":
-		return !condAnyValue(condValues, func(v string) bool { return strings.EqualFold(ctxVal, v) }), true
+		return !condAnyValue(condValues, func(v policyPattern) bool { return strings.EqualFold(ctxVal, v.text) }), true
 	case "StringLike":
-		return condAnyValue(condValues, func(v string) bool { return globMatch(v, ctxVal) }), true
+		return condAnyValue(condValues, func(v policyPattern) bool { return v.matches(ctxVal) }), true
 	case "StringNotLike":
-		return !condAnyValue(condValues, func(v string) bool { return globMatch(v, ctxVal) }), true
+		return !condAnyValue(condValues, func(v policyPattern) bool { return v.matches(ctxVal) }), true
 
 	case "ArnEquals", "ArnLike":
-		return condAnyValue(condValues, func(v string) bool { return condARNMatches(v, ctxVal) }), true
+		return condAnyValue(condValues, func(v policyPattern) bool { return condARNMatches(v, ctxVal) }), true
 	case "ArnNotEquals", "ArnNotLike":
-		return !condAnyValue(condValues, func(v string) bool { return condARNMatches(v, ctxVal) }), true
+		return !condAnyValue(condValues, func(v policyPattern) bool { return condARNMatches(v, ctxVal) }), true
 
 	case "NumericEquals", "NumericNotEquals", "NumericLessThan", "NumericLessThanEquals",
 		"NumericGreaterThan", "NumericGreaterThanEquals":
@@ -68,9 +73,9 @@ func condEvaluate(base, ctxVal string, condValues StringOrSlice) (matched, recog
 		return condDateMatches(base, ctxVal, condValues), true
 
 	case "IpAddress":
-		return condAnyValue(condValues, func(v string) bool { return condIPMatches(v, ctxVal) }), true
+		return condAnyValue(condValues, func(v policyPattern) bool { return condIPMatches(v.text, ctxVal) }), true
 	case "NotIpAddress":
-		return !condAnyValue(condValues, func(v string) bool { return condIPMatches(v, ctxVal) }), true
+		return !condAnyValue(condValues, func(v policyPattern) bool { return condIPMatches(v.text, ctxVal) }), true
 
 	case "Bool":
 		// AWS publishes only the lowercase forms, and substrate's own producers write
@@ -78,7 +83,7 @@ func condEvaluate(base, ctxVal string, condValues StringOrSlice) (matched, recog
 		// there because an unquoted JSON `true` and the string "TRUE" are the same
 		// assertion by a caller, and [StringOrSlice.UnmarshalJSON] renders the first
 		// as "true" — the two forms must not disagree.
-		return condAnyValue(condValues, func(v string) bool { return strings.EqualFold(ctxVal, v) }), true
+		return condAnyValue(condValues, func(v policyPattern) bool { return strings.EqualFold(ctxVal, v.text) }), true
 
 	case "BinaryEquals":
 		// AWS: BinaryEquals "compares the value of the specified key byte for byte
@@ -87,9 +92,9 @@ func condEvaluate(base, ctxVal string, condValues StringOrSlice) (matched, recog
 		// on the encoded text, and a policy value that is not valid base64 encodes no
 		// binary value and cannot match. No substrate producer writes a binary context
 		// key, so this operator is reachable only through a simulation's ContextEntries.
-		return condAnyValue(condValues, func(v string) bool {
-			_, err := base64.StdEncoding.DecodeString(v)
-			return err == nil && ctxVal == v
+		return condAnyValue(condValues, func(v policyPattern) bool {
+			_, err := base64.StdEncoding.DecodeString(v.text)
+			return err == nil && ctxVal == v.text
 		}), true
 
 	case "Null":
@@ -99,8 +104,8 @@ func condEvaluate(base, ctxVal string, condValues StringOrSlice) (matched, recog
 		// (the key exists and its value is not null)" — so a key present with an empty
 		// value is null, the reading substrate has always had here.
 		isNull := ctxVal == ""
-		return condAnyValue(condValues, func(v string) bool {
-			return (strings.ToLower(v) == "true") == isNull
+		return condAnyValue(condValues, func(v policyPattern) bool {
+			return (strings.ToLower(v.text) == "true") == isNull
 		}), true
 	}
 
@@ -113,7 +118,7 @@ func condEvaluate(base, ctxVal string, condValues StringOrSlice) (matched, recog
 // operator is the same scan with the answer inverted, which is what makes AWS's "the
 // ArnNotEquals and ArnNotLike condition operators behave identically" to the negation
 // of their positive pair true by construction rather than by two parallel loops.
-func condAnyValue(condValues StringOrSlice, match func(string) bool) bool {
+func condAnyValue(condValues []policyPattern, match func(policyPattern) bool) bool {
 	for _, v := range condValues {
 		if match(v) {
 			return true
@@ -181,17 +186,21 @@ const condARNComponents = 6
 // narrowing a Deny is the direction that cannot be recovered from. A *context* value
 // with fewer than six components is not padded — it is the request's own ARN, and a
 // short one is malformed rather than abbreviated.
-func condARNMatches(pattern, value string) bool {
+//
+// The pattern arrives as a [policyPattern] so that a `*` a variable resolved to stays
+// literal here too; the padding this function adds is authored by substrate on AWS's
+// behalf and is therefore a wildcard (#745).
+func condARNMatches(pattern policyPattern, value string) bool {
 	valueParts := strings.SplitN(value, ":", condARNComponents)
-	patternParts := strings.SplitN(pattern, ":", condARNComponents)
+	patternParts := pattern.splitN(":", condARNComponents)
 	for len(patternParts) < len(valueParts) {
-		patternParts = append(patternParts, "*")
+		patternParts = append(patternParts, rawPolicyPattern("*"))
 	}
 	if len(patternParts) != len(valueParts) {
 		return false
 	}
 	for i := range patternParts {
-		if !globMatch(patternParts[i], valueParts[i]) {
+		if !patternParts[i].matches(valueParts[i]) {
 			return false
 		}
 	}
@@ -204,13 +213,13 @@ func condARNMatches(pattern, value string) bool {
 // decimal value". Both sides are read as decimals, so a policy that quotes its number
 // and one that does not — legal IAM either way, see [StringOrSlice.UnmarshalJSON] —
 // compare identically.
-func condNumericMatches(base, ctxVal string, condValues StringOrSlice) bool {
+func condNumericMatches(base, ctxVal string, condValues []policyPattern) bool {
 	ctxNum, ok := condParseNumber(ctxVal)
 	if !ok {
 		return condOperatorNegated(base)
 	}
-	return condCompare(base, condValues, func(v string) (int, bool) {
-		n, ok := condParseNumber(v)
+	return condCompare(base, condValues, func(v policyPattern) (int, bool) {
+		n, ok := condParseNumber(v.text)
 		if !ok {
 			return 0, false
 		}
@@ -230,13 +239,13 @@ func condNumericMatches(base, ctxVal string, condValues StringOrSlice) bool {
 // AWS: "You must specify date/time values with one of the W3C implementations of the
 // ISO 8601 date formats or in epoch (UNIX) time." Either notation is accepted on either
 // side, so the two can be compared against each other; see [condParseTime].
-func condDateMatches(base, ctxVal string, condValues StringOrSlice) bool {
+func condDateMatches(base, ctxVal string, condValues []policyPattern) bool {
 	ctxTime, ok := condParseTime(ctxVal)
 	if !ok {
 		return condOperatorNegated(base)
 	}
-	return condCompare(base, condValues, func(v string) (int, bool) {
-		t, ok := condParseTime(v)
+	return condCompare(base, condValues, func(v policyPattern) (int, bool) {
+		t, ok := condParseTime(v.text)
 		if !ok {
 			return 0, false
 		}
@@ -251,7 +260,7 @@ func condDateMatches(base, ctxVal string, condValues StringOrSlice) bool {
 // families because the six operator suffixes mean the same thing in both, and writing
 // them twice would let the two families disagree about, say, whether LessThanEquals
 // includes equality.
-func condCompare(base string, condValues StringOrSlice, cmp func(string) (int, bool)) bool {
+func condCompare(base string, condValues []policyPattern, cmp func(policyPattern) (int, bool)) bool {
 	// A negated operator is satisfied unless some value matches, so its scan cannot
 	// short-circuit on the first parse failure the way a positive one does.
 	if strings.HasSuffix(base, "NotEquals") {

--- a/emulator/iam_eval.go
+++ b/emulator/iam_eval.go
@@ -183,12 +183,15 @@ func EvaluateSourced(documents []SourcedPolicyDocument, req EvaluationRequest) E
 	missing := make(map[string]struct{})
 
 	for _, doc := range documents {
+		// Variables resolve per document, because whether they resolve at all is a
+		// property of the document's own Version element (#745).
+		vars := policyVars{ctx: req.Context, enabled: policyVarsSupported(doc.Document.Version)}
 		for _, stmt := range doc.Document.Statement {
-			if !statementMatches(stmt, req) {
+			if !statementMatches(stmt, req, vars) {
 				// A statement that covers the action and resource but was ruled out by a
 				// condition on an unset key is the reportable case: the answer would
 				// change given a value.
-				if actionResourcePrincipalMatch(stmt, req) {
+				if actionResourcePrincipalMatch(stmt, req, vars) {
 					for _, key := range unsetConditionKeys(stmt.Condition, req.Context, req.MultiContext) {
 						missing[key] = struct{}{}
 					}
@@ -261,10 +264,10 @@ func sortedKeys(set map[string]struct{}) []string {
 // actionResourcePrincipalMatch reports whether stmt covers req apart from its
 // conditions. It is the "would this statement apply, given the right context"
 // question MissingContextValues answers.
-func actionResourcePrincipalMatch(stmt PolicyStatement, req EvaluationRequest) bool {
+func actionResourcePrincipalMatch(stmt PolicyStatement, req EvaluationRequest, vars policyVars) bool {
 	return principalMatches(stmt, req.Principal) &&
 		actionMatches(stmt, req.Action) &&
-		resourceMatches(stmt, req.Resource)
+		resourceMatches(stmt, req.Resource, vars)
 }
 
 // unsetConditionKeys returns the condition keys stmt tests that the request context
@@ -306,17 +309,22 @@ func unsetConditionKeys(
 
 // statementMatches returns true if stmt covers the principal, action, resource,
 // and conditions specified in req.
-func statementMatches(stmt PolicyStatement, req EvaluationRequest) bool {
+//
+// vars is what the statement's ${…} variables resolve against, and it reaches only
+// the two elements AWS substitutes in: "You can use policy variables in the Resource
+// element and in string comparisons in the Condition element." Action and Principal
+// are compared as written.
+func statementMatches(stmt PolicyStatement, req EvaluationRequest, vars policyVars) bool {
 	if !principalMatches(stmt, req.Principal) {
 		return false
 	}
 	if !actionMatches(stmt, req.Action) {
 		return false
 	}
-	if !resourceMatches(stmt, req.Resource) {
+	if !resourceMatches(stmt, req.Resource, vars) {
 		return false
 	}
-	if !conditionMatches(stmt.Condition, req.Context, req.MultiContext) {
+	if !conditionMatches(stmt.Condition, req.Context, req.MultiContext, vars) {
 		return false
 	}
 	return true
@@ -445,20 +453,30 @@ func actionMatches(stmt PolicyStatement, action string) bool {
 
 // resourceMatches returns true when req.Resource is covered by stmt.Resource or,
 // for NotResource statements, when req.Resource is NOT in stmt.NotResource.
-func resourceMatches(stmt PolicyStatement, resource string) bool {
+//
+// An entry whose variables do not all resolve is skipped, in **either** element, which
+// is AWS's own rule stated once for both: "If a variable that has no value in the
+// authorization context is used as part of the Resource or NotResource element of a
+// policy, the resource that includes a policy variable with no value will not match
+// any resource." So such an entry grants nothing where it is a Resource, and excludes
+// nothing where it is a NotResource. Substrate reached the same two answers before
+// #745 by leaving the `${…}` in place and matching it literally against an ARN that
+// never contains one; doing it by the rule rather than by coincidence is what makes it
+// hold once the variable's *value* can contain a wildcard.
+func resourceMatches(stmt PolicyStatement, resource string, vars policyVars) bool {
 	if resource == "" {
 		return true
 	}
 	if len(stmt.NotResource) > 0 {
 		for _, r := range stmt.NotResource {
-			if globMatch(r, resource) {
+			if pattern, ok := vars.resolve(r); ok && pattern.matches(resource) {
 				return false
 			}
 		}
 		return true
 	}
 	for _, r := range stmt.Resource {
-		if globMatch(r, resource) {
+		if pattern, ok := vars.resolve(r); ok && pattern.matches(resource) {
 			return true
 		}
 	}
@@ -513,11 +531,12 @@ func conditionMatches(
 	conditions map[string]map[string]StringOrSlice,
 	ctx map[string]string,
 	multiCtx map[string][]string,
+	vars policyVars,
 ) bool {
 	for operator, keyValues := range conditions {
 		qualifier, base := splitConditionOperator(operator)
 		for condKey, condValues := range keyValues {
-			if !conditionKeyMatches(qualifier, base, condKey, condValues, ctx, multiCtx) {
+			if !conditionKeyMatches(qualifier, base, condKey, condValues, ctx, multiCtx, vars) {
 				return false
 			}
 		}
@@ -553,6 +572,7 @@ func conditionKeyMatches(
 	condValues StringOrSlice,
 	ctx map[string]string,
 	multiCtx map[string][]string,
+	vars policyVars,
 ) bool {
 	base, ifExists := condSplitIfExists(operator)
 	if base == "Null" && ifExists {
@@ -561,16 +581,20 @@ func conditionKeyMatches(
 		return false
 	}
 
+	// The policy's own values, with their variables resolved once for every arm below
+	// (#745).
+	values := condPolicyValues(base, condValues, vars)
+
 	switch qualifier {
 	case "":
 		if base == "Null" {
-			matched, _ := condEvaluate(base, condContextValue(condKey, ctx, multiCtx), condValues)
+			matched, _ := condEvaluate(base, condContextValue(condKey, ctx, multiCtx), values)
 			return matched
 		}
 		if !condKeyPresent(condKey, ctx, multiCtx) {
 			return condAbsentMatches(base, ifExists)
 		}
-		matched, recognized := condEvaluate(base, condContextValue(condKey, ctx, multiCtx), condValues)
+		matched, recognized := condEvaluate(base, condContextValue(condKey, ctx, multiCtx), values)
 		return recognized && matched
 
 	case condForAllValues:
@@ -583,7 +607,7 @@ func conditionKeyMatches(
 		// pair ForAllValues with `"Null": {"key": "false"}` on an Allow, and why every
 		// one of its aws:TagKeys examples does.
 		for _, reqVal := range condRequestValues(condKey, ctx, multiCtx) {
-			if matched, _ := condEvaluate(base, reqVal, condValues); !matched {
+			if matched, _ := condEvaluate(base, reqVal, values); !matched {
 				return false
 			}
 		}
@@ -603,7 +627,7 @@ func conditionKeyMatches(
 			return true
 		}
 		for _, reqVal := range condRequestValues(condKey, ctx, multiCtx) {
-			if matched, _ := condEvaluate(base, reqVal, condValues); matched {
+			if matched, _ := condEvaluate(base, reqVal, values); matched {
 				return true
 			}
 		}
@@ -735,44 +759,10 @@ func condRequestValues(condKey string, ctx map[string]string, multiCtx map[strin
 
 // globMatch returns true if pattern matches value using AWS glob rules:
 // '*' matches any sequence of characters, '?' matches exactly one character.
+//
+// Every character of pattern is the policy author's own, so every `*` and `?` in it
+// is a wildcard. A pattern that has had a variable substituted into it carries text
+// that is not, and matches through [policyPattern.matches] instead (#745).
 func globMatch(pattern, value string) bool {
-	return globMatchRec(pattern, value)
-}
-
-// globMatchRec is the recursive implementation of globMatch.
-func globMatchRec(pattern, value string) bool {
-	for len(pattern) > 0 {
-		switch pattern[0] {
-		case '*':
-			// Skip consecutive stars.
-			for len(pattern) > 0 && pattern[0] == '*' {
-				pattern = pattern[1:]
-			}
-			if len(pattern) == 0 {
-				return true
-			}
-			// Try matching the rest of the pattern at every position.
-			for i := 0; i <= len(value); i++ {
-				if globMatchRec(pattern, value[i:]) {
-					return true
-				}
-			}
-			return false
-
-		case '?':
-			if len(value) == 0 {
-				return false
-			}
-			pattern = pattern[1:]
-			value = value[1:]
-
-		default:
-			if len(value) == 0 || pattern[0] != value[0] {
-				return false
-			}
-			pattern = pattern[1:]
-			value = value[1:]
-		}
-	}
-	return len(value) == 0
+	return globMatchMask(pattern, nil, value)
 }

--- a/emulator/iam_plugin.go
+++ b/emulator/iam_plugin.go
@@ -1621,12 +1621,15 @@ func (p *IAMPlugin) authorize(goCtx context.Context, reqCtx *RequestContext, act
 	// satisfied through this door even though [CheckAccess] populates both — which is
 	// worth knowing before writing a condition against an iam: action (#690).
 	//
-	// aws:PrincipalArn is the exception, for [authzPrincipalContext]'s reason: it is not
-	// read from the request at all, it is who signed it, and this door knows that as
-	// surely as the other three. Leaving it out let a negated operator over it hold
-	// vacuously here while failing at the main gate (#714).
-	condCtx := make(map[string]string, 1)
-	authzPrincipalContext(condCtx, reqCtx.Principal.ARN)
+	// The caller's own keys are the exception, for [authzPrincipalContext]'s reason: they
+	// are not read from the request at all, they name who signed it, and this door knows
+	// that as surely as the other three. Leaving aws:PrincipalArn out let a negated
+	// operator over it hold vacuously here while failing at the main gate (#714), and
+	// leaving aws:username out is what made `${aws:username}` in an iam: statement — the
+	// shape of "let a user manage their own credentials" — match nothing at this door
+	// while resolving at the other (#745).
+	condCtx := make(map[string]string, 2)
+	authzPrincipalContext(condCtx, reqCtx.Principal)
 
 	result := Evaluate(docs, EvaluationRequest{
 		Principal: reqCtx.Principal.ARN,

--- a/emulator/iam_policy_variables.go
+++ b/emulator/iam_policy_variables.go
@@ -1,0 +1,330 @@
+package emulator
+
+import "strings"
+
+// policyVarOpen and policyVarClose delimit a policy variable.
+//
+// AWS: "Variables are marked using a $ prefix followed by a pair of curly braces
+// ({ }) that include the variable name of the value from the request" — so the closing
+// brace is a byte rather than a string, since that is how it is scanned for.
+const (
+	policyVarOpen  = "${"
+	policyVarClose = '}'
+)
+
+// policyVarVersion is the policy language version that introduced variables.
+//
+// AWS: "In order to use policy variables, you must include the Version element in a
+// statement, and the version must be set to a version that supports policy variables.
+// Variables were introduced in version 2012-10-17. Earlier versions of the policy
+// language don't support policy variables. If you don't include the Version element
+// and set it to an appropriate version date, variables like ${aws:username} are
+// treated as literal strings in the policy" — which is the reading substrate had for
+// every document before #745, and keeps for a document that predates the element.
+const policyVarVersion = "2012-10-17"
+
+// policyVarsSupported reports whether a document's Version admits variables.
+//
+// The comparison is lexical rather than an equality test against the one version
+// that exists today, because both published versions are dates and a third would
+// sort after this one. A document with no Version element compares below it and is
+// read literally, which is what AWS's sentence above says to do.
+func policyVarsSupported(version string) bool {
+	return version >= policyVarVersion
+}
+
+// policyVars is what a statement's ${…} variables resolve against.
+//
+// The context is the request's *single-valued* map alone. AWS: "You can use any
+// single-valued condition key as a variable. You can't use a multivalued condition
+// key as a variable" — so MultiContext is deliberately not consulted here, unlike in
+// [condContextValue], where a multivalued key is a legitimate fallback for the
+// operator that reads it.
+type policyVars struct {
+	// ctx is the request's single-valued condition context.
+	ctx map[string]string
+
+	// enabled is false for a document whose Version predates variables, and for
+	// every element AWS does not substitute in.
+	enabled bool
+}
+
+// resolve substitutes text's variables, or returns it verbatim when the document
+// this statement came from does not admit variables.
+func (v policyVars) resolve(text string) (policyPattern, bool) {
+	if !v.enabled {
+		return rawPolicyPattern(text), true
+	}
+	return substitutePolicyVariables(text, v.ctx)
+}
+
+// policyPattern is a policy string with its ${…} variables resolved, carrying which
+// of its bytes are wildcards and which are literal text.
+//
+// Those are not the same question once a variable resolves. A `*` or `?` is a
+// wildcard because the *policy author* wrote one; a `*` that arrived from a tag value,
+// or from the `${*}` escape whose entire purpose is to denote a literal asterisk, is
+// text. A plain string cannot hold that distinction, which is why substitution
+// produces this instead: substituting `${*}` and handing the result to [globMatch]
+// would turn AWS's escape for a literal `*` into a wildcard, widening the statement —
+// the one direction a deliberate escape must never take (#745).
+//
+// A substituted *value* is literal for the same reason pointed the other way. AWS
+// documents no rule for a resolved value that itself contains a `*`, so substrate
+// reads it as text: a tag value is data the request carried, not pattern the policy
+// author wrote, and reading it as pattern is the reading that can only widen.
+type policyPattern struct {
+	// text is the pattern after substitution.
+	text string
+
+	// literal reports, per byte of text, whether that byte matches itself even when
+	// it is `*` or `?`.
+	//
+	// nil means no byte is exempt, which is every policy string containing no `${`
+	// — so such a pattern matches exactly as it did before #745 and allocates
+	// nothing for the distinction.
+	literal []bool
+}
+
+// rawPolicyPattern is text as written, with every `*` and `?` a wildcard.
+func rawPolicyPattern(text string) policyPattern {
+	return policyPattern{text: text}
+}
+
+// matches reports whether p covers value under AWS's glob rules.
+func (p policyPattern) matches(value string) bool {
+	return globMatchMask(p.text, p.literal, value)
+}
+
+// splitN splits p at sep into at most n pieces, keeping each piece's mask aligned
+// with its text.
+//
+// It exists for [condARNMatches], which compares an ARN component by component. A
+// separator inside a substituted value is split on like any other: AWS's rule is
+// about the six colon-delimited components of the pattern, and the pattern is what
+// this is.
+func (p policyPattern) splitN(sep string, n int) []policyPattern {
+	parts := strings.SplitN(p.text, sep, n)
+	out := make([]policyPattern, 0, len(parts))
+	offset := 0
+	for _, part := range parts {
+		piece := policyPattern{text: part}
+		if p.literal != nil {
+			piece.literal = p.literal[offset : offset+len(part)]
+		}
+		out = append(out, piece)
+		offset += len(part) + len(sep)
+	}
+	return out
+}
+
+// substitutePolicyVariables resolves every ${…} in text against the request context,
+// and reports whether all of them resolved.
+//
+// A variable with no value makes the whole string unresolved, and no pattern is
+// returned for it, because AWS's rule leaves nothing to compare: "When policy
+// variables reference a condition context key that has no value or is not present in
+// an authorization context for a request, the value is effectively null. There is no
+// equal or like value." Every caller therefore drops the element rather than matching
+// it — see [resourceMatches] and [condPolicyValues], which is where that rule is
+// applied for each element AWS states it for.
+//
+// A key present with an empty value counts as having no value, which is the reading
+// [condKeyPresent] has always taken of AWS's "resolves to a null dataset, such as an
+// empty string".
+//
+// A `${` with no closing brace is not a variable and is passed through as text. AWS
+// documents no such form, so it cannot be a variable with a value; treating it as an
+// unresolved one instead would silently void a statement over a typo.
+func substitutePolicyVariables(text string, ctx map[string]string) (policyPattern, bool) {
+	if !strings.Contains(text, policyVarOpen) {
+		return rawPolicyPattern(text), true
+	}
+
+	var out strings.Builder
+	out.Grow(len(text))
+	literal := make([]bool, 0, len(text))
+
+	// Text the author wrote keeps its wildcards; text a variable resolved to does not.
+	appendAuthored := func(s string) {
+		out.WriteString(s)
+		literal = append(literal, make([]bool, len(s))...)
+	}
+	appendResolved := func(s string) {
+		out.WriteString(s)
+		for i := 0; i < len(s); i++ {
+			literal = append(literal, true)
+		}
+	}
+
+	rest := text
+	for {
+		open := strings.Index(rest, policyVarOpen)
+		if open < 0 {
+			appendAuthored(rest)
+			break
+		}
+		appendAuthored(rest[:open])
+		body := rest[open+len(policyVarOpen):]
+		end := strings.IndexByte(body, policyVarClose)
+		if end < 0 {
+			appendAuthored(rest[open:])
+			break
+		}
+		value, ok := resolvePolicyVariable(body[:end], ctx)
+		if !ok {
+			return policyPattern{}, false
+		}
+		appendResolved(value)
+		rest = body[end+1:]
+	}
+	return policyPattern{text: out.String(), literal: literal}, true
+}
+
+// resolvePolicyVariable resolves one variable's contents — what stands between `${`
+// and `}` — to the text it stands for.
+//
+// The three special forms come first. AWS: "There are a few special predefined policy
+// variables that have fixed values that enable you to represent characters that
+// otherwise have special meaning… ${*} - use where you need an * (asterisk)
+// character. ${?} - use where you need a ? (question mark) character. ${$} - use
+// where you need a $ (dollar sign) character." They resolve to that character as
+// text, never as a wildcard; see [policyPattern].
+//
+// A name resolves through [condResolveKey] rather than by indexing the context,
+// because AWS's rule for a variable is the rule for a condition key it names: "Key
+// names are case-insensitive. For example, aws:CurrentTime is equivalent to
+// AWS:currenttime." A producer's spelling and a policy's need not agree.
+func resolvePolicyVariable(expr string, ctx map[string]string) (string, bool) {
+	switch expr {
+	case "*", "?", "$":
+		return expr, true
+	}
+	name, fallback, hasFallback := splitPolicyVariableDefault(expr)
+	if key, ok := condResolveKey(name, ctx); ok && ctx[key] != "" {
+		return ctx[key], true
+	}
+	if hasFallback {
+		return fallback, true
+	}
+	return "", false
+}
+
+// splitPolicyVariableDefault separates a variable's name from its default value.
+//
+// AWS: "To add a default value to a variable, surround the default value with single
+// quotes (' '), and separate the variable text and the default value with a comma and
+// space (, )" — `${aws:PrincipalTag/team, 'company-wide'}`.
+//
+// The quotes are stripped when both are present and the value is used as written when
+// they are not, which AWS does not specify: a name cannot contain a comma, so
+// everything after the first one was meant as a default whether or not it was quoted,
+// and reading it as part of the key name would make the variable unresolvable instead.
+// That is substrate's reading (#745).
+func splitPolicyVariableDefault(expr string) (name, fallback string, ok bool) {
+	comma := strings.IndexByte(expr, ',')
+	if comma < 0 {
+		return expr, "", false
+	}
+	name = strings.TrimSpace(expr[:comma])
+	fallback = strings.TrimSpace(expr[comma+1:])
+	if len(fallback) >= 2 && strings.HasPrefix(fallback, "'") && strings.HasSuffix(fallback, "'") {
+		fallback = fallback[1 : len(fallback)-1]
+	}
+	return name, fallback, true
+}
+
+// condOperatorSubstitutes reports whether AWS resolves policy variables in the values
+// of a condition written with base.
+//
+// AWS: "You can use a policy variable for Condition values in any condition that
+// involves the string operators or the ARN operators (StringEquals, StringLike,
+// StringNotLike, ArnLike, ArnNotLike, and so on). You can't use a policy variable with
+// other operators, such as Numeric, Date, Boolean, Binary, IP Address, or Null
+// operators." That list is exhaustive on both sides, so the test is the operator
+// family's prefix rather than a list of names that would drift from [condEvaluate]'s
+// switch.
+//
+// base is the operator with its `...IfExists` suffix and set qualifier already stripped
+// by [conditionKeyMatches], because neither changes which family the operator belongs
+// to.
+func condOperatorSubstitutes(base string) bool {
+	return strings.HasPrefix(base, "String") || strings.HasPrefix(base, "Arn")
+}
+
+// condPolicyValues resolves a condition's policy values into the patterns
+// [condEvaluate] compares against.
+//
+// A value whose variable had no value is *dropped* rather than compared, because AWS
+// leaves nothing to compare it with: "When policy variables reference a condition
+// context key that has no value or is not present in an authorization context for a
+// request, the value is effectively null. There is no equal or like value." Dropping is
+// what makes both directions of that rule fall out of one scan — a positive operator
+// finds no match among the values that remain, and a negated one is satisfied, which is
+// AWS's "Inverted condition operators like StringNotEquals or StringNotLike do match
+// against a null value."
+//
+// An operator whose family AWS does not substitute in keeps its values verbatim, `${…}`
+// and all, per [condOperatorSubstitutes] — a Numeric condition on the literal text
+// "${aws:username}" is a comparison that cannot be made, which [condNumericMatches]
+// already answers, and not an unresolved variable (#745).
+func condPolicyValues(base string, condValues StringOrSlice, vars policyVars) []policyPattern {
+	if !vars.enabled || !condOperatorSubstitutes(base) {
+		out := make([]policyPattern, 0, len(condValues))
+		for _, v := range condValues {
+			out = append(out, rawPolicyPattern(v))
+		}
+		return out
+	}
+	out := make([]policyPattern, 0, len(condValues))
+	for _, v := range condValues {
+		if pattern, ok := vars.resolve(v); ok {
+			out = append(out, pattern)
+		}
+	}
+	return out
+}
+
+// globMatchMask is [globMatch] over a pattern whose wildcards are named by a mask.
+//
+// literal may be nil, meaning every `*` and `?` in pattern is a wildcard — which is
+// every Action, and every Resource naming no variable, so the common path is
+// unchanged by #745.
+//
+// The walk is iterative and remembers one `*`: on a mismatch it resumes from the last
+// star having let it consume one more byte. That answers identically to the recursion
+// it replaced for the `*`/`?` grammar AWS defines — "'*' matches any sequence of
+// characters, '?' matches exactly one character" — without recursing once per star,
+// and it is the only form in which the mask can be consulted, since a recursive call
+// on a pattern suffix would have to carry the matching slice of the mask with it.
+func globMatchMask(pattern string, literal []bool, value string) bool {
+	wildcard := func(i int, c byte) bool {
+		return pattern[i] == c && (literal == nil || !literal[i])
+	}
+
+	// star is where the last wildcard `*` was found and starValue how much of value
+	// it had consumed at the time; -1 means there has been none to fall back to.
+	p, v, star, starValue := 0, 0, -1, 0
+	for v < len(value) {
+		switch {
+		case p < len(pattern) && wildcard(p, '?'):
+			p++
+			v++
+		case p < len(pattern) && !wildcard(p, '*') && pattern[p] == value[v]:
+			p++
+			v++
+		case p < len(pattern) && wildcard(p, '*'):
+			star, starValue = p, v
+			p++
+		case star >= 0:
+			starValue++
+			p, v = star+1, starValue
+		default:
+			return false
+		}
+	}
+	for p < len(pattern) && wildcard(p, '*') {
+		p++
+	}
+	return p == len(pattern)
+}

--- a/emulator/iam_policy_variables_test.go
+++ b/emulator/iam_policy_variables_test.go
@@ -1,0 +1,622 @@
+package emulator_test
+
+import (
+	"bytes"
+	"encoding/xml"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// policyVarDoc is one statement with the version that admits variables, which is what
+// every case below is about except the one that deliberately omits it.
+func policyVarDoc(stmt emulator.PolicyStatement) []emulator.PolicyDocument {
+	return []emulator.PolicyDocument{{Version: "2012-10-17", Statement: []emulator.PolicyStatement{stmt}}}
+}
+
+// TestEvaluate_ResourceVariableResolves is the positive direction of #745: a variable
+// with a value is substituted, so a statement scoped to the caller's own prefix allows
+// their object and refuses somebody else's.
+//
+// This is the shape of every "let a user manage their own things" policy, including AWS's
+// own IAMUserChangePassword, and before #745 it allowed nothing at all: the literal
+// `${aws:username}` was compared against an ARN that never contains one.
+func TestEvaluate_ResourceVariableResolves(t *testing.T) {
+	docs := policyVarDoc(emulator.PolicyStatement{
+		Effect:   emulator.IAMEffectAllow,
+		Action:   emulator.StringOrSlice{"s3:GetObject"},
+		Resource: emulator.StringOrSlice{"arn:aws:s3:::home/${aws:username}/*"},
+	})
+
+	tests := []struct {
+		name     string
+		resource string
+		want     string
+	}{
+		{"the caller's own prefix", "arn:aws:s3:::home/alice/report.txt", emulator.DecisionAllow},
+		{"somebody else's prefix", "arn:aws:s3:::home/bob/report.txt", emulator.DecisionImplicitDeny},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := emulator.Evaluate(docs, emulator.EvaluationRequest{
+				Action:   "s3:GetObject",
+				Resource: tt.resource,
+				Context:  map[string]string{"aws:username": "alice"},
+			})
+			assert.Equal(t, tt.want, result.Decision)
+		})
+	}
+}
+
+// TestEvaluate_UnresolvedVariableMatchesNoResource pins AWS's rule for an unresolved
+// variable in both resource elements, which is one rule stated once for the pair: "If a
+// variable that has no value in the authorization context is used as part of the Resource
+// or NotResource element of a policy, the resource that includes a policy variable with no
+// value will not match any resource."
+//
+// So the two directions of the criterion fall out of one skip: as a Resource the entry
+// grants nothing, and as a NotResource it excludes nothing — which is what makes the
+// negated element match every resource. Substrate answered both correctly before #745 by
+// leaving the `${…}` in place and comparing it literally against an ARN that never
+// contains one; this pins the answer now that the rule is applied deliberately, so it
+// cannot regress once a resolved value can itself hold a wildcard.
+func TestEvaluate_UnresolvedVariableMatchesNoResource(t *testing.T) {
+	t.Run("Resource grants nothing", func(t *testing.T) {
+		docs := policyVarDoc(emulator.PolicyStatement{
+			Effect:   emulator.IAMEffectAllow,
+			Action:   emulator.StringOrSlice{"s3:GetObject"},
+			Resource: emulator.StringOrSlice{"arn:aws:s3:::home/${aws:username}/*"},
+		})
+		result := emulator.Evaluate(docs, emulator.EvaluationRequest{
+			Action:   "s3:GetObject",
+			Resource: "arn:aws:s3:::home/alice/report.txt",
+		})
+		assert.Equal(t, emulator.DecisionImplicitDeny, result.Decision)
+	})
+
+	t.Run("NotResource excludes nothing", func(t *testing.T) {
+		docs := policyVarDoc(emulator.PolicyStatement{
+			Effect:      emulator.IAMEffectAllow,
+			Action:      emulator.StringOrSlice{"s3:GetObject"},
+			NotResource: emulator.StringOrSlice{"arn:aws:s3:::home/${aws:username}/*"},
+		})
+		result := emulator.Evaluate(docs, emulator.EvaluationRequest{
+			Action:   "s3:GetObject",
+			Resource: "arn:aws:s3:::home/alice/report.txt",
+		})
+		assert.Equal(t, emulator.DecisionAllow, result.Decision)
+	})
+}
+
+// TestEvaluate_ConditionVariableResolves is the divergence #745 exists for, and its
+// negated half is the dangerous one: with the variable compared literally, a resolved
+// value could not match, so `StringNotEquals` was satisfied by every caller — a false
+// deny on a Deny statement and a false *allow* on an Allow.
+//
+// The issue's own framing has this backwards, describing the unresolved case as the
+// divergence. Substituting is what makes the negated form exclude the caller it names.
+func TestEvaluate_ConditionVariableResolves(t *testing.T) {
+	tests := []struct {
+		name     string
+		operator string
+		owner    string
+		want     string
+	}{
+		{"StringEquals matches the caller's own value", "StringEquals", "alice", emulator.DecisionAllow},
+		{"StringEquals refuses another's", "StringEquals", "bob", emulator.DecisionImplicitDeny},
+		{"StringNotEquals excludes the caller it names", "StringNotEquals", "alice", emulator.DecisionImplicitDeny},
+		{"StringNotEquals admits everybody else", "StringNotEquals", "bob", emulator.DecisionAllow},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			docs := policyVarDoc(emulator.PolicyStatement{
+				Effect:   emulator.IAMEffectAllow,
+				Action:   emulator.StringOrSlice{"s3:GetObject"},
+				Resource: emulator.StringOrSlice{"*"},
+				Condition: map[string]map[string]emulator.StringOrSlice{
+					tt.operator: {"s3:owner": {"${aws:username}"}},
+				},
+			})
+			result := emulator.Evaluate(docs, emulator.EvaluationRequest{
+				Action:   "s3:GetObject",
+				Resource: "arn:aws:s3:::mybucket/file.txt",
+				Context:  map[string]string{"aws:username": "alice", "s3:owner": tt.owner},
+			})
+			assert.Equal(t, tt.want, result.Decision)
+		})
+	}
+}
+
+// TestEvaluate_UnresolvedConditionVariableIsNull pins the other half of the criterion,
+// which for a condition value is *not* the resource rule: AWS says the value "is
+// effectively null. There is no equal or like value", and then that "inverted condition
+// operators like StringNotEquals or StringNotLike do match against a null value".
+//
+// So the positive form matches nothing and the negated form matches everything, which is
+// exactly the asymmetry the resource elements do not have.
+func TestEvaluate_UnresolvedConditionVariableIsNull(t *testing.T) {
+	tests := []struct {
+		name     string
+		operator string
+		want     string
+	}{
+		{"positive form matches nothing", "StringEquals", emulator.DecisionImplicitDeny},
+		{"negated form matches a null value", "StringNotEquals", emulator.DecisionAllow},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			docs := policyVarDoc(emulator.PolicyStatement{
+				Effect:   emulator.IAMEffectAllow,
+				Action:   emulator.StringOrSlice{"s3:GetObject"},
+				Resource: emulator.StringOrSlice{"*"},
+				Condition: map[string]map[string]emulator.StringOrSlice{
+					tt.operator: {"s3:owner": {"${aws:username}"}},
+				},
+			})
+			result := emulator.Evaluate(docs, emulator.EvaluationRequest{
+				Action:   "s3:GetObject",
+				Resource: "arn:aws:s3:::mybucket/file.txt",
+				// No aws:username, so the variable has no value. s3:owner is present, so
+				// the answer is about the *policy's* null value and not about an absent
+				// request key, which condEvaluate answers separately.
+				Context: map[string]string{"s3:owner": "alice"},
+			})
+			assert.Equal(t, tt.want, result.Decision)
+		})
+	}
+}
+
+// TestEvaluate_VariablesNeedTheVersionElement pins AWS's gate: "Variables were introduced
+// in version 2012-10-17… If you don't include the Version element and set it to an
+// appropriate version date, variables like ${aws:username} are treated as literal strings
+// in the policy."
+//
+// A document with no Version therefore compares the text as written, so the statement
+// matches only a resource that literally contains `${aws:username}` — and refuses the one
+// the variable would have resolved to.
+func TestEvaluate_VariablesNeedTheVersionElement(t *testing.T) {
+	stmt := emulator.PolicyStatement{
+		Effect:   emulator.IAMEffectAllow,
+		Action:   emulator.StringOrSlice{"s3:GetObject"},
+		Resource: emulator.StringOrSlice{"arn:aws:s3:::home/${aws:username}/*"},
+	}
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{"2012-10-17 substitutes", "2012-10-17", emulator.DecisionAllow},
+		{"2008-10-17 does not", "2008-10-17", emulator.DecisionImplicitDeny},
+		{"no Version element does not", "", emulator.DecisionImplicitDeny},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			docs := []emulator.PolicyDocument{{
+				Version:   tt.version,
+				Statement: []emulator.PolicyStatement{stmt},
+			}}
+			result := emulator.Evaluate(docs, emulator.EvaluationRequest{
+				Action:   "s3:GetObject",
+				Resource: "arn:aws:s3:::home/alice/report.txt",
+				Context:  map[string]string{"aws:username": "alice"},
+			})
+			assert.Equal(t, tt.want, result.Decision)
+		})
+	}
+}
+
+// TestEvaluate_VariableEscapesStayLiteral pins the hazard substitution introduces, which
+// AWS's escapes exist precisely to avoid: `${*}` "use where you need an * (asterisk)
+// character". Substituting it and handing the result to the glob matcher would turn the
+// author's deliberate escape into a wildcard, widening the statement — the one direction an
+// escape must never take.
+//
+// A substituted *value* containing a wildcard is literal for the same reason pointed the
+// other way: a tag value is data the request carried, not pattern the author wrote, so a
+// caller who can set a tag cannot widen the policy that reads it.
+func TestEvaluate_VariableEscapesStayLiteral(t *testing.T) {
+	t.Run("${*} is an asterisk, not a wildcard", func(t *testing.T) {
+		docs := policyVarDoc(emulator.PolicyStatement{
+			Effect:   emulator.IAMEffectAllow,
+			Action:   emulator.StringOrSlice{"s3:GetObject"},
+			Resource: emulator.StringOrSlice{"arn:aws:s3:::home/${*}"},
+		})
+		allowed := emulator.Evaluate(docs, emulator.EvaluationRequest{
+			Action:   "s3:GetObject",
+			Resource: "arn:aws:s3:::home/*",
+		})
+		assert.Equal(t, emulator.DecisionAllow, allowed.Decision, "the literal asterisk must match")
+
+		refused := emulator.Evaluate(docs, emulator.EvaluationRequest{
+			Action:   "s3:GetObject",
+			Resource: "arn:aws:s3:::home/alice",
+		})
+		assert.Equal(t, emulator.DecisionImplicitDeny, refused.Decision,
+			"a wildcard read of ${*} would have allowed every object under home/")
+	})
+
+	t.Run("a wildcard inside a resolved value is text", func(t *testing.T) {
+		docs := policyVarDoc(emulator.PolicyStatement{
+			Effect:   emulator.IAMEffectAllow,
+			Action:   emulator.StringOrSlice{"s3:GetObject"},
+			Resource: emulator.StringOrSlice{"arn:aws:s3:::home/${aws:username}"},
+		})
+		result := emulator.Evaluate(docs, emulator.EvaluationRequest{
+			Action:   "s3:GetObject",
+			Resource: "arn:aws:s3:::home/alice",
+			Context:  map[string]string{"aws:username": "*"},
+		})
+		assert.Equal(t, emulator.DecisionImplicitDeny, result.Decision)
+	})
+}
+
+// TestEvaluate_VariableDefaultValue pins AWS's documented default syntax: "To add a
+// default value to a variable, surround the default value with single quotes (' '), and
+// separate the variable text and the default value with a comma and space (, )".
+//
+// A variable with a default is never unresolved, which is the whole point of writing one —
+// so the statement matches the default's prefix rather than nothing.
+func TestEvaluate_VariableDefaultValue(t *testing.T) {
+	docs := policyVarDoc(emulator.PolicyStatement{
+		Effect:   emulator.IAMEffectAllow,
+		Action:   emulator.StringOrSlice{"s3:GetObject"},
+		Resource: emulator.StringOrSlice{"arn:aws:s3:::${aws:PrincipalTag/team, 'company-wide'}/*"},
+	})
+
+	tests := []struct {
+		name     string
+		ctx      map[string]string
+		resource string
+		want     string
+	}{
+		{
+			name:     "the tag's value wins when it has one",
+			ctx:      map[string]string{"aws:PrincipalTag/team": "platform"},
+			resource: "arn:aws:s3:::platform/file.txt",
+			want:     emulator.DecisionAllow,
+		},
+		{
+			name:     "the default applies when it does not",
+			ctx:      nil,
+			resource: "arn:aws:s3:::company-wide/file.txt",
+			want:     emulator.DecisionAllow,
+		},
+		{
+			name:     "and the default is not a wildcard",
+			ctx:      nil,
+			resource: "arn:aws:s3:::platform/file.txt",
+			want:     emulator.DecisionImplicitDeny,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := emulator.Evaluate(docs, emulator.EvaluationRequest{
+				Action:   "s3:GetObject",
+				Resource: tt.resource,
+				Context:  tt.ctx,
+			})
+			assert.Equal(t, tt.want, result.Decision)
+		})
+	}
+}
+
+// TestEvaluate_VariableNamesAreCaseInsensitive pins AWS's rule for the name inside the
+// braces, which is the rule for the condition key it names: "Key names are
+// case-insensitive. For example, aws:CurrentTime is equivalent to AWS:currenttime."
+//
+// It matters because a producer's spelling and a policy author's need not agree, and
+// substrate's own producers write `aws:username` while AWS's documentation and examples
+// mix `aws:username` and `aws:userName`.
+func TestEvaluate_VariableNamesAreCaseInsensitive(t *testing.T) {
+	for _, spelling := range []string{"aws:username", "aws:userName", "AWS:USERNAME"} {
+		t.Run(spelling, func(t *testing.T) {
+			docs := policyVarDoc(emulator.PolicyStatement{
+				Effect:   emulator.IAMEffectAllow,
+				Action:   emulator.StringOrSlice{"s3:GetObject"},
+				Resource: emulator.StringOrSlice{"arn:aws:s3:::home/${" + spelling + "}/*"},
+			})
+			result := emulator.Evaluate(docs, emulator.EvaluationRequest{
+				Action:   "s3:GetObject",
+				Resource: "arn:aws:s3:::home/alice/report.txt",
+				Context:  map[string]string{"aws:username": "alice"},
+			})
+			assert.Equal(t, emulator.DecisionAllow, result.Decision)
+		})
+	}
+}
+
+// TestEvaluate_VariablesOnlyInTheElementsAWSSubstitutes pins the two limits AWS states,
+// both of which narrow where substitution runs.
+//
+// Action is not on AWS's list of elements variables resolve in, and neither is a Numeric
+// condition: "You can't use a policy variable with other operators, such as Numeric, Date,
+// Boolean, Binary, IP Address, or Null operators." So both compare the text as written,
+// which for a Numeric value is a comparison that cannot be made.
+func TestEvaluate_VariablesOnlyInTheElementsAWSSubstitutes(t *testing.T) {
+	t.Run("Action is compared as written", func(t *testing.T) {
+		docs := policyVarDoc(emulator.PolicyStatement{
+			Effect:   emulator.IAMEffectAllow,
+			Action:   emulator.StringOrSlice{"s3:${aws:username}"},
+			Resource: emulator.StringOrSlice{"*"},
+		})
+		result := emulator.Evaluate(docs, emulator.EvaluationRequest{
+			Action:   "s3:GetObject",
+			Resource: "arn:aws:s3:::mybucket/file.txt",
+			Context:  map[string]string{"aws:username": "GetObject"},
+		})
+		assert.Equal(t, emulator.DecisionImplicitDeny, result.Decision)
+	})
+
+	t.Run("a Numeric value is compared as written", func(t *testing.T) {
+		docs := policyVarDoc(emulator.PolicyStatement{
+			Effect:   emulator.IAMEffectAllow,
+			Action:   emulator.StringOrSlice{"s3:ListBucket"},
+			Resource: emulator.StringOrSlice{"*"},
+			Condition: map[string]map[string]emulator.StringOrSlice{
+				"NumericEquals": {"s3:max-keys": {"${aws:username}"}},
+			},
+		})
+		result := emulator.Evaluate(docs, emulator.EvaluationRequest{
+			Action:   "s3:ListBucket",
+			Resource: "arn:aws:s3:::mybucket",
+			Context:  map[string]string{"aws:username": "10", "s3:max-keys": "10"},
+		})
+		assert.Equal(t, emulator.DecisionImplicitDeny, result.Decision)
+	})
+}
+
+// TestEvaluate_VariableInsideAnARNCondition pins that substitution and AWS's
+// component-by-component ARN comparison compose: "Each of the six colon-delimited
+// components of the ARN is checked separately", and a `*` a variable resolved to is still
+// text inside whichever component it landed in.
+func TestEvaluate_VariableInsideAnARNCondition(t *testing.T) {
+	docs := policyVarDoc(emulator.PolicyStatement{
+		Effect:   emulator.IAMEffectAllow,
+		Action:   emulator.StringOrSlice{"sns:Publish"},
+		Resource: emulator.StringOrSlice{"*"},
+		Condition: map[string]map[string]emulator.StringOrSlice{
+			"ArnLike": {"aws:SourceArn": {"arn:aws:sns:*:*:${aws:username}-*"}},
+		},
+	})
+
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{"the caller's own topic", "arn:aws:sns:us-east-1:123456789012:alice-alerts", emulator.DecisionAllow},
+		{"another's topic", "arn:aws:sns:us-east-1:123456789012:bob-alerts", emulator.DecisionImplicitDeny},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := emulator.Evaluate(docs, emulator.EvaluationRequest{
+				Action:   "sns:Publish",
+				Resource: "arn:aws:sns:us-east-1:123456789012:alice-alerts",
+				Context:  map[string]string{"aws:username": "alice", "aws:SourceArn": tt.source},
+			})
+			assert.Equal(t, tt.want, result.Decision)
+		})
+	}
+}
+
+// TestCheckAccess_UsernameVariableScopesToTheCaller joins the two halves of #745 at the
+// enforcement door: the producer writes aws:username from [Principal.UserName], and the
+// substituter resolves the `${aws:username}` a policy names.
+//
+// The policy is the shape AWS's own documentation gives for "a bucket prefix per user",
+// and before this release it allowed nothing at all — so a consumer testing a
+// perfectly ordinary IaC policy saw AccessDenied for a request AWS permits.
+func TestCheckAccess_UsernameVariableScopesToTheCaller(t *testing.T) {
+	ownPrefixOnly := emulator.PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []emulator.PolicyStatement{{
+			Effect:   "Allow",
+			Action:   emulator.StringOrSlice{"s3:*"},
+			Resource: emulator.StringOrSlice{"arn:aws:s3:::home/${aws:username}/*"},
+		}},
+	}
+	policyARN := "arn:aws:iam::123456789012:policy/OwnPrefixOnly"
+
+	tests := []struct {
+		name      string
+		principal *emulator.Principal
+		path      string
+		allowed   bool
+	}{
+		{
+			name: "the caller's own prefix",
+			principal: &emulator.Principal{
+				ARN: "arn:aws:iam::123456789012:user/alice", Type: "IAMUser", UserName: "alice",
+			},
+			path:    "/home/alice/report.txt",
+			allowed: true,
+		},
+		{
+			name: "another user's prefix",
+			principal: &emulator.Principal{
+				ARN: "arn:aws:iam::123456789012:user/alice", Type: "IAMUser", UserName: "alice",
+			},
+			path:    "/home/bob/report.txt",
+			allowed: false,
+		},
+		{
+			// A principal with no recorded user name publishes no aws:username, so the
+			// variable does not resolve and the statement matches nothing — which is
+			// AWS's rule for an unresolved variable in a Resource, and the reason this
+			// direction is safe to leave to the absent key.
+			name: "a principal with no user name",
+			principal: &emulator.Principal{
+				ARN: "arn:aws:iam::123456789012:user/alice", Type: "IAMUser",
+			},
+			path:    "/home/alice/report.txt",
+			allowed: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := newAuthTestState(t, "alice", policyARN, ownPrefixOnly)
+			auth := emulator.NewAuthController(state, emulator.NewDefaultLogger(slog.LevelError, false))
+
+			reqCtx := &emulator.RequestContext{
+				RequestID: "req-1",
+				AccountID: authzTestAccount,
+				Region:    "us-east-1",
+				Principal: tt.principal,
+				Metadata:  make(map[string]interface{}),
+			}
+			err := auth.CheckAccess(reqCtx, &emulator.AWSRequest{
+				Service: "s3", Operation: "GetObject", Path: tt.path,
+			})
+			if tt.allowed {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestServer_ResolvePrincipal_CarriesTheUserName is the producer half end to end: the name
+// has to survive the credential lookup, because that is the only place it exists.
+//
+// The three cases are AWS's own table. A long-term key names its user; an assumed-role
+// session names none, where `aws:username` reads "(not present)"; and a GetSessionToken
+// session names the *same* user, because its principal is unchanged — which is why
+// presence cannot be keyed off Principal.Type, which reads "AssumedRole" for both STS
+// forms (#745).
+func TestServer_ResolvePrincipal_CarriesTheUserName(t *testing.T) {
+	t.Run("a long-term key names its user", func(t *testing.T) {
+		srv, capture := newPrincipalTestServer(t)
+		keyID := principalCreateAccessKey(t, srv, "alice")
+
+		resp := principalDynamoCall(t, srv, keyID)
+		require.NoError(t, resp.Body.Close())
+		require.NotNil(t, capture.principal)
+		assert.Equal(t, "alice", capture.principal.UserName)
+	})
+
+	t.Run("an assumed-role session names none", func(t *testing.T) {
+		srv, capture := newPrincipalTestServer(t)
+		require.Equal(t, http.StatusOK,
+			principalIAMCall(t, srv, "CreateRole", map[string]any{"RoleName": "worker"}).StatusCode)
+		keyID := principalCreateAccessKey(t, srv, "alice")
+
+		sessionKey := principalSTSCall(t, srv, keyID,
+			"Action=AssumeRole&RoleArn=arn:aws:iam::123456789012:role/worker&RoleSessionName=sess1")
+
+		resp := principalDynamoCall(t, srv, sessionKey)
+		require.NoError(t, resp.Body.Close())
+		require.NotNil(t, capture.principal)
+		assert.Empty(t, capture.principal.UserName,
+			"the session name is not a user name, and AWS publishes no aws:username here")
+	})
+
+	t.Run("a GetSessionToken session names the same user", func(t *testing.T) {
+		srv, capture := newPrincipalTestServer(t)
+		keyID := principalCreateAccessKey(t, srv, "alice")
+
+		sessionKey := principalSTSCall(t, srv, keyID, "Action=GetSessionToken")
+
+		resp := principalDynamoCall(t, srv, sessionKey)
+		require.NoError(t, resp.Body.Close())
+		require.NotNil(t, capture.principal)
+		assert.Equal(t, "alice", capture.principal.UserName)
+	})
+}
+
+// principalSTSCall issues a query-protocol STS call signed with accessKeyID and returns
+// the access key ID of the session it minted.
+//
+// The Credentials element is found by walking the document rather than by an XML path,
+// because AssumeRole and GetSessionToken wrap it in differently-named results and one
+// walk serves both.
+func principalSTSCall(t *testing.T, srv *emulator.Server, accessKeyID, query string) string {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, "/?"+query, nil)
+	r.Host = "sts.amazonaws.com"
+	r.Header.Set("Authorization", principalAuthHeader(accessKeyID, "sts"))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var minted struct {
+		AccessKeyID string `xml:"AccessKeyId"`
+	}
+	decoder := xml.NewDecoder(bytes.NewReader(w.Body.Bytes()))
+	for {
+		tok, err := decoder.Token()
+		require.NoError(t, err, "no Credentials in %s", w.Body.String())
+		start, ok := tok.(xml.StartElement)
+		if ok && start.Name.Local == "Credentials" {
+			require.NoError(t, decoder.DecodeElement(&minted, &start))
+			break
+		}
+	}
+	require.NotEmpty(t, minted.AccessKeyID, w.Body.String())
+	return minted.AccessKeyID
+}
+
+// TestSimulateCustomPolicy_ResolvesUsernameFromCallerArn is the reachable-today half of
+// #745: SimulateCustomPolicy runs the same evaluator, so a caller naming ${aws:username}
+// in a policy got implicitDeny here and allowed on AWS with no producer involved at all.
+//
+// The simulator is also the one place substrate derives a user name from an ARN, because
+// CallerArn is the caller's own assertion of who to simulate as — see [simulationUserName].
+func TestSimulateCustomPolicy_ResolvesUsernameFromCallerArn(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	policy := iamPolicyJSON(t, "Allow", []string{"s3:GetObject"}, "arn:aws:s3:::home/${aws:username}/*")
+
+	tests := []struct {
+		name      string
+		callerArn string
+		resource  string
+		want      string
+	}{
+		{
+			name:      "a user ARN resolves the variable",
+			callerArn: "arn:aws:iam::123456789012:user/alice",
+			resource:  "arn:aws:s3:::home/alice/report.txt",
+			want:      "allowed",
+		},
+		{
+			name:      "a path does not become part of the name",
+			callerArn: "arn:aws:iam::123456789012:user/division/engineering/alice",
+			resource:  "arn:aws:s3:::home/alice/report.txt",
+			want:      "allowed",
+		},
+		{
+			name:      "another user's object is refused",
+			callerArn: "arn:aws:iam::123456789012:user/alice",
+			resource:  "arn:aws:s3:::home/bob/report.txt",
+			want:      "implicitDeny",
+		},
+		{
+			name: "a role session has no user name, so the variable does not resolve",
+			// AWS's own table reads "(not present)" for aws:username on an assumed
+			// role, so the statement matches nothing rather than matching the session
+			// name.
+			callerArn: "arn:aws:sts::123456789012:assumed-role/deploy/alice",
+			resource:  "arn:aws:s3:::home/alice/report.txt",
+			want:      "implicitDeny",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := iamSimulate(t, srv, "SimulateCustomPolicy", map[string]any{
+				"PolicyInputList": []string{policy},
+				"ActionNames":     []string{"s3:GetObject"},
+				"ResourceArns":    []string{tt.resource},
+				"CallerArn":       tt.callerArn,
+			})
+			require.Equal(t, tt.want, resp.byAction()["s3:GetObject"].Decision)
+		})
+	}
+}

--- a/emulator/iam_simulate.go
+++ b/emulator/iam_simulate.go
@@ -632,10 +632,21 @@ func simulationDecision(decision string) string {
 // for AWS:PrincipalArn before #704, since it left the derived aws:PrincipalArn in the
 // map beside it and the evaluator would then resolve to whichever sorted first.
 // Deleting the folded-equal name is what makes the caller's entry win.
+//
+// aws:username is derived from CallerArn, and this is the one place substrate derives it
+// from an ARN. The enforcement path refuses to ([authzPrincipalContext]) because the ARN
+// it holds may have been synthesized from an access key ID; here the ARN *is* the
+// caller's own assertion of who to simulate as, so reading a user name out of it states
+// back exactly what was asked for. A CallerArn naming anything but a user contributes no
+// key, matching AWS's table, where `aws:username` reads "(not present)" for a role
+// session and for the account root (#745).
 func simulationConditionContext(params *iamSimulateRequest, callerArn string, now time.Time) map[string]string {
-	ctx := make(map[string]string, len(params.context)+4)
+	ctx := make(map[string]string, len(params.context)+5)
 	if callerArn != "" {
 		ctx["aws:PrincipalArn"] = callerArn
+		if name := simulationUserName(callerArn); name != "" {
+			ctx["aws:username"] = name
+		}
 	}
 	if params.ResourceOwner != "" {
 		ctx["aws:ResourceAccount"] = params.ResourceOwner
@@ -649,6 +660,25 @@ func simulationConditionContext(params *iamSimulateRequest, callerArn string, no
 		ctx[key] = value
 	}
 	return ctx
+}
+
+// simulationUserName returns the IAM user name a CallerArn names, or "" when it names
+// something that is not a user.
+//
+// AWS defines aws:username as "the friendly name of the current user", and a user's
+// friendly name is the last segment of its ARN rather than the whole resource part: the
+// user `arn:aws:iam::123456789012:user/division/engineering/alice` has the path
+// `/division/engineering/` and the name `alice`, and it is the name that appears in
+// `${aws:username}`.
+func simulationUserName(callerArn string) string {
+	entityType, name := parsePrincipalARN(callerArn)
+	if entityType != "user" {
+		return ""
+	}
+	if slash := strings.LastIndexByte(name, '/'); slash >= 0 {
+		return name[slash+1:]
+	}
+	return name
 }
 
 // paginateSimulationResults applies the Marker cursor and MaxItems to the flattened

--- a/emulator/server.go
+++ b/emulator/server.go
@@ -715,6 +715,11 @@ func (s *Server) handleAWSRequest(w http.ResponseWriter, r *http.Request) {
 			// GetCallerIdentity's ARN from :root and turn GetUser from a validation
 			// error into a NoSuchEntity lookup for every test server that wires a
 			// registry only to attribute accounts.
+			//
+			// UserName is deliberately left empty, so aws:username is absent rather
+			// than wrong: the ARN's last segment here is the access key ID, and a
+			// substituted ${aws:username} carrying a credential ID into a resource
+			// comparison would be a worse answer than no key at all (#745).
 			reqCtx.Principal = &Principal{
 				ARN:  buildCallerARN(reqCtx.AccountID, accessKey),
 				Type: "IAMUser",

--- a/emulator/sts_plugin.go
+++ b/emulator/sts_plugin.go
@@ -296,7 +296,7 @@ func (p *STSPlugin) checkTrustPolicy(ctx *RequestContext, role IAMRole, roleARN,
 	// narrowed to particular callers — and with the key absent, a negated operator over it
 	// was satisfied by every caller, exempting nobody and, on an Allow, admitting all
 	// (#714). See [authzPrincipalContext].
-	authzPrincipalContext(condCtx, ctx.Principal.ARN)
+	authzPrincipalContext(condCtx, ctx.Principal)
 
 	// Resource is empty because a trust policy carries no Resource element — the
 	// role it is attached to *is* the resource. resourceMatches treats an empty
@@ -368,6 +368,10 @@ func (p *STSPlugin) getSessionToken(ctx *RequestContext, req *AWSRequest) (*AWSR
 	}
 	if ctx.Principal != nil {
 		creds.PrincipalARN = ctx.Principal.ARN
+		// GetSessionToken returns credentials for the *same* IAM user, so the session
+		// carries that user's name forward and `aws:username` keeps its value across the
+		// call. assumeRole deliberately sets no UserName (#745).
+		creds.UserName = ctx.Principal.UserName
 	}
 
 	goCtx := context.Background()
@@ -423,6 +427,16 @@ type STSSessionCredentials struct {
 	Expiration      time.Time `json:"Expiration"`
 	PrincipalARN    string    `json:"PrincipalArn"`
 	AccountID       string    `json:"AccountId"`
+
+	// UserName is the IAM user name behind the session, set for GetSessionToken and
+	// empty for AssumeRole.
+	//
+	// AWS publishes `aws:username` for a GetSessionToken session — its principal is
+	// the calling IAM user, unchanged — and publishes none for an assumed role. The
+	// distinction cannot be recovered from PrincipalARN, whose GetSessionToken form is
+	// the user's own ARN and whose AssumeRole form is an assumed-role ARN, so it is
+	// recorded when the session is minted (#745).
+	UserName string `json:"UserName,omitempty"`
 }
 
 // responseMetadata is the XML response metadata included in all STS responses.

--- a/emulator/types.go
+++ b/emulator/types.go
@@ -104,6 +104,19 @@ type Principal struct {
 
 	// Type is the principal type: "User", "Role", "Service", or "AssumedRole".
 	Type string
+
+	// UserName is the IAM user name behind the request, or empty when there is
+	// none.
+	//
+	// It is what [authzPrincipalContext] publishes as `aws:username`, and it is
+	// carried here rather than parsed back out of ARN because not every ARN in
+	// that field names a user: a registry hit with no IAM entity behind it
+	// synthesizes `…:user/<access-key-id>` (see [Server.resolveCallerPrincipal]),
+	// and publishing that as a user name would put a credential ID in a policy
+	// comparison. Empty for every principal for which AWS publishes no
+	// `aws:username` — the account root, an assumed role, and a federated or
+	// service-linked caller (#745).
+	UserName string
 }
 
 // StateManager defines the interface for reading and writing emulator state.


### PR DESCRIPTION
Closes #745.

## The bug

AWS substitutes a policy variable before it compares. `arn:aws:s3:::home/${aws:username}/*`
is the shape AWS's own documentation gives for "a prefix per user". Substrate compared the
fifteen characters `${aws:username}` against the ARN in hand, which matched no ARN at all — so
a policy of exactly that shape granted nothing, including the bundled `IAMUserChangePassword`,
the one bundled policy that uses a variable.

**The issue's central claim is inverted, and this PR does not implement it as written.** #745
says the divergence is an *unresolved* variable under negated forms. There is no such
divergence: AWS applies one sentence to both elements — "If a variable that has no value … is
used as part of the `Resource` **or** `NotResource` element … will not match any resource" —
and substrate's literal comparison reached the same answer, because an ARN never contains a
`${…}`. #744 already corrected the docs on that point.

The real divergence is a variable that *would have resolved*. Positive forms are a false deny;
negated forms are a false **allow** — a `StringNotEquals` comparing a tag against
`${aws:ResourceTag/Team}` is false on AWS when the two agree and true here, which makes such a
statement inert on a `Deny` and granting on an `Allow`. That was reachable with no new producer
at all, since `SimulateCustomPolicy` copies a caller's `ContextEntries` into the context the
same evaluator reads — which is also why the substituter was independently testable, contrary
to the issue's ordering constraint.

## Where substitution runs

`Resource`, `NotResource`, and condition values under the string and ARN operators. AWS's
sentence on the rest is exhaustive — "You can't use a policy variable with other operators,
such as Numeric, Date, Boolean, Binary, IP Address, or Null operators" — so the test is the
operator family's prefix rather than a name list that would drift from `condEvaluate`'s own
switch. `Action` is not on AWS's list and keeps its plain glob.

Four rules from AWS's *Variables and tags* page decide the edges: the `Version` element gates
the feature ("variables like `${aws:username}` are treated as literal strings in the policy"
otherwise), key names are case-insensitive so resolution goes through `condResolveKey` rather
than a raw map index, `${key, 'default'}` honours its default, and only the single-valued
context is consulted per "You can't use a multivalued condition key as a variable".

## The `${*}` hazard, resolved rather than shipped

`${*}`, `${?}` and `${$}` are AWS's escapes for characters the glob reads as pattern.
Substituting them into a plain string and handing it to `globMatch` would turn an escape for a
literal asterisk into a wildcard — widening a statement, the one direction a deliberate escape
must never take. A resolved value is a `policyPattern` carrying a per-byte mask of which
characters are pattern and which are text, so an escape stays literal and **a `*` inside a
resolved value is literal too**: a tag value is data the request carried, not pattern the policy
author wrote. AWS documents no rule for that second case; it is substrate's reading, stated in
the docs, and it is the reading that cannot widen a statement on behalf of whoever set the tag.

`globMatchRec` is replaced by an iterative `globMatchMask` that consults the mask, so there is
one matcher rather than two that could disagree. `globMatch` is now a wrapper passing a nil
mask, which is every `Action` and every `Resource` naming no variable — the common path
allocates nothing for the distinction.

## The producer

`aws:username`, **recorded rather than derived**. `Principal` gained a `UserName` carried from
the credential lookup, which had the IAM user's name in hand and spent it into an ARN. Deriving
it back out of that ARN would be wrong twice: a registry hit with no IAM entity behind it
synthesizes `…:user/<access-key-id>`, so the last segment is a credential ID, and an assumed
role's is a session name where AWS publishes no `aws:username` at all.

Presence is keyed off the recorded name and **not** off `Principal.Type`, because
`resolvePrincipal` types both STS forms `AssumedRole` while AWS publishes the key for
`GetSessionToken` and not for `AssumeRole` — so `STSSessionCredentials` gained the field too. A
stack's own resource calls carry the creator's name, recorded on `CFNStackState` so a rollback's
deletes authorize as the create did. `SimulateCustomPolicy`/`SimulatePrincipalPolicy` is the one
place a name is read out of an ARN, because there `CallerArn` is the caller's own assertion of
who to simulate as.

IAM's second authorization door — `IAMPlugin.authorize`, which passes `"*"` and builds its own
small context — publishes `aws:username` as well, for the reason it was taught `aws:PrincipalArn`
in #714: an `iam:` statement scoped to `${aws:username}`, the shape of "let a user manage their
own credentials", resolved at one door and matched nothing at the other.

## What this does not fix

Substitution alone does not make `IAMUserChangePassword` grant anything. Its `Resource` now
correctly reads `arn:aws:iam::*:user/alice`, but every IAM request's resource is built as
`arn:aws:iam::<account>:*`, so there is nothing user-shaped to match. Filed as #770 and stated
in `docs/services.md` rather than left for a reader to discover. The two caller keys still
without a producer, `aws:userid` and `aws:PrincipalTag/`, are #771.

## Verification

Full gate green: `gofmt`, `go build`, `go vet`, `golangci-lint run` (0 issues), `make test`
(race on), `make coverage` — **emulator 83.4%, total 82.9%** — `make docs-reference
docs-reference-check docs-versions`, `npm --prefix docs run build` plus the `href="#…"` vs
`id="…"` diff over `dist/services.html` (empty), and `go vet -C test/e2e ./... && go test -C
test/e2e ./...`.

Two fail-before probes were run and reverted: forcing `policyVarsSupported` false failed 11
subtests, and removing the `aws:username` write plus both `UserName` assignments failed 3.

Live proof against a built binary, the same script against `main` and against this branch:

| Case | `main` | This branch |
|---|---|---|
| alice reaching `home/alice/*` | `implicitDeny` | **`allowed`** |
| alice reaching `home/bob/*` | `implicitDeny` | `implicitDeny` |
| an assumed role, which has no `aws:username` | `implicitDeny` | `implicitDeny` |
| the same policy at `Version: 2008-10-17` | `implicitDeny` | `implicitDeny` |
| `home/${*}` against `home/alice/file.txt` | `implicitDeny` | `implicitDeny` |
| `${aws:PrincipalTag/team, 'company-wide'}` | `implicitDeny` | **`allowed`** |
| `${aws:username}` under `NumericEquals` | `implicitDeny` | `implicitDeny` |

The four rows that do not move are the point: the `Version` gate, the escape, the absent
producer and the unsubstituted operator family each keep the answer substrate already gave.
