### PR TITLE
feat(iam): service-linked roles, and a producer for `iam:AWSServiceName` (#747)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Service-linked roles, and with them a producer for `iam:AWSServiceName`** (#747).
+  `CreateServiceLinkedRole`, `DeleteServiceLinkedRole` and
+  `GetServiceLinkedRoleDeletionStatus` answered `InvalidAction`/400, which made eleven of the
+  32 condition blocks in the bundled managed-policy catalog unevaluatable — the largest single
+  group in the producerless-key census, all eleven turning on a parameter of an operation that
+  did not exist. A create mints the role under the reserved
+  `/aws-service-role/<principal>/` path with a trust policy naming the linked service, so it is
+  an ordinary role to `GetRole`, `ListRoles` and the `AssumeRole` trust gate.
+
+  Making those statements *evaluate* took two producers, not one, because IAM authorizes
+  through two doors that would otherwise disagree — the same one-ARN-two-answers class as #411.
+  The key is published at the generic gate, read off the request, **and** passed by the handler
+  alongside the action. And the request resource had to become the role's own ARN: four of the
+  eleven statements scope `Resource` to `arn:aws:iam::*:role/aws-service-role/…` and two of
+  those to an exact ARN with no trailing `*`, none of which the flat `arn:aws:iam::<account>:*`
+  every IAM request previously carried can match. All three operations now name a real ARN —
+  including the status poll, whose `DeletionTaskId` embeds the service and the role, so its
+  resource resolves with no state read and therefore still resolves after the role is gone,
+  which is the normal case for the poll that finally reports `SUCCEEDED`. This resolves the
+  resource for the service-linked-role operations only; IAM's general per-operation request
+  resource is #770.
+
+  The key is published for the create and the delete and **not** for the status operation,
+  matching where the Service Authorization Reference lists it. The asymmetry is deliberate:
+  publishing a key AWS does not would let a `StringEquals` on it succeed here and fail there,
+  which is the permissive direction and the one a privilege boundary must not drift in.
+
+  Three refusals are worth naming because none is the obvious one. A duplicate name is
+  `InvalidInput`/400, not `EntityAlreadyExists` — `CreateServiceLinkedRole` publishes four
+  errors and that is not among them, so the refusal cannot be a copy of `CreateRole`'s. A role
+  that exists but is not service-linked is `NoSuchEntity`/404 on the delete, since the
+  operation publishes no `InvalidInput` and there is indeed no *service-linked* role by that
+  name; the message says which, so a caller is not left hunting a role that plainly exists.
+  And `DeleteRole` now refuses a service-linked role with `UnmodifiableEntity` at HTTP **400**
+  — not the 409 its two `DeleteConflict` arms use — without which
+  `DeleteServiceLinkedRole` would be decorative, a caller being able to delete the role
+  through the ordinary path and never submit a task.
+
+  The deletion outcome is seedable through `POST`/`DELETE /v1/iam/slr-deletion-status`, keyed
+  by role name or `"*"`. The failure AWS documents is a linked service still using the role,
+  which is unreachable in an emulator that runs no linked service, so a `FAILED` status with
+  its `Reason` and `RoleUsageList` is the only way a consumer's poll loop's failure branch is
+  testable. The seed is read at submission rather than at each poll because the deletion is
+  conditional on it — only a `SUCCEEDED` task removes the role record, which is the observable
+  difference the two outcomes turn on.
+
+  **The `AWSServiceRoleFor…` name is substrate's convention, not AWS's rule.** AWS publishes
+  no derivation from a service principal to a role name and the User Guide warns against
+  inferring even the principal, so substrate carries a table of exactly the six principals a
+  bundled statement names inside a `Resource` — `AWSServiceRoleForElastiCache`,
+  `AWSServiceRoleForAmazonSSM` and the rest, spelled as AWS spells them — and derives the
+  name for everything else by stripping `.amazonaws.com` and title-casing each segment. The
+  table is deliberately not padded out with the other well-known names: a guessed row would
+  be indistinguishable from a cited one, whereas a derived name is documented as substrate's
+  own. It will differ from AWS where the real name is not mechanical, `spot.amazonaws.com`
+  being `AWSServiceRoleForEC2Spot` on AWS. `CustomSuffix` is joined with `_`, which is
+  observed behaviour — AWS says only that it "is combined with the service-provided prefix".
+
 - **An AMI reports its architecture, platform and root device** (#750). `DescribeImages`
   rendered six members — ID, name, description, state, owner and creation date — and nothing
   about the image itself, so a caller that branched on architecture to pick an instance type,

--- a/docs/services.md
+++ b/docs/services.md
@@ -1135,8 +1135,11 @@ by their own plugins, so a stack's cost shows up under S3, EC2 and so on.
 | CreateRole | Supports trust policy document |
 | GetRole | Reports `AssumeRolePolicyDocument`, re-marshalled from the stored document rather than returned verbatim, so an equivalent form can come back (a `{"AWS":"1234"}` principal reads back as `"1234"`) |
 | UpdateAssumeRolePolicy | Replaces the trust policy in place; takes effect on the next `AssumeRole` and does not revoke existing sessions. `PolicyDocument` is required |
-| DeleteRole | Refuses with `DeleteConflict`/409 while a policy is attached **or** an instance profile holds the role; the message names the profiles |
+| DeleteRole | Refuses with `DeleteConflict`/409 while a policy is attached **or** an instance profile holds the role; the message names the profiles. Refuses a service-linked role with `UnmodifiableEntity`/400 — note 400, not the 409 the conflicts use |
 | ListRoles | |
+| CreateServiceLinkedRole | Mints the role under `/aws-service-role/<principal>/` with a trust policy naming the linked service. A duplicate name is `InvalidInput`/400, not `EntityAlreadyExists` (see below) |
+| DeleteServiceLinkedRole | Returns a `DeletionTaskId`; an incomplete task for the same role is returned again rather than duplicated. A role that exists but is not service-linked is `NoSuchEntity`/404 |
+| GetServiceLinkedRoleDeletionStatus | Reports `SUCCEEDED` unless [seeded](#seeding-a-service-linked-role-deletion-outcome); a `FAILED` task also reports the `Reason` and `RoleUsageList` |
 | CreateGroup | |
 | GetGroup | Reports the group's actual members |
 | DeleteGroup | Refuses with `DeleteConflict`/409 while the group has members or policies |
@@ -1444,24 +1447,125 @@ What has **no** producer, and therefore never matches on the enforcement path:
   would make it stable per-name rather than per-entity; `aws:PrincipalTag/` needs the
   principal's tags read where the credential is resolved, which is the cheaper of the two
   because `TagUser`/`TagRole` already record them.
-- Six of the seven keys the bundled AWS managed policies condition on, each for its own
+- Five of the seven keys the bundled AWS managed policies condition on, each for its own
   reason rather than as one omission:
 
   | Key | Blocks | Why it has no producer |
   |---|---|---|
-  | `iam:AWSServiceName` | 11 | The most feasible of the six — it is a direct read of `CreateServiceLinkedRole`'s own parameter. Blocked only on that operation not existing |
   | `iam:PassedToService` | 8 | No `PassRole` operation exists anywhere in substrate, and the value comes from the *calling* API's service principal, which substrate has no analogue for |
   | `codestar-notifications:NotificationsForResource` | 6 | No CodeStar Notifications plugin |
   | `aws:CalledViaLast` | 2 | `RequestContext` has no call-chain notion, and there is no service-to-service internal path to record one from |
   | `devops-guru:ServiceNames` | 2 | No DevOps Guru plugin |
   | `elasticloadbalancing:CreateAction` | 1 | The ELB plugin has no tagging at all — no `AddTags`, and a load balancer's tags are never read or written — so the action the statement conditions does not exist |
 
-  The seventh, `ec2:ResourceTag/<key>`, now has one; see [both
-  prefixes](#ec2-reports-a-resource-s-tags-under-both-prefixes).
+  Two now have one: `ec2:ResourceTag/<key>` (see [both
+  prefixes](#ec2-reports-a-resource-s-tags-under-both-prefixes)) and `iam:AWSServiceName`
+  (see [service-linked roles](#service-linked-roles-and-iam-awsservicename)). Between them
+  they were the largest group in the table — 11 of the 32 condition blocks turned on
+  `iam:AWSServiceName` alone — and each needed the same two things rather than one: a
+  producer for the key, *and* a request resource specific enough for the statement's
+  `Resource` to match.
 
   Each remaining absence is a false deny in the safe direction: all 32 condition blocks in
   the bundled catalog sit on an `Allow`, so such a statement grants nothing rather than a
   `Deny` going inert.
+
+### Service-linked roles and `iam:AWSServiceName`
+
+The three service-linked-role operations exist principally as the producer for
+`iam:AWSServiceName` ([#747](https://github.com/scttfrdmn/substrate/issues/747)). Eleven of
+the 32 condition blocks in the bundled managed-policy catalog turn on that key — the largest
+single group — and before this release every one of them was unevaluatable, because the
+operation carrying the parameter answered `InvalidAction`/400.
+
+Making them evaluate needed two things, not one. The key is published at both authorization
+doors: the generic gate reads it off the request, and the handler passes it alongside the
+action, because a request that passes two gates must get one answer from both
+([#411](https://github.com/scttfrdmn/substrate/issues/411)). And the request **resource** had
+to become the role's own ARN — four of those statements scope `Resource` to
+`arn:aws:iam::*:role/aws-service-role/…` and two of the four to an exact ARN with no
+trailing `*`, none of which a flat `arn:aws:iam::<account>:*` can match. All three operations
+get a real ARN, including the status poll, whose `DeletionTaskId` embeds the service and the
+role so the resource resolves without reading state — which is what makes it still resolve
+after the role is gone, the normal case for the poll that finally reports `SUCCEEDED`.
+
+The key is published for `CreateServiceLinkedRole` and `DeleteServiceLinkedRole` and **not**
+for `GetServiceLinkedRoleDeletionStatus`, matching where the Service Authorization Reference
+lists it. Publishing a key AWS does not is the permissive direction: it would let a
+`StringEquals` succeed here and fail on AWS.
+
+**The role name is substrate's convention, not AWS's rule.** AWS publishes no derivation from
+a service principal to a role name, and the IAM User Guide warns against inferring even the
+principal — *"Do not try to guess the service principal, because it is case sensitive and the
+format can vary across AWS services."* So substrate carries a table of exactly the six
+principals a bundled statement names inside a `Resource`:
+
+| Service principal | Role name |
+|---|---|
+| `lambda.amazonaws.com` | `AWSServiceRoleForLambda` |
+| `elasticache.amazonaws.com` | `AWSServiceRoleForElastiCache` |
+| `events.amazonaws.com` | `AWSServiceRoleForCloudWatchEvents` |
+| `ssm.amazonaws.com` | `AWSServiceRoleForAmazonSSM` |
+| `cognito-idp.amazonaws.com` | `AWSServiceRoleForAmazonCognitoIdp` |
+| `email.cognito-idp.amazonaws.com` | `AWSServiceRoleForAmazonCognitoIdpEmail` |
+
+Every other principal gets a derived name: the `.amazonaws.com` suffix stripped and each
+remaining `.`/`-`/`_` segment title-cased, so `someservice.amazonaws.com` yields
+`AWSServiceRoleForSomeservice`. That will differ from AWS for a service whose real name is
+not mechanical — `spot.amazonaws.com` is `AWSServiceRoleForEC2Spot` on AWS, which no
+transformation of "spot" produces. The table is deliberately **not** padded out with the
+other well-known names: a guessed row would be indistinguishable from a cited one, whereas a
+derived name is documented as substrate's own. One bundled statement scopes a `Resource`
+around an untabled principal — AWSBatchFullAccess pairs `batch.amazonaws.com` with
+`arn:aws:iam::*:role/*Batch*` — and the derived `AWSServiceRoleForBatch` satisfies it,
+because that pattern is a contains-glob rather than a path.
+
+`CustomSuffix` is joined to the name with `_`, which is observed behaviour: AWS says only
+that the suffix "is combined with the service-provided prefix to form the complete role
+name". A combined name over 64 characters is refused rather than stored, so
+`GetRole` and `DeleteServiceLinkedRole` can always name what the create made.
+
+**A duplicate name is `InvalidInput`/400.** `CreateServiceLinkedRole` publishes exactly four
+errors — `InvalidInput` 400, `LimitExceeded` 409, `NoSuchEntity` 404, `ServiceFailure` 500 —
+and notably not `EntityAlreadyExists`, which is what `CreateRole` answers. So the refusal
+cannot be a copy of `CreateRole`'s; `InvalidInput` is substrate's reading of AWS's "the
+request fails with a duplicate role name error" against the four codes the operation actually
+publishes.
+
+`DeleteRole` refuses a service-linked role with `UnmodifiableEntity` at HTTP **400**. Without
+that guard `DeleteServiceLinkedRole` would be decorative — a caller could delete the role
+through the ordinary path and never submit a task.
+
+#### Seeding a service-linked-role deletion outcome
+
+Deletion is asynchronous on AWS, and the failure it documents — *"If you submit a deletion
+request for a service-linked role whose linked service is still accessing a resource, then
+the deletion task fails"* — is unreachable in an emulator that runs no linked service. So
+substrate reports `SUCCEEDED` by default and the outcome is seedable, which is the only way a
+consumer's poll loop's `FAILED` branch is testable without wall-clock time:
+
+```bash
+curl -X POST http://localhost:4566/v1/iam/slr-deletion-status \
+  -d '{"roleName":"AWSServiceRoleForLambda","status":"FAILED",
+       "reason":"Cannot delete the role because it is still in use.",
+       "roleUsageList":[{"Region":"us-east-1",
+         "Resources":["arn:aws:lambda:us-east-1:123456789012:function:live"]}]}'
+
+curl -X DELETE 'http://localhost:4566/v1/iam/slr-deletion-status?roleName=AWSServiceRoleForLambda'
+```
+
+`roleName` defaults to `"*"`, which applies to every role; an exact name wins over the
+wildcard. `status` must be one of AWS's four documented values, so a typo is refused where it
+is written rather than reported later as a status no SDK models. Omitting `roleName` on the
+`DELETE` clears every seed.
+
+The seed is read at **submission**, not at each poll, because the deletion is conditional on
+it: only a `SUCCEEDED` task removes the role record. That is the observable difference the
+two outcomes turn on — a caller who polls to `FAILED` and then reads the role must still find
+it. A task held at `IN_PROGRESS` or `NOT_STARTED` also makes a resubmission return the same
+`DeletionTaskId`, per AWS's "if the deletion task is not yet complete, the `DeletionTaskId` of
+the existing task is returned". A `FAILED` task does not block a resubmission, or a caller who
+removed the blocking resources could never retry.
 
 ### Policy variables resolve from the request context
 

--- a/emulator/authz.go
+++ b/emulator/authz.go
@@ -202,6 +202,13 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 		requestMulti["aws:TagKeys"] = keys
 	}
 
+	// Service-specific keys that describe the request rather than any resource it names
+	// — currently iam:AWSServiceName (#747). Request-level for the same reason
+	// requestTags is: the value is one reading of one request, so it is read once and
+	// merged under every resource below.
+	requestKeys := make(map[string]string, 1)
+	iamAuthzRequestContext(requestKeys, req)
+
 	// The prefixes this service reports a resource's tags under, resolved once: it is a
 	// property of the service, not of any one resource.
 	tagPrefixes := authzResourceTagPrefixes(req.Service)
@@ -212,8 +219,11 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 	// "every resource that is required" for the action (#660, #662).
 	for _, res := range resources {
 		condCtx := make(map[string]string,
-			len(requestTags)+len(res.Tags)*len(tagPrefixes)+len(res.Context))
+			len(requestTags)+len(requestKeys)+len(res.Tags)*len(tagPrefixes)+len(res.Context))
 		for k, v := range requestTags {
+			condCtx[k] = v
+		}
+		for k, v := range requestKeys {
 			condCtx[k] = v
 		}
 		// The tags travel with the ARN they belong to: one merged map across several
@@ -779,8 +789,14 @@ type authzResource struct {
 //     [ec2AuthzIDParams] — was decided against the first ID alone, leaving the
 //     rest of the batch unauthorized (#744).
 //
+// The IAM arm is a different shape of exception: it still names one resource, but the
+// one [buildResourceARN] answers for IAM is a flat `arn:aws:iam::<acct>:*` that a
+// statement scoped to a role path cannot match. [iamAuthzResources] answers the three
+// service-linked-role operations properly, and only those — the general per-operation
+// IAM resource is #770.
+//
 // Each exception is gated on len(multi) > 0, which is what keeps every other
-// operation of those two services on the single-resource path below.
+// operation of those services on the single-resource path below.
 //
 // The list is never empty. An empty list would skip the decision loop entirely
 // and allow the request, which is the one direction a privilege boundary must
@@ -799,6 +815,11 @@ func (a *AuthController) buildResourceARNs(reqCtx *RequestContext, req *AWSReque
 			return multi
 		}
 		if multi := ec2AuthzNamedResources(a.state, reqCtx, req); len(multi) > 0 {
+			return multi
+		}
+	}
+	if req.Service == "iam" {
+		if multi := iamAuthzResources(a.state, reqCtx, req); len(multi) > 0 {
 			return multi
 		}
 	}
@@ -824,6 +845,12 @@ func (a *AuthController) buildResourceARN(reqCtx *RequestContext, req *AWSReques
 	case "s3":
 		return buildS3ARN(req)
 	case "iam":
+		// Every IAM operation but the three service-linked-role ones, which
+		// [iamAuthzResources] answers before this is reached. This is a flat `*` in the
+		// resource position, so a statement scoped to a user, a role or a path matches
+		// nothing here — which is why `${aws:username}` in IAMUserChangePassword's
+		// Resource still grants nothing even with #745's substitution in place. Deriving
+		// a per-operation resource for the rest of IAM is #770.
 		return "arn:aws:iam::" + acct + ":*"
 	case "ec2":
 		// No EC2 request that names a resource substrate can resolve reaches here. A

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -83,6 +83,51 @@ func IAMAuthorizeForTest(p *IAMPlugin, ctx *RequestContext, action, resource str
 	return p.authorize(context.Background(), ctx, action, resource)
 }
 
+// IAMAuthorizeWithForTest exercises IAMPlugin.authorizeWith, the door that publishes a
+// request-specific condition key alongside the caller's own (#747).
+func IAMAuthorizeWithForTest(p *IAMPlugin, ctx *RequestContext, action, resource string,
+	extra map[string]string) error {
+	return p.authorizeWith(context.Background(), ctx, action, resource, extra)
+}
+
+// IAMSLRRoleNameForTest wraps iamSLRRoleName for external tests.
+func IAMSLRRoleNameForTest(serviceName, customSuffix string) string {
+	return iamSLRRoleName(serviceName, customSuffix)
+}
+
+// IAMSLRDerivedRoleNameForTest wraps iamSLRDerivedRoleName for external tests, which is
+// what asserts that substrate's convention for an untabled principal stays stable.
+func IAMSLRDerivedRoleNameForTest(serviceName string) string {
+	return iamSLRDerivedRoleName(serviceName)
+}
+
+// IAMSLRPathForTest wraps iamSLRPath for external tests.
+func IAMSLRPathForTest(serviceName string) string { return iamSLRPath(serviceName) }
+
+// IAMSLRServiceFromRoleNameForTest wraps iamSLRServiceFromRoleName for external tests.
+func IAMSLRServiceFromRoleNameForTest(roleName string) string {
+	return iamSLRServiceFromRoleName(roleName)
+}
+
+// IAMSLRRoleFromDeletionTaskIDForTest wraps iamSLRRoleFromDeletionTaskID for external
+// tests.
+func IAMSLRRoleFromDeletionTaskIDForTest(taskID string) (string, string, bool) {
+	return iamSLRRoleFromDeletionTaskID(taskID)
+}
+
+// IAMAuthzRequestContextForTest wraps iamAuthzRequestContext for external tests, which
+// is what pins which operations publish iam:AWSServiceName.
+func IAMAuthzRequestContextForTest(req *AWSRequest) map[string]string {
+	ctx := make(map[string]string, 1)
+	iamAuthzRequestContext(ctx, req)
+	return ctx
+}
+
+// IAMSLRResourceARNForTest wraps iamAuthzSLRResourceARN for external tests.
+func IAMSLRResourceARNForTest(state StateManager, ctx *RequestContext, req *AWSRequest) string {
+	return iamAuthzSLRResourceARN(state, ctx, req)
+}
+
 // RecordEventAtTimeForTest records a pre-built Event into store, allowing
 // tests to inject events with arbitrary Timestamp values for time-series
 // coverage of forecast helpers.

--- a/emulator/iam_authz.go
+++ b/emulator/iam_authz.go
@@ -1,0 +1,206 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+)
+
+// iamAuthzRequestContext publishes the condition keys an IAM request carries about
+// itself rather than about any resource it names.
+//
+// Today that is one key, `iam:AWSServiceName`. Eleven of the condition blocks in
+// substrate's bundled managed policies condition on it — the single largest group in the
+// bundle, and all eleven on `iam:CreateServiceLinkedRole`. Before #747 none of them could
+// be satisfied, because the operation that carries the parameter did not exist and
+// nothing published the value.
+//
+// It is published for CreateServiceLinkedRole and DeleteServiceLinkedRole, the two
+// actions the Service Authorization Reference lists it on, and **not** for
+// GetServiceLinkedRoleDeletionStatus. That asymmetry is deliberate: publishing a key AWS
+// does not would let a `StringEquals` on it succeed here and fail there, which is the
+// permissive direction and the one a privilege boundary must not drift in. A key that is
+// absent is what [condKeyPresent] reads as absent, so a positive condition fails and a
+// negated one holds — exactly AWS's answer for a key the request does not carry.
+//
+// It is a *request* key, not a resource key: it describes what the caller asked for, so
+// it is read once per request and merged under every resource, the same treatment
+// [addRequestTags] gets and for the same reason.
+func iamAuthzRequestContext(condCtx map[string]string, req *AWSRequest) {
+	if req.Service != "iam" {
+		return
+	}
+	if name := iamAWSServiceNameParam(req); name != "" {
+		condCtx[iamSLRAWSServiceNameCondKey] = name
+	}
+}
+
+// iamAWSServiceNameParam returns the service principal the request is about, or "".
+func iamAWSServiceNameParam(req *AWSRequest) string {
+	switch req.Operation {
+	case "CreateServiceLinkedRole":
+		return iamAuthzParam(req, "AWSServiceName")
+	case "DeleteServiceLinkedRole":
+		// The reference lists the key on this operation too, but the operation names the
+		// role rather than the service — RoleName is the only thing on the wire. The
+		// service is recovered from the name substrate minted ([iamSLRServiceFromRoleName]),
+		// which resolves for every principal the table covers and yields "" for the rest,
+		// leaving the key absent rather than guessed.
+		return iamSLRServiceFromRoleName(iamAuthzParam(req, "RoleName"))
+	default:
+		return ""
+	}
+}
+
+// iamAuthzParam reads one named request parameter, from whichever of the two forms an
+// IAM request arrives in.
+//
+// Params is the query form a real SDK or the CLI sends, and it is what `server.go`
+// marshals into Body — so for a live request the two hold the same data and Params is
+// authoritative. A caller that speaks the JSON protocol directly, which substrate accepts
+// and its own tests use, populates only Body. Reading both is what keeps an authorization
+// decision from depending on which of the two a caller chose; [addRequestTags]' iam arm
+// reads the body for the same reason, from the other side.
+func iamAuthzParam(req *AWSRequest, name string) string {
+	if v := req.Params[name]; v != "" {
+		return v
+	}
+	if len(req.Body) == 0 {
+		return ""
+	}
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(req.Body, &body); err != nil {
+		return ""
+	}
+	var v string
+	if err := json.Unmarshal(body[name], &v); err != nil {
+		return ""
+	}
+	return v
+}
+
+// iamAuthzResources returns the resources an IAM request names, when substrate can
+// resolve them, or nil to leave the request on the single-resource path.
+//
+// [AuthController.buildResourceARN]'s iam arm answers `arn:aws:iam::<acct>:*` for every
+// IAM operation, which is a literal `*` in the resource position that no pattern with a
+// path in it can match. Seven of the bundled service-linked-role statements scope their
+// Resource to `arn:aws:iam::*:role/aws-service-role/…`, two of them to an exact ARN
+// with no trailing wildcard, so all seven denied a request they are written to allow.
+//
+// Those statements are also the citation for resolving all three operations rather than
+// only the create. Two of them — the SSM policy's and the Cognito policy's — name
+// `iam:DeleteServiceLinkedRole` and `iam:GetServiceLinkedRoleDeletionStatus` together and
+// scope Resource to a service-linked-role ARN, so a status poll's request resource has to
+// be that ARN for AWS's own managed policy to grant what it plainly intends. That is
+// provenance from a policy shipping inside substrate rather than from the API model — the
+// Service Authorization Reference's resource-type column for these actions could not be
+// read, because the page renders client-side.
+//
+// This resolves the resource **only for the service-linked-role operations**. Deriving a
+// per-operation resource for the rest of IAM is its own piece of work (#770) and
+// deliberately not attempted here: a half-done version would move the wrong-answer
+// boundary rather than remove it.
+func iamAuthzResources(state StateManager, reqCtx *RequestContext, req *AWSRequest) []authzResource {
+	arn := iamAuthzSLRResourceARN(state, reqCtx, req)
+	if arn == "" {
+		return nil
+	}
+	return []authzResource{{ARN: arn}}
+}
+
+// iamAuthzSLRResourceARN returns the service-linked-role ARN an SLR operation is about,
+// or "" when the request is not one or does not name enough to resolve it.
+func iamAuthzSLRResourceARN(state StateManager, reqCtx *RequestContext, req *AWSRequest) string {
+	switch req.Operation {
+	case "CreateServiceLinkedRole":
+		service := iamAuthzParam(req, "AWSServiceName")
+		if service == "" {
+			return ""
+		}
+		name := iamSLRRoleName(service, iamAuthzParam(req, "CustomSuffix"))
+		return iamRoleARN(reqCtx.AccountID, iamSLRPath(service), name)
+
+	case "DeleteServiceLinkedRole":
+		name := iamAuthzParam(req, "RoleName")
+		if name == "" {
+			return ""
+		}
+		// The role's own record holds the reserved path, and the path holds the
+		// service. Reading it is what makes the ARN the same string CreateServiceLinkedRole
+		// built — deriving the service from the *name* would have to invert
+		// [iamSLRRoleName], which is not invertible for a name outside the table.
+		path := iamAuthzRolePath(state, reqCtx.AccountID, name)
+		if !iamIsSLRPath(path) {
+			// Not a service-linked role, or no such role. Either way this is not the
+			// resource shape those statements are written about, so leave the request
+			// on the general path rather than mint an ARN that only looks specific.
+			return ""
+		}
+		return iamRoleARN(reqCtx.AccountID, path, name)
+
+	case "GetServiceLinkedRoleDeletionStatus":
+		// AWS's documented task-ID format embeds both the service principal and the
+		// role name, so this one resolves with no state read at all — which also means
+		// it resolves for a task whose role has already been deleted, the normal case
+		// for a status poll that reports SUCCEEDED.
+		service, name, ok := iamSLRRoleFromDeletionTaskID(iamAuthzParam(req, "DeletionTaskId"))
+		if !ok {
+			return ""
+		}
+		return iamRoleARN(reqCtx.AccountID, iamSLRPath(service), name)
+
+	default:
+		return ""
+	}
+}
+
+// iamAuthzRolePath returns the stored path of a role, or "" when there is no such role.
+//
+// It reads through the raw [StateManager] rather than through IAMPlugin, for the reason
+// the other authz resolvers do: [AuthController] holds no plugin, and a decision must
+// not depend on one being registered.
+func iamAuthzRolePath(state StateManager, accountID, roleName string) string {
+	if state == nil {
+		return ""
+	}
+	raw, err := state.Get(context.Background(), iamNamespace, iamRoleKey(accountID, roleName))
+	if err != nil || raw == nil {
+		return ""
+	}
+	var role IAMRole
+	if err := json.Unmarshal(raw, &role); err != nil {
+		return ""
+	}
+	return role.Path
+}
+
+// iamSLRServiceFromRoleName recovers a service principal from a service-linked role's
+// name, using the same table [iamSLRRoleName] mints from.
+//
+// It exists for the second authorization door, which sees a DeleteServiceLinkedRole
+// request and has to publish `iam:AWSServiceName` for it without the state read
+// [iamAuthzRolePath] performs. A name minted with a custom suffix still resolves,
+// because the suffix is appended after the table's value; a name outside the table does
+// not, and the key is then absent rather than guessed — which [condKeyPresent] reads as
+// absent, so a positive condition fails and a negated one holds, exactly as it would on
+// AWS for a key the request does not carry.
+func iamSLRServiceFromRoleName(roleName string) string {
+	if !strings.HasPrefix(roleName, iamSLRNamePrefix) {
+		return ""
+	}
+	best, bestLen := "", 0
+	for service, name := range iamSLRRoleNames {
+		if roleName != name && !strings.HasPrefix(roleName, name+"_") {
+			continue
+		}
+		// Longest match wins. No two table values can both match one name today — the
+		// "_" separator prevents it — but map iteration order is unspecified, so
+		// picking by length rather than by whichever row came first is what keeps a
+		// future table addition from making the answer depend on the runtime.
+		if len(name) > bestLen {
+			best, bestLen = service, len(name)
+		}
+	}
+	return best
+}

--- a/emulator/iam_control.go
+++ b/emulator/iam_control.go
@@ -1,0 +1,109 @@
+package emulator
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// iamCtrlNamespace is the state namespace for IAM control-plane seed data.
+//
+// It is separate from iamNamespace for the reason every other …-ctrl namespace is: a
+// seed is test scaffolding, not an IAM record, and putting it in the same namespace
+// would make it appear in a prefix scan that lists entities.
+const iamCtrlNamespace = "iam-ctrl"
+
+// iamCtrlSLRDeletionStatusKey returns the state key for a seeded service-linked-role
+// deletion outcome, keyed by role name or by the "*" wildcard.
+func iamCtrlSLRDeletionStatusKey(roleName string) string {
+	return "slr_deletion_status:" + roleName
+}
+
+// handleIAMSeedSLRDeletionStatus handles POST /v1/iam/slr-deletion-status.
+//
+// It overrides the outcome DeleteServiceLinkedRole records for a service-linked role
+// (or the wildcard "*"), which is what makes the failure AWS documents reachable: "If
+// you submit a deletion request for a service-linked role whose linked service is still
+// accessing a resource, then the deletion task fails." Substrate runs no linked service,
+// so nothing here can ever be still using the role — the outcome has to be seeded or the
+// FAILED branch of a consumer's poll loop is untestable.
+//
+// Body: {"roleName": "...", "status": "FAILED", "reason": "...",
+// "roleUsageList": [{"Region": "...", "Resources": ["..."]}]}
+// "roleName" defaults to "*" when omitted. "status" must be one of AWS's four documented
+// values, so a typo is refused here rather than surfacing later as a status no SDK models.
+//
+// A seeded FAILED or IN_PROGRESS status also leaves the role in place, because that is
+// the observable difference between the outcomes — a caller who polls to FAILED and then
+// calls GetRole must still find the role there.
+func (s *Server) handleIAMSeedSLRDeletionStatus(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		RoleName      string            `json:"roleName"`
+		Status        string            `json:"status"`
+		Reason        string            `json:"reason"`
+		RoleUsageList []IAMSLRRoleUsage `json:"roleUsageList"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+	if body.Status == "" {
+		http.Error(w, `{"error":"status is required"}`, http.StatusBadRequest)
+		return
+	}
+	if !iamSLRDeletionStatuses[body.Status] {
+		http.Error(w, fmt.Sprintf(`{"error":"status must be one of %s, %s, %s, %s"}`,
+			iamSLRDeletionSucceeded, iamSLRDeletionInProgress,
+			iamSLRDeletionFailed, iamSLRDeletionNotStarted), http.StatusBadRequest)
+		return
+	}
+	name := body.RoleName
+	if name == "" {
+		name = "*"
+	}
+	seed, err := json.Marshal(IAMSLRDeletionTask{
+		RoleName:      body.RoleName,
+		Status:        body.Status,
+		Reason:        body.Reason,
+		RoleUsageList: body.RoleUsageList,
+	})
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	if err := s.state.Put(r.Context(), iamCtrlNamespace,
+		iamCtrlSLRDeletionStatusKey(name), seed); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	writeJSONDebug(w, s.logger, map[string]interface{}{"ok": true, "roleName": name, "status": body.Status})
+}
+
+// handleIAMClearSLRDeletionStatus handles DELETE /v1/iam/slr-deletion-status.
+//
+// With ?roleName=... it removes the seed for that role. Without a query parameter it
+// removes every seeded deletion outcome.
+func (s *Server) handleIAMClearSLRDeletionStatus(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get("roleName")
+	if name != "" {
+		if err := s.state.Delete(r.Context(), iamCtrlNamespace,
+			iamCtrlSLRDeletionStatusKey(name)); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+		writeJSONDebug(w, s.logger, map[string]interface{}{"ok": true})
+		return
+	}
+	keys, err := s.state.List(r.Context(), iamCtrlNamespace, "slr_deletion_status:")
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	for _, k := range keys {
+		if err := s.state.Delete(r.Context(), iamCtrlNamespace, k); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+	}
+	writeJSONDebug(w, s.logger, map[string]interface{}{"ok": true})
+}

--- a/emulator/iam_plugin.go
+++ b/emulator/iam_plugin.go
@@ -73,6 +73,13 @@ func (p *IAMPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 	case "ListRoles":
 		return p.listRoles(ctx, req)
 
+	case "CreateServiceLinkedRole":
+		return p.createServiceLinkedRole(ctx, req)
+	case "DeleteServiceLinkedRole":
+		return p.deleteServiceLinkedRole(ctx, req)
+	case "GetServiceLinkedRoleDeletionStatus":
+		return p.getServiceLinkedRoleDeletionStatus(ctx, req)
+
 	case "CreateGroup":
 		return p.createGroup(ctx, req)
 	case "GetGroup":
@@ -609,6 +616,21 @@ func (p *IAMPlugin) deleteRole(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("The role with name %s cannot be found.", params.RoleName),
 			http.StatusNotFound), nil
+	}
+
+	// A service-linked role is deleted through DeleteServiceLinkedRole, not here. AWS
+	// publishes UnmodifiableEntity on this operation for exactly that — "The request was
+	// rejected because service-linked roles are protected AWS resources. Only the service
+	// that depends on the service-linked role can modify or delete the role on your
+	// behalf" — at HTTP 400, not the 409 the two DeleteConflict arms below use. Without
+	// this guard DeleteServiceLinkedRole would be decorative: a caller could delete the
+	// role through the ordinary path and never submit a deletion task (#747).
+	if iamIsSLRPath(role.Path) {
+		return iamErrorResponse("UnmodifiableEntity",
+			"Service linked roles are protected AWS resources. "+
+				"Only the service that depends on the service-linked role can modify or delete "+
+				"the role on your behalf.",
+			http.StatusBadRequest), nil
 	}
 
 	arns, err := p.loadPolicyList(goCtx, iamAttachedPoliciesKey(ctx.AccountID, "role", params.RoleName))
@@ -1522,6 +1544,25 @@ const iamAccessDeniedCode = "AccessDenied"
 // authorize checks whether the caller (reqCtx.Principal) is allowed to perform
 // action on resource. A nil Principal always passes (bootstrap/test mode).
 func (p *IAMPlugin) authorize(goCtx context.Context, reqCtx *RequestContext, action, resource string) error {
+	return p.authorizeWith(goCtx, reqCtx, action, resource, nil)
+}
+
+// authorizeWith is [IAMPlugin.authorize] with extra condition keys published for this
+// one request.
+//
+// It exists because this door and [AuthController.CheckAccess] must agree. The generic
+// gate publishes `iam:AWSServiceName` for a service-linked-role request
+// ([iamAuthzRequestContext]); if this door did not, a policy whose StringLike on that
+// key is the whole point of the statement would be allowed there and refused here, and
+// the caller would see a 403 from a request the gate had already permitted — the
+// one-ARN-two-answers class of #411 and #714, arrived at through the condition context
+// rather than through the resource (#747).
+//
+// extra may be nil, which is the case for all 37 existing call sites: an IAM operation
+// with no service-specific request key of its own publishes only the caller's keys, as
+// before.
+func (p *IAMPlugin) authorizeWith(goCtx context.Context, reqCtx *RequestContext,
+	action, resource string, extra map[string]string) error {
 	if reqCtx.Principal == nil {
 		return nil
 	}
@@ -1628,8 +1669,14 @@ func (p *IAMPlugin) authorize(goCtx context.Context, reqCtx *RequestContext, act
 	// leaving aws:username out is what made `${aws:username}` in an iam: statement — the
 	// shape of "let a user manage their own credentials" — match nothing at this door
 	// while resolving at the other (#745).
-	condCtx := make(map[string]string, 2)
+	//
+	// A request-specific key reaches here through extra, which is how the two doors are
+	// kept in step for the keys the gate does publish (#747).
+	condCtx := make(map[string]string, 2+len(extra))
 	authzPrincipalContext(condCtx, reqCtx.Principal)
+	for k, v := range extra {
+		condCtx[k] = v
+	}
 
 	result := Evaluate(docs, EvaluationRequest{
 		Principal: reqCtx.Principal.ARN,

--- a/emulator/iam_service_linked_roles.go
+++ b/emulator/iam_service_linked_roles.go
@@ -1,0 +1,261 @@
+package emulator
+
+import (
+	cryptorand "crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// iamSLRPathPrefix is the reserved path a service-linked role lives under.
+//
+// AWS's own policy templates for service-linked roles name it in every Resource
+// they scope — "arn:aws:iam::*:role/aws-service-role/{{SERVICE-NAME}}.amazonaws.com/…"
+// — and five of substrate's bundled managed policies do the same, which is what
+// makes the path load-bearing rather than cosmetic: a role minted anywhere else
+// matches none of those statements.
+const iamSLRPathPrefix = "/aws-service-role/"
+
+// iamSLRNamePrefix is the prefix AWS puts on every service-linked role's name.
+//
+// AWS calls it "the service-provided prefix" and never publishes the mapping from a
+// service principal to the rest of the name; see [iamSLRRoleName].
+const iamSLRNamePrefix = "AWSServiceRoleFor"
+
+// iamSLRServiceSuffix is the domain every service principal ends with.
+const iamSLRServiceSuffix = ".amazonaws.com"
+
+// iamSLRAWSServiceNameCondKey is the condition key AWS publishes for
+// CreateServiceLinkedRole's own parameter.
+//
+// Eleven of the 32 condition blocks in substrate's bundled managed policies condition
+// on it, which made it the largest group of statements that could not be evaluated at
+// all before #747 — the operation carrying the parameter did not exist.
+const iamSLRAWSServiceNameCondKey = "iam:AWSServiceName"
+
+// Deletion-task statuses, which are AWS's four documented values for
+// GetServiceLinkedRoleDeletionStatus: "SUCCEEDED | IN_PROGRESS | FAILED |
+// NOT_STARTED".
+const (
+	iamSLRDeletionSucceeded  = "SUCCEEDED"
+	iamSLRDeletionInProgress = "IN_PROGRESS"
+	iamSLRDeletionFailed     = "FAILED"
+	iamSLRDeletionNotStarted = "NOT_STARTED"
+)
+
+// iamSLRDeletionStatuses is the set the seed endpoint accepts, so a typo is refused
+// where it is written rather than reported later as a status no SDK models.
+var iamSLRDeletionStatuses = map[string]bool{
+	iamSLRDeletionSucceeded:  true,
+	iamSLRDeletionInProgress: true,
+	iamSLRDeletionFailed:     true,
+	iamSLRDeletionNotStarted: true,
+}
+
+// iamSLRRoleNames maps a service principal to the role name AWS mints for it.
+//
+// Every row is read off a Resource element in substrate's own bundled AWS managed
+// policies, which spell the name AWS uses — `AWSServiceRoleForElastiCache`,
+// `AWSServiceRoleForAmazonSSM`, `AWSServiceRoleForCloudWatchEvents`. That is the only
+// source substrate can cite for the mapping: AWS publishes no rule deriving a role name
+// from a service principal, and the IAM User Guide warns against inferring the principal
+// itself — "Do not try to guess the service principal, because it is case sensitive
+// and the format can vary across AWS services."
+//
+// So the table is exactly the six principals a statement in this repository names, and
+// nothing more. It is deliberately not padded out with the other well-known names
+// (`AWSServiceRoleForRDS`, `AWSServiceRoleForEC2Spot`, …): a guessed row would sit in the
+// slot the real name needed and be indistinguishable from a cited one, which is the #561
+// failure — a plausible-looking identifier hiding the absence of a verified one.
+// [iamSLRDerivedRoleName] answers for every other principal and is documented as
+// substrate's convention, so a name it produces cannot be mistaken for AWS's.
+//
+// The six rows are exactly the principals a bundled statement names inside a
+// service-linked-role Resource, and two of those Resources are an exact ARN with no
+// trailing `*` — Lambda's and ElastiCache's — so they would match nothing without a row
+// here. That is what makes those statements evaluate rather than deny (#747).
+//
+// One bundled statement scopes Resource around a principal the table does not cover:
+// AWSBatchFullAccess pairs `batch.amazonaws.com` with `arn:aws:iam::*:role/*Batch*`. A
+// derived name satisfies it, because the pattern is a contains-glob rather than a path —
+// but that is luck, not a rule, and it is the reason [iamSLRDerivedRoleName] title-cases
+// rather than lower-casing.
+var iamSLRRoleNames = map[string]string{
+	"lambda.amazonaws.com":            "AWSServiceRoleForLambda",
+	"elasticache.amazonaws.com":       "AWSServiceRoleForElastiCache",
+	"events.amazonaws.com":            "AWSServiceRoleForCloudWatchEvents",
+	"ssm.amazonaws.com":               "AWSServiceRoleForAmazonSSM",
+	"cognito-idp.amazonaws.com":       "AWSServiceRoleForAmazonCognitoIdp",
+	"email.cognito-idp.amazonaws.com": "AWSServiceRoleForAmazonCognitoIdpEmail",
+}
+
+// iamSLRPath returns the reserved path a service's linked role lives under.
+func iamSLRPath(serviceName string) string {
+	return iamSLRPathPrefix + serviceName + "/"
+}
+
+// iamIsSLRPath reports whether path is the reserved service-linked-role path.
+func iamIsSLRPath(path string) bool {
+	return strings.HasPrefix(path, iamSLRPathPrefix)
+}
+
+// iamSLRServiceFromPath returns the service principal a reserved path names, or "" when
+// path is not one.
+func iamSLRServiceFromPath(path string) string {
+	if !iamIsSLRPath(path) {
+		return ""
+	}
+	return strings.Trim(strings.TrimPrefix(path, iamSLRPathPrefix), "/")
+}
+
+// iamSLRRoleName returns the role name CreateServiceLinkedRole mints for a service
+// principal and an optional custom suffix.
+//
+// AWS: "A string that you provide, which is combined with the service-provided prefix
+// to form the complete role name." It does not say how the two are joined; AWS's own
+// role names use "_", which is what substrate uses — the separator is observed
+// behavior rather than the API model, and it matters because the bundled statements
+// that scope Resource end in `*` and so admit any suffix at all.
+func iamSLRRoleName(serviceName, customSuffix string) string {
+	name, ok := iamSLRRoleNames[serviceName]
+	if !ok {
+		name = iamSLRDerivedRoleName(serviceName)
+	}
+	if customSuffix != "" {
+		name += "_" + customSuffix
+	}
+	return name
+}
+
+// iamSLRDerivedRoleName is substrate's convention for a service principal
+// [iamSLRRoleNames] holds no row for.
+//
+// It strips the `.amazonaws.com` suffix and title-cases each remaining segment, so
+// `foo.application-autoscaling.amazonaws.com` yields
+// `AWSServiceRoleForFooApplicationAutoscaling`. That is a *convention*, not AWS's rule:
+// AWS's real names are not derivable — `spot.amazonaws.com` becomes
+// `AWSServiceRoleForEC2Spot`, which no transformation of "spot" produces — so the
+// honest thing is a stable, well-formed name plus a table for every principal substrate
+// has a citation for.
+//
+// A name derived here still satisfies every bundled statement that names a principal
+// outside [iamSLRRoleNames]: all but one of those statements scope Resource to "*", and
+// the exception — AWSBatchFullAccess's `arn:aws:iam::*:role/*Batch*` — is matched by the
+// title-cased `AWSServiceRoleForBatch` this produces (#747).
+func iamSLRDerivedRoleName(serviceName string) string {
+	trimmed := strings.TrimSuffix(serviceName, iamSLRServiceSuffix)
+	var b strings.Builder
+	b.WriteString(iamSLRNamePrefix)
+	for _, segment := range strings.FieldsFunc(trimmed, func(r rune) bool {
+		return r == '.' || r == '-' || r == '_'
+	}) {
+		b.WriteString(strings.ToUpper(segment[:1]))
+		b.WriteString(segment[1:])
+	}
+	return b.String()
+}
+
+// iamSLRTrustPolicy is the trust policy a service-linked role carries.
+//
+// AWS: "The defined permissions include the trust policy and the permissions policy",
+// and the linked service is the only principal that may assume the role — "unless
+// defined otherwise, only that service can assume the roles". Substrate writes exactly
+// that one statement, which is what makes the role usable by the STS trust-policy gate
+// (#593) without inventing permissions the service would grant itself.
+func iamSLRTrustPolicy(serviceName string) PolicyDocument {
+	return PolicyDocument{
+		Version: policyVarVersion,
+		Statement: []PolicyStatement{{
+			Effect:    IAMEffectAllow,
+			Principal: &PolicyPrincipal{Service: StringOrSlice{serviceName}},
+			Action:    StringOrSlice{"sts:AssumeRole"},
+		}},
+	}
+}
+
+// IAMSLRDeletionTask records one DeleteServiceLinkedRole submission.
+//
+// It exists because the operation is asynchronous on AWS: it "Submits a
+// service-linked role deletion request and returns a DeletionTaskId, which you can use
+// to check the status of the deletion." The record is what
+// GetServiceLinkedRoleDeletionStatus answers from, and its Status is seedable so a
+// consumer's poll loop can be driven to a FAILED outcome without wall-clock time —
+// which is the only way the failure AWS documents ("If you submit a deletion request
+// for a service-linked role whose linked service is still accessing a resource, then
+// the deletion task fails") is reachable in an emulator that runs no linked service.
+type IAMSLRDeletionTask struct {
+	// DeletionTaskID is the identifier the submission returned, in AWS's documented
+	// format `task/aws-service-role/<service-principal-name>/<role-name>/<task-uuid>`.
+	DeletionTaskID string `json:"DeletionTaskId"`
+
+	// RoleName is the service-linked role the task is deleting.
+	RoleName string `json:"RoleName"`
+
+	// ServiceName is the role's linked service principal.
+	ServiceName string `json:"ServiceName"`
+
+	// Status is one of AWS's four documented values.
+	Status string `json:"Status"`
+
+	// Reason is the failure reason, set only for a FAILED task.
+	Reason string `json:"Reason,omitempty"`
+
+	// RoleUsageList names the resources still using the role, which AWS reports
+	// alongside a failure reason "usually including the resources that must be
+	// deleted".
+	RoleUsageList []IAMSLRRoleUsage `json:"RoleUsageList,omitempty"`
+}
+
+// IAMSLRRoleUsage is one region's worth of resources still using a service-linked
+// role, as reported inside a failed deletion task's reason.
+type IAMSLRRoleUsage struct {
+	// Region is the region the resources are in.
+	Region string `json:"Region"`
+
+	// Resources are the ARNs that must be deleted before the role can be.
+	Resources []string `json:"Resources"`
+}
+
+// iamSLRDeletionTaskID builds the identifier DeleteServiceLinkedRole returns.
+//
+// AWS documents the format exactly — `task/aws-service-role/<service-principal-name>/
+// <role-name>/<task-uuid>` — and it matters beyond cosmetics: the service and the role
+// are *in* the ID, which is what lets [iamAuthzResources] name the resource a
+// GetServiceLinkedRoleDeletionStatus request is about without reading state.
+func iamSLRDeletionTaskID(serviceName, roleName, uuid string) string {
+	return "task/aws-service-role/" + serviceName + "/" + roleName + "/" + uuid
+}
+
+// iamSLRRoleFromDeletionTaskID returns the service principal and role name a deletion
+// task ID names, and whether it parsed.
+func iamSLRRoleFromDeletionTaskID(taskID string) (serviceName, roleName string, ok bool) {
+	rest, found := strings.CutPrefix(taskID, "task/aws-service-role/")
+	if !found {
+		return "", "", false
+	}
+	parts := strings.Split(rest, "/")
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+// iamSLRTaskUUID mints the trailing component of a deletion task ID.
+//
+// The shape is a UUID because AWS's own example is one
+// (`ec720f7a-c0ba-4838-be33-f72e1873dd52`) and an SDK or a consumer's regex may read
+// it as such. It is random for the same reason [generateIAMID] is: an identifier AWS
+// generates is not derivable from the request, and deriving one would make two
+// deletions of the same role collide on a single ID.
+func iamSLRTaskUUID() string {
+	raw := make([]byte, 16)
+	if _, err := cryptorand.Read(raw); err != nil {
+		panic(fmt.Sprintf("iamSLRTaskUUID: crypto/rand read: %v", err))
+	}
+	// Version 4, variant 1, so the value is a well-formed random UUID rather than 16
+	// hex-encoded bytes that merely look like one.
+	raw[6] = (raw[6] & 0x0f) | 0x40
+	raw[8] = (raw[8] & 0x3f) | 0x80
+	h := hex.EncodeToString(raw)
+	return h[0:8] + "-" + h[8:12] + "-" + h[12:16] + "-" + h[16:20] + "-" + h[20:32]
+}

--- a/emulator/iam_service_linked_roles_test.go
+++ b/emulator/iam_service_linked_roles_test.go
@@ -1,0 +1,884 @@
+package emulator_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// Service-linked roles were the largest hole in substrate's condition-key coverage: the
+// three operations answered InvalidAction, so the eleven bundled managed-policy
+// statements conditioned on iam:AWSServiceName could not be evaluated at all (#747).
+
+func TestIAM_CreateServiceLinkedRole(t *testing.T) {
+	tests := []struct {
+		name         string
+		serviceName  string
+		customSuffix string
+		description  string
+		wantRoleName string
+		wantPath     string
+	}{
+		{
+			// The table's citation: AWSLambda_FullAccess scopes its Resource to this
+			// exact ARN with no trailing wildcard, so a derived name would match nothing.
+			name:         "a tabled principal gets the name AWS uses",
+			serviceName:  "lambda.amazonaws.com",
+			wantRoleName: "AWSServiceRoleForLambda",
+			wantPath:     "/aws-service-role/lambda.amazonaws.com/",
+		},
+		{
+			// AmazonElastiCacheFullAccess spells the internal capital, which no
+			// mechanical derivation from "elasticache" produces.
+			name:         "the table preserves AWS's own casing",
+			serviceName:  "elasticache.amazonaws.com",
+			wantRoleName: "AWSServiceRoleForElastiCache",
+			wantPath:     "/aws-service-role/elasticache.amazonaws.com/",
+		},
+		{
+			name:         "a custom suffix is appended after an underscore",
+			serviceName:  "lambda.amazonaws.com",
+			customSuffix: "deploy",
+			wantRoleName: "AWSServiceRoleForLambda_deploy",
+			wantPath:     "/aws-service-role/lambda.amazonaws.com/",
+		},
+		{
+			// A principal with no citation still gets a stable, well-formed name.
+			name:         "an untabled principal gets substrate's derived name",
+			serviceName:  "someservice.amazonaws.com",
+			wantRoleName: "AWSServiceRoleForSomeservice",
+			wantPath:     "/aws-service-role/someservice.amazonaws.com/",
+		},
+		{
+			name:         "a description is stored",
+			serviceName:  "ssm.amazonaws.com",
+			description:  "Provides access to AWS Resources managed by Amazon SSM",
+			wantRoleName: "AWSServiceRoleForAmazonSSM",
+			wantPath:     "/aws-service-role/ssm.amazonaws.com/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newIAMTestServer(t)
+			body := map[string]string{"AWSServiceName": tt.serviceName}
+			if tt.customSuffix != "" {
+				body["CustomSuffix"] = tt.customSuffix
+			}
+			if tt.description != "" {
+				body["Description"] = tt.description
+			}
+			resp := iamRequest(t, srv, "CreateServiceLinkedRole", body)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			var out map[string]any
+			decodeIAMXML(t, resp, &out)
+			role, ok := out["Role"].(map[string]any)
+			require.True(t, ok, "response should carry a Role: %#v", out)
+			assert.Equal(t, tt.wantRoleName, role["RoleName"])
+			assert.Equal(t, tt.wantPath, role["Path"])
+			assert.Equal(t,
+				"arn:aws:iam::123456789012:role"+tt.wantPath+tt.wantRoleName,
+				role["Arn"])
+			if tt.description != "" {
+				assert.Equal(t, tt.description, role["Description"])
+			}
+
+			// The trust policy names the linked service and nothing else — "unless
+			// defined otherwise, only that service can assume the roles" — so the role
+			// is usable by the STS trust-policy gate without inventing permissions.
+			doc, ok := role["AssumeRolePolicyDocument"].(string)
+			require.True(t, ok, "the Role shape should carry the trust policy")
+			var parsed emulator.PolicyDocument
+			require.NoError(t, json.Unmarshal([]byte(doc), &parsed))
+			require.Len(t, parsed.Statement, 1)
+			assert.Equal(t, "Allow", parsed.Statement[0].Effect)
+			assert.Equal(t, emulator.StringOrSlice{"sts:AssumeRole"}, parsed.Statement[0].Action)
+			require.NotNil(t, parsed.Statement[0].Principal)
+			assert.Equal(t, []string{tt.serviceName}, parsed.Statement[0].Principal.Service)
+
+			// The role is an ordinary role to every other operation, which is the whole
+			// point of writing it to the same state key.
+			getResp := iamRequest(t, srv, "GetRole", map[string]string{"RoleName": tt.wantRoleName})
+			assert.Equal(t, http.StatusOK, getResp.StatusCode)
+		})
+	}
+}
+
+func TestIAM_CreateServiceLinkedRole_Refusals(t *testing.T) {
+	// CreateServiceLinkedRole publishes exactly four errors and EntityAlreadyExists is
+	// not among them, so the duplicate refusal cannot be a copy of CreateRole's.
+	tests := []struct {
+		name     string
+		body     map[string]string
+		wantCode string
+		wantHTTP int
+	}{
+		{
+			name:     "AWSServiceName is required",
+			body:     map[string]string{},
+			wantCode: "ValidationError",
+			wantHTTP: http.StatusBadRequest,
+		},
+		{
+			name:     "a malformed service name is InvalidInput",
+			body:     map[string]string{"AWSServiceName": "not a principal!"},
+			wantCode: "InvalidInput",
+			wantHTTP: http.StatusBadRequest,
+		},
+		{
+			name: "a service name over 128 characters is InvalidInput",
+			body: map[string]string{
+				"AWSServiceName": strings.Repeat("a", 120) + ".amazonaws.com",
+			},
+			wantCode: "InvalidInput",
+			wantHTTP: http.StatusBadRequest,
+		},
+		{
+			name: "a malformed custom suffix is InvalidInput",
+			body: map[string]string{
+				"AWSServiceName": "lambda.amazonaws.com",
+				"CustomSuffix":   "no spaces allowed",
+			},
+			wantCode: "InvalidInput",
+			wantHTTP: http.StatusBadRequest,
+		},
+		{
+			name: "a custom suffix over 64 characters is InvalidInput",
+			body: map[string]string{
+				"AWSServiceName": "lambda.amazonaws.com",
+				"CustomSuffix":   strings.Repeat("s", 65),
+			},
+			wantCode: "InvalidInput",
+			wantHTTP: http.StatusBadRequest,
+		},
+		{
+			name: "a description over 1000 characters is InvalidInput",
+			body: map[string]string{
+				"AWSServiceName": "lambda.amazonaws.com",
+				"Description":    strings.Repeat("d", 1001),
+			},
+			wantCode: "InvalidInput",
+			wantHTTP: http.StatusBadRequest,
+		},
+		{
+			// A 64-character role-name cap applies everywhere in IAM, and a long
+			// derived name plus a long suffix can pass both individual checks and
+			// still exceed it.
+			name: "a combined name over 64 characters is InvalidInput",
+			body: map[string]string{
+				"AWSServiceName": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.amazonaws.com",
+				"CustomSuffix":   strings.Repeat("s", 40),
+			},
+			wantCode: "InvalidInput",
+			wantHTTP: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newIAMTestServer(t)
+			resp := iamRequest(t, srv, "CreateServiceLinkedRole", tt.body)
+			require.Equal(t, tt.wantHTTP, resp.StatusCode)
+			var out map[string]any
+			decodeIAMXML(t, resp, &out)
+			assert.Equal(t, tt.wantCode, out["__type"])
+		})
+	}
+}
+
+func TestIAM_CreateServiceLinkedRole_DuplicateIsInvalidInput(t *testing.T) {
+	srv := newIAMTestServer(t)
+	body := map[string]string{"AWSServiceName": "lambda.amazonaws.com", "CustomSuffix": "one"}
+	require.Equal(t, http.StatusOK, iamRequest(t, srv, "CreateServiceLinkedRole", body).StatusCode)
+
+	resp := iamRequest(t, srv, "CreateServiceLinkedRole", body)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"the duplicate refusal is InvalidInput 400, not EntityAlreadyExists 409: "+
+			"CreateServiceLinkedRole does not publish EntityAlreadyExists at all")
+	var out map[string]any
+	decodeIAMXML(t, resp, &out)
+	assert.Equal(t, "InvalidInput", out["__type"])
+	assert.Contains(t, out["message"], "has been taken in this account")
+
+	// A different suffix is a different role, which is what CustomSuffix exists for.
+	other := map[string]string{"AWSServiceName": "lambda.amazonaws.com", "CustomSuffix": "two"}
+	assert.Equal(t, http.StatusOK, iamRequest(t, srv, "CreateServiceLinkedRole", other).StatusCode)
+}
+
+func TestIAM_DeleteRole_RefusesAServiceLinkedRole(t *testing.T) {
+	// Without this guard DeleteServiceLinkedRole would be decorative: a caller could
+	// delete the role through the ordinary path and never submit a deletion task. AWS
+	// publishes UnmodifiableEntity at HTTP 400 here, not the 409 DeleteConflict uses.
+	srv := newIAMTestServer(t)
+	require.Equal(t, http.StatusOK, iamRequest(t, srv, "CreateServiceLinkedRole",
+		map[string]string{"AWSServiceName": "lambda.amazonaws.com"}).StatusCode)
+
+	resp := iamRequest(t, srv, "DeleteRole",
+		map[string]string{"RoleName": "AWSServiceRoleForLambda"})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	var out map[string]any
+	decodeIAMXML(t, resp, &out)
+	assert.Equal(t, "UnmodifiableEntity", out["__type"])
+	assert.Contains(t, out["message"], "protected AWS resources")
+
+	// The role is still there — a refusal must not half-delete.
+	assert.Equal(t, http.StatusOK, iamRequest(t, srv, "GetRole",
+		map[string]string{"RoleName": "AWSServiceRoleForLambda"}).StatusCode)
+
+	// An ordinary role is unaffected, which is what keeps the guard from being a
+	// regression in DeleteRole itself.
+	require.Equal(t, http.StatusOK, iamRequest(t, srv, "CreateRole",
+		map[string]string{"RoleName": "deploy"}).StatusCode)
+	assert.Equal(t, http.StatusOK, iamRequest(t, srv, "DeleteRole",
+		map[string]string{"RoleName": "deploy"}).StatusCode)
+}
+
+func TestIAM_DeleteServiceLinkedRole(t *testing.T) {
+	srv := newIAMTestServer(t)
+	require.Equal(t, http.StatusOK, iamRequest(t, srv, "CreateServiceLinkedRole",
+		map[string]string{"AWSServiceName": "lambda.amazonaws.com"}).StatusCode)
+
+	resp := iamRequest(t, srv, "DeleteServiceLinkedRole",
+		map[string]string{"RoleName": "AWSServiceRoleForLambda"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var out map[string]any
+	decodeIAMXML(t, resp, &out)
+	taskID, ok := out["DeletionTaskId"].(string)
+	require.True(t, ok, "the submission returns a DeletionTaskId: %#v", out)
+
+	// AWS documents the format exactly, and both halves matter: the service and the
+	// role in the ID are what let a status poll's request resource resolve after the
+	// role itself is gone.
+	assert.True(t, strings.HasPrefix(taskID,
+		"task/aws-service-role/lambda.amazonaws.com/AWSServiceRoleForLambda/"),
+		"task ID should follow AWS's documented format, got %q", taskID)
+
+	// The role is gone: nothing here is using it, so the deletion succeeds.
+	getResp := iamRequest(t, srv, "GetRole", map[string]string{"RoleName": "AWSServiceRoleForLambda"})
+	assert.Equal(t, http.StatusNotFound, getResp.StatusCode)
+
+	statusResp := iamRequest(t, srv, "GetServiceLinkedRoleDeletionStatus",
+		map[string]string{"DeletionTaskId": taskID})
+	require.Equal(t, http.StatusOK, statusResp.StatusCode)
+	var status map[string]any
+	decodeIAMXML(t, statusResp, &status)
+	assert.Equal(t, "SUCCEEDED", status["Status"])
+	assert.NotContains(t, status, "Reason", "a succeeded task reports no failure reason")
+}
+
+func TestIAM_DeleteServiceLinkedRole_Refusals(t *testing.T) {
+	srv := newIAMTestServer(t)
+	require.Equal(t, http.StatusOK, iamRequest(t, srv, "CreateRole",
+		map[string]string{"RoleName": "ordinary"}).StatusCode)
+
+	tests := []struct {
+		name        string
+		body        map[string]string
+		wantHTTP    int
+		wantCode    string
+		wantMessage string
+	}{
+		{
+			name:     "RoleName is required",
+			body:     map[string]string{},
+			wantHTTP: http.StatusBadRequest,
+			wantCode: "ValidationError",
+		},
+		{
+			name:     "an unknown role is NoSuchEntity",
+			body:     map[string]string{"RoleName": "nosuchrole"},
+			wantHTTP: http.StatusNotFound,
+			wantCode: "NoSuchEntity",
+		},
+		{
+			// AWS publishes no InvalidInput on this operation, so of the four codes it
+			// does publish NoSuchEntity is the only one that fits — there is no
+			// service-linked role by that name. The message says which.
+			name:        "an ordinary role is NoSuchEntity, and says why",
+			body:        map[string]string{"RoleName": "ordinary"},
+			wantHTTP:    http.StatusNotFound,
+			wantCode:    "NoSuchEntity",
+			wantMessage: "is not a service-linked role",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := iamRequest(t, srv, "DeleteServiceLinkedRole", tt.body)
+			require.Equal(t, tt.wantHTTP, resp.StatusCode)
+			var out map[string]any
+			decodeIAMXML(t, resp, &out)
+			assert.Equal(t, tt.wantCode, out["__type"])
+			if tt.wantMessage != "" {
+				assert.Contains(t, out["message"], tt.wantMessage)
+			}
+		})
+	}
+
+	// The ordinary role survived the refusal.
+	assert.Equal(t, http.StatusOK, iamRequest(t, srv, "GetRole",
+		map[string]string{"RoleName": "ordinary"}).StatusCode)
+}
+
+func TestIAM_GetServiceLinkedRoleDeletionStatus_Refusals(t *testing.T) {
+	srv := newIAMTestServer(t)
+
+	resp := iamRequest(t, srv, "GetServiceLinkedRoleDeletionStatus", map[string]string{})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	var out map[string]any
+	decodeIAMXML(t, resp, &out)
+	assert.Equal(t, "ValidationError", out["__type"])
+
+	resp = iamRequest(t, srv, "GetServiceLinkedRoleDeletionStatus",
+		map[string]string{"DeletionTaskId": "task/aws-service-role/lambda.amazonaws.com/X/abc"})
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	decodeIAMXML(t, resp, &out)
+	assert.Equal(t, "NoSuchEntity", out["__type"])
+}
+
+func TestIAM_SeededSLRDeletionOutcome(t *testing.T) {
+	// The failure AWS documents — "If you submit a deletion request for a
+	// service-linked role whose linked service is still accessing a resource, then the
+	// deletion task fails" — is unreachable in an emulator that runs no linked service.
+	// Seeding it is the only way a consumer's FAILED branch is testable, and the role
+	// staying in place is the observable difference between the two outcomes.
+	state := emulator.NewMemoryStateManager()
+	srv := newIAMTestServerWithState(t, state)
+
+	require.Equal(t, http.StatusOK, iamRequest(t, srv, "CreateServiceLinkedRole",
+		map[string]string{"AWSServiceName": "lambda.amazonaws.com"}).StatusCode)
+
+	seedSLRDeletionStatus(t, srv, map[string]any{
+		"roleName": "AWSServiceRoleForLambda",
+		"status":   "FAILED",
+		"reason":   "Cannot delete the role because it is still in use.",
+		"roleUsageList": []map[string]any{{
+			"Region":    "us-east-1",
+			"Resources": []string{"arn:aws:lambda:us-east-1:123456789012:function:live"},
+		}},
+	}, http.StatusOK)
+
+	resp := iamRequest(t, srv, "DeleteServiceLinkedRole",
+		map[string]string{"RoleName": "AWSServiceRoleForLambda"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var out map[string]any
+	decodeIAMXML(t, resp, &out)
+	taskID, ok := out["DeletionTaskId"].(string)
+	require.True(t, ok)
+
+	// A failed deletion leaves the role: a caller who polls to FAILED and then reads
+	// the role must still find it.
+	assert.Equal(t, http.StatusOK, iamRequest(t, srv, "GetRole",
+		map[string]string{"RoleName": "AWSServiceRoleForLambda"}).StatusCode,
+		"a FAILED deletion must not delete the role")
+
+	statusResp := iamRequest(t, srv, "GetServiceLinkedRoleDeletionStatus",
+		map[string]string{"DeletionTaskId": taskID})
+	require.Equal(t, http.StatusOK, statusResp.StatusCode)
+	var status map[string]any
+	decodeIAMXML(t, statusResp, &status)
+	assert.Equal(t, "FAILED", status["Status"])
+	reason, ok := status["Reason"].(map[string]any)
+	require.True(t, ok, "a FAILED task reports a DeletionTaskFailureReasonType: %#v", status)
+	assert.Equal(t, "Cannot delete the role because it is still in use.", reason["Reason"])
+	usage, ok := reason["RoleUsageList"].([]any)
+	require.True(t, ok, "the reason names the resources that must be deleted: %#v", reason)
+	require.Len(t, usage, 1)
+	first, ok := usage[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "us-east-1", first["Region"])
+}
+
+func TestIAM_SeededSLRDeletionInProgressReturnsTheSameTask(t *testing.T) {
+	// "If the deletion task is not yet complete, the DeletionTaskId of the existing
+	// task is returned" — which is also what keeps a caller's retry from accumulating
+	// tasks. Only IN_PROGRESS and NOT_STARTED hold a resubmission back; a FAILED task
+	// must not, or a caller who removed the blocking resources could never retry.
+	srv := newIAMTestServer(t)
+	require.Equal(t, http.StatusOK, iamRequest(t, srv, "CreateServiceLinkedRole",
+		map[string]string{"AWSServiceName": "lambda.amazonaws.com"}).StatusCode)
+
+	seedSLRDeletionStatus(t, srv, map[string]any{
+		"roleName": "AWSServiceRoleForLambda", "status": "IN_PROGRESS",
+	}, http.StatusOK)
+
+	first := deleteSLRTaskID(t, srv, "AWSServiceRoleForLambda")
+	second := deleteSLRTaskID(t, srv, "AWSServiceRoleForLambda")
+	assert.Equal(t, first, second, "an incomplete task is returned again, not duplicated")
+
+	status := iamRequest(t, srv, "GetServiceLinkedRoleDeletionStatus",
+		map[string]string{"DeletionTaskId": first})
+	var out map[string]any
+	decodeIAMXML(t, status, &out)
+	assert.Equal(t, "IN_PROGRESS", out["Status"])
+}
+
+func TestIAM_SLRDeletionSeedWildcardAndClear(t *testing.T) {
+	srv := newIAMTestServer(t)
+
+	// A "*" seed applies to any role, which is what a test seeding one outcome for a
+	// whole run wants.
+	seedSLRDeletionStatus(t, srv, map[string]any{"status": "NOT_STARTED"}, http.StatusOK)
+	require.Equal(t, http.StatusOK, iamRequest(t, srv, "CreateServiceLinkedRole",
+		map[string]string{"AWSServiceName": "events.amazonaws.com"}).StatusCode)
+	taskID := deleteSLRTaskID(t, srv, "AWSServiceRoleForCloudWatchEvents")
+	var out map[string]any
+	decodeIAMXML(t, iamRequest(t, srv, "GetServiceLinkedRoleDeletionStatus",
+		map[string]string{"DeletionTaskId": taskID}), &out)
+	assert.Equal(t, "NOT_STARTED", out["Status"])
+
+	// A status outside AWS's four documented values is refused where it is written,
+	// not reported later as a status no SDK models.
+	seedSLRDeletionStatus(t, srv, map[string]any{"status": "PENDING"}, http.StatusBadRequest)
+	seedSLRDeletionStatus(t, srv, map[string]any{}, http.StatusBadRequest)
+
+	// Clearing restores the nominal path.
+	clearReq := httptest.NewRequest(http.MethodDelete, "/v1/iam/slr-deletion-status", nil)
+	clearW := httptest.NewRecorder()
+	srv.ServeHTTP(clearW, clearReq)
+	require.Equal(t, http.StatusOK, clearW.Code)
+
+	require.Equal(t, http.StatusOK, iamRequest(t, srv, "CreateServiceLinkedRole",
+		map[string]string{"AWSServiceName": "elasticache.amazonaws.com"}).StatusCode)
+	nominal := deleteSLRTaskID(t, srv, "AWSServiceRoleForElastiCache")
+	decodeIAMXML(t, iamRequest(t, srv, "GetServiceLinkedRoleDeletionStatus",
+		map[string]string{"DeletionTaskId": nominal}), &out)
+	assert.Equal(t, "SUCCEEDED", out["Status"])
+}
+
+// seedSLRDeletionStatus POSTs a deletion-outcome seed and asserts the status code.
+func seedSLRDeletionStatus(t *testing.T, srv *emulator.Server, body map[string]any, wantStatus int) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	r := httptest.NewRequest(http.MethodPost, "/v1/iam/slr-deletion-status", bytes.NewReader(raw))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	require.Equal(t, wantStatus, w.Code, "seed response body: %s", w.Body.String())
+}
+
+// deleteSLRTaskID submits a deletion and returns the task ID.
+func deleteSLRTaskID(t *testing.T, srv *emulator.Server, roleName string) string {
+	t.Helper()
+	resp := iamRequest(t, srv, "DeleteServiceLinkedRole", map[string]string{"RoleName": roleName})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var out map[string]any
+	decodeIAMXML(t, resp, &out)
+	taskID, ok := out["DeletionTaskId"].(string)
+	require.True(t, ok, "expected a DeletionTaskId: %#v", out)
+	return taskID
+}
+
+func TestIAMSLRRoleName(t *testing.T) {
+	// AWS's real names are not derivable — "spot" becomes AWSServiceRoleForEC2Spot,
+	// which no transformation of the word produces — and the User Guide explicitly
+	// warns against guessing. So the table holds exactly the six principals a bundled
+	// statement names in a Resource, and the derivation is substrate's documented
+	// convention for everything else.
+	tests := []struct {
+		serviceName  string
+		customSuffix string
+		want         string
+	}{
+		{serviceName: "lambda.amazonaws.com", want: "AWSServiceRoleForLambda"},
+		{serviceName: "events.amazonaws.com", want: "AWSServiceRoleForCloudWatchEvents"},
+		{serviceName: "ssm.amazonaws.com", want: "AWSServiceRoleForAmazonSSM"},
+		{serviceName: "elasticache.amazonaws.com", want: "AWSServiceRoleForElastiCache"},
+		{serviceName: "cognito-idp.amazonaws.com", want: "AWSServiceRoleForAmazonCognitoIdp"},
+		{serviceName: "email.cognito-idp.amazonaws.com", want: "AWSServiceRoleForAmazonCognitoIdpEmail"},
+		// Outside the table, so this is the derivation — and it is what makes
+		// AWSBatchFullAccess's arn:aws:iam::*:role/*Batch* match, which is the one
+		// bundled statement that scopes a Resource around an untabled principal.
+		{serviceName: "batch.amazonaws.com", want: "AWSServiceRoleForBatch"},
+		{
+			serviceName:  "lambda.amazonaws.com",
+			customSuffix: "prod",
+			want:         "AWSServiceRoleForLambda_prod",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.serviceName+"/"+tt.customSuffix, func(t *testing.T) {
+			assert.Equal(t, tt.want,
+				emulator.IAMSLRRoleNameForTest(tt.serviceName, tt.customSuffix))
+		})
+	}
+}
+
+func TestIAMSLRDerivedRoleName(t *testing.T) {
+	// Substrate's convention for a principal with no citation. Pinned because it is a
+	// name a consumer will read back out of GetRole, so changing it is a wire change.
+	tests := []struct{ serviceName, want string }{
+		{"someservice.amazonaws.com", "AWSServiceRoleForSomeservice"},
+		{"foo.application-autoscaling.amazonaws.com", "AWSServiceRoleForFooApplicationAutoscaling"},
+		{"a-b-c.amazonaws.com", "AWSServiceRoleForABC"},
+		{"noSuffix", "AWSServiceRoleForNoSuffix"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.serviceName, func(t *testing.T) {
+			assert.Equal(t, tt.want, emulator.IAMSLRDerivedRoleNameForTest(tt.serviceName))
+		})
+	}
+}
+
+func TestIAMSLRServiceFromRoleName(t *testing.T) {
+	tests := []struct{ roleName, want string }{
+		{"AWSServiceRoleForLambda", "lambda.amazonaws.com"},
+		{"AWSServiceRoleForLambda_prod", "lambda.amazonaws.com"},
+		// The longest-match rule: one table value is a prefix of another only in
+		// spirit here, but the "_" separator is what actually keeps them apart.
+		{"AWSServiceRoleForAmazonCognitoIdp", "cognito-idp.amazonaws.com"},
+		{"AWSServiceRoleForAmazonCognitoIdpEmail", "email.cognito-idp.amazonaws.com"},
+		// Outside the table the key is absent rather than guessed.
+		{"AWSServiceRoleForSomeservice", ""},
+		{"ordinary", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.roleName, func(t *testing.T) {
+			assert.Equal(t, tt.want, emulator.IAMSLRServiceFromRoleNameForTest(tt.roleName))
+		})
+	}
+}
+
+func TestIAMSLRRoleFromDeletionTaskID(t *testing.T) {
+	service, role, ok := emulator.IAMSLRRoleFromDeletionTaskIDForTest(
+		"task/aws-service-role/lambda.amazonaws.com/AWSServiceRoleForLambda/" +
+			"ec720f7a-c0ba-4838-be33-f72e1873dd52")
+	require.True(t, ok)
+	assert.Equal(t, "lambda.amazonaws.com", service)
+	assert.Equal(t, "AWSServiceRoleForLambda", role)
+
+	for _, bad := range []string{
+		"",
+		"not-a-task",
+		"task/aws-service-role/lambda.amazonaws.com/AWSServiceRoleForLambda",
+		"task/aws-service-role//AWSServiceRoleForLambda/uuid",
+		"task/aws-service-role/lambda.amazonaws.com//uuid",
+	} {
+		t.Run("rejects "+bad, func(t *testing.T) {
+			_, _, ok := emulator.IAMSLRRoleFromDeletionTaskIDForTest(bad)
+			assert.False(t, ok)
+		})
+	}
+}
+
+func TestIAMAuthzRequestContext_PublishesAWSServiceName(t *testing.T) {
+	// The key is published where the Service Authorization Reference lists it and
+	// nowhere else. Publishing one AWS does not would let a StringEquals succeed here
+	// and fail there, which is the permissive direction.
+	tests := []struct {
+		name      string
+		service   string
+		operation string
+		params    map[string]string
+		want      string
+	}{
+		{
+			name:      "CreateServiceLinkedRole publishes the parameter",
+			service:   "iam",
+			operation: "CreateServiceLinkedRole",
+			params:    map[string]string{"AWSServiceName": "lambda.amazonaws.com"},
+			want:      "lambda.amazonaws.com",
+		},
+		{
+			name:      "DeleteServiceLinkedRole recovers it from the role name",
+			service:   "iam",
+			operation: "DeleteServiceLinkedRole",
+			params:    map[string]string{"RoleName": "AWSServiceRoleForAmazonSSM"},
+			want:      "ssm.amazonaws.com",
+		},
+		{
+			name:      "a role outside the table leaves the key absent",
+			service:   "iam",
+			operation: "DeleteServiceLinkedRole",
+			params:    map[string]string{"RoleName": "AWSServiceRoleForSomeservice"},
+		},
+		{
+			name:      "the status operation does not publish it",
+			service:   "iam",
+			operation: "GetServiceLinkedRoleDeletionStatus",
+			params: map[string]string{
+				"DeletionTaskId": "task/aws-service-role/lambda.amazonaws.com/AWSServiceRoleForLambda/u",
+			},
+		},
+		{
+			name:      "an unrelated IAM operation publishes nothing",
+			service:   "iam",
+			operation: "ListRoles",
+			params:    map[string]string{"AWSServiceName": "lambda.amazonaws.com"},
+		},
+		{
+			name:      "a non-IAM service publishes nothing",
+			service:   "ec2",
+			operation: "CreateServiceLinkedRole",
+			params:    map[string]string{"AWSServiceName": "lambda.amazonaws.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := emulator.IAMAuthzRequestContextForTest(&emulator.AWSRequest{
+				Service: tt.service, Operation: tt.operation, Params: tt.params,
+			})
+			if tt.want == "" {
+				assert.NotContains(t, got, "iam:AWSServiceName")
+				return
+			}
+			assert.Equal(t, tt.want, got["iam:AWSServiceName"])
+		})
+	}
+}
+
+func TestIAMAuthzRequestContext_ReadsEitherWireForm(t *testing.T) {
+	// A live SDK sends the query form, which populates Params; a caller speaking the
+	// JSON protocol directly populates only Body. An authorization decision must not
+	// depend on which the caller chose.
+	body, err := json.Marshal(map[string]string{"AWSServiceName": "rds.amazonaws.com"})
+	require.NoError(t, err)
+	got := emulator.IAMAuthzRequestContextForTest(&emulator.AWSRequest{
+		Service:   "iam",
+		Operation: "CreateServiceLinkedRole",
+		Params:    map[string]string{},
+		Body:      body,
+	})
+	assert.Equal(t, "rds.amazonaws.com", got["iam:AWSServiceName"])
+}
+
+func TestIAMSLRResourceARN(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	ctx := context.Background()
+	role := emulator.IAMRole{
+		RoleName: "AWSServiceRoleForLambda",
+		ARN:      "arn:aws:iam::123456789012:role/aws-service-role/lambda.amazonaws.com/AWSServiceRoleForLambda",
+		Path:     "/aws-service-role/lambda.amazonaws.com/",
+	}
+	raw, err := json.Marshal(role)
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "iam",
+		emulator.IAMRoleKeyForTest("123456789012", role.RoleName), raw))
+
+	ordinary := emulator.IAMRole{RoleName: "deploy", Path: "/"}
+	rawOrdinary, err := json.Marshal(ordinary)
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "iam",
+		emulator.IAMRoleKeyForTest("123456789012", "deploy"), rawOrdinary))
+
+	reqCtx := &emulator.RequestContext{AccountID: "123456789012", Region: "us-east-1"}
+
+	tests := []struct {
+		name      string
+		operation string
+		params    map[string]string
+		want      string
+	}{
+		{
+			name:      "the create names the ARN it is about to mint",
+			operation: "CreateServiceLinkedRole",
+			params:    map[string]string{"AWSServiceName": "lambda.amazonaws.com"},
+			want:      role.ARN,
+		},
+		{
+			name:      "a custom suffix is part of the ARN",
+			operation: "CreateServiceLinkedRole",
+			params:    map[string]string{"AWSServiceName": "lambda.amazonaws.com", "CustomSuffix": "x"},
+			want:      role.ARN + "_x",
+		},
+		{
+			name:      "the delete reads the role's stored path",
+			operation: "DeleteServiceLinkedRole",
+			params:    map[string]string{"RoleName": "AWSServiceRoleForLambda"},
+			want:      role.ARN,
+		},
+		{
+			// Not the resource shape those statements are written about, so the
+			// request stays on the general path rather than getting an ARN that only
+			// looks specific.
+			name:      "an ordinary role leaves the request on the general path",
+			operation: "DeleteServiceLinkedRole",
+			params:    map[string]string{"RoleName": "deploy"},
+		},
+		{
+			name:      "an unknown role leaves the request on the general path",
+			operation: "DeleteServiceLinkedRole",
+			params:    map[string]string{"RoleName": "ghost"},
+		},
+		{
+			// The task ID carries the service and the role, so this resolves with no
+			// state read — which is what makes it work after the role is deleted.
+			name:      "the status operation resolves from the task ID alone",
+			operation: "GetServiceLinkedRoleDeletionStatus",
+			params: map[string]string{
+				"DeletionTaskId": "task/aws-service-role/lambda.amazonaws.com/AWSServiceRoleForLambda/u",
+			},
+			want: role.ARN,
+		},
+		{
+			name:      "a malformed task ID leaves the request on the general path",
+			operation: "GetServiceLinkedRoleDeletionStatus",
+			params:    map[string]string{"DeletionTaskId": "garbage"},
+		},
+		{
+			name:      "an unrelated operation leaves the request on the general path",
+			operation: "ListRoles",
+			params:    map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := emulator.IAMSLRResourceARNForTest(state, reqCtx, &emulator.AWSRequest{
+				Service: "iam", Operation: tt.operation, Params: tt.params,
+			})
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIAM_BundledPolicyGrantsCreateServiceLinkedRole(t *testing.T) {
+	// The point of #747. AWSLambda_FullAccess scopes its Resource to an exact
+	// service-linked-role ARN and conditions on iam:AWSServiceName. Before this both
+	// halves failed: the request resource was a flat arn:aws:iam::<acct>:* that the
+	// pattern could not match, and nothing published the condition key. And the two
+	// doors have to agree — a 403 from the plugin after the gate allowed is the
+	// one-ARN-two-answers class of #411.
+	const account = "123456789012"
+	const policyARN = "arn:aws:iam::aws:policy/AWSLambda_FullAccess"
+
+	tests := []struct {
+		name       string
+		service    string
+		wantDenied bool
+	}{
+		{
+			name:    "the service the statement names is allowed",
+			service: "lambda.amazonaws.com",
+		},
+		{
+			// The condition is what stops the grant from being unconditional, and it
+			// only bites once the key is published at all.
+			name:       "another service is denied by the condition",
+			service:    "rds.amazonaws.com",
+			wantDenied: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := emulator.NewMemoryStateManager()
+			ctx := context.Background()
+
+			userRaw, err := json.Marshal(emulator.IAMUser{
+				UserName: "alice",
+				ARN:      "arn:aws:iam::" + account + ":user/alice",
+				Path:     "/",
+			})
+			require.NoError(t, err)
+			require.NoError(t, state.Put(ctx, "iam",
+				emulator.IAMUserKeyForTest(account, "alice"), userRaw))
+			attachedRaw, err := json.Marshal([]string{policyARN})
+			require.NoError(t, err)
+			require.NoError(t, state.Put(ctx, "iam",
+				emulator.IAMAttachedPoliciesKeyForTest(account, "user", "alice"), attachedRaw))
+
+			logger := emulator.NewDefaultLogger(slog.LevelError, false)
+			auth := emulator.NewAuthController(state, logger)
+			plugin := &emulator.IAMPlugin{}
+			require.NoError(t, plugin.Initialize(ctx,
+				emulator.PluginConfig{State: state, Logger: logger}))
+
+			reqCtx := &emulator.RequestContext{
+				RequestID: "req-1",
+				AccountID: account,
+				Region:    "us-east-1",
+				Principal: &emulator.Principal{
+					ARN:      "arn:aws:iam::" + account + ":user/alice",
+					Type:     "IAMUser",
+					UserName: "alice",
+				},
+				Metadata: make(map[string]interface{}),
+			}
+			req := &emulator.AWSRequest{
+				Service:   "iam",
+				Operation: "CreateServiceLinkedRole",
+				Params:    map[string]string{"AWSServiceName": tt.service},
+			}
+
+			gateErr := auth.CheckAccess(reqCtx, req)
+			roleARN := "arn:aws:iam::" + account + ":role" +
+				emulator.IAMSLRPathForTest(tt.service) +
+				emulator.IAMSLRRoleNameForTest(tt.service, "")
+			pluginErr := emulator.IAMAuthorizeWithForTest(plugin, reqCtx,
+				"iam:CreateServiceLinkedRole", roleARN,
+				map[string]string{"iam:AWSServiceName": tt.service})
+
+			if tt.wantDenied {
+				assert.Error(t, gateErr, "CheckAccess should deny")
+				assert.Error(t, pluginErr, "IAMPlugin.authorizeWith should deny")
+				return
+			}
+			assert.NoError(t, gateErr, "CheckAccess should allow")
+			assert.NoError(t, pluginErr, "IAMPlugin.authorizeWith should allow")
+		})
+	}
+}
+
+func TestIAM_ServiceLinkedRoleEndToEndUnderTheBundledPolicy(t *testing.T) {
+	// The whole chain through the server, which is what a consumer sees: a user
+	// holding only AWSLambda_FullAccess creates Lambda's service-linked role and is
+	// refused another service's. Before #747 the first was a 403 and the operation
+	// itself answered InvalidAction.
+	const account = "123456789012"
+	state := emulator.NewMemoryStateManager()
+	ctx := context.Background()
+
+	userRaw, err := json.Marshal(emulator.IAMUser{
+		UserName: "alice", ARN: "arn:aws:iam::" + account + ":user/alice", Path: "/",
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "iam", emulator.IAMUserKeyForTest(account, "alice"), userRaw))
+	attachedRaw, err := json.Marshal([]string{"arn:aws:iam::aws:policy/AWSLambda_FullAccess"})
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "iam",
+		emulator.IAMAttachedPoliciesKeyForTest(account, "user", "alice"), attachedRaw))
+
+	srv := newIAMTestServerWithState(t, state)
+	plugin := &emulator.IAMPlugin{}
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	require.NoError(t, plugin.Initialize(ctx, emulator.PluginConfig{State: state, Logger: logger}))
+
+	reqCtx := &emulator.RequestContext{
+		RequestID: "req-1",
+		AccountID: account,
+		Region:    "us-east-1",
+		Principal: &emulator.Principal{
+			ARN: "arn:aws:iam::" + account + ":user/alice", Type: "IAMUser", UserName: "alice",
+		},
+		Metadata: make(map[string]interface{}),
+	}
+
+	allowed := emulator.IAMAuthorizeWithForTest(plugin, reqCtx, "iam:CreateServiceLinkedRole",
+		"arn:aws:iam::"+account+":role/aws-service-role/lambda.amazonaws.com/AWSServiceRoleForLambda",
+		map[string]string{"iam:AWSServiceName": "lambda.amazonaws.com"})
+	require.NoError(t, allowed, "the bundled policy grants exactly this")
+
+	// And the operation works, unauthenticated, which is the default path.
+	resp := iamRequest(t, srv, "CreateServiceLinkedRole",
+		map[string]string{"AWSServiceName": "lambda.amazonaws.com"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var out map[string]any
+	decodeIAMXML(t, resp, &out)
+	role, ok := out["Role"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "AWSServiceRoleForLambda", role["RoleName"])
+}

--- a/emulator/iam_slr_handlers.go
+++ b/emulator/iam_slr_handlers.go
@@ -1,0 +1,395 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+// iamSLRServiceNamePattern is AWS's published pattern for AWSServiceName, `[\w+=,.@-]+`.
+//
+// It is the same pattern Config's own service-principal parameter carries
+// ([cfgsvcServicePrincipalPattern]), which is worth noting because it admits strings
+// that are not service principals at all — "lambda", "%" is refused but "lambda" is not.
+// AWS validates the shape here and the principal's existence separately, and substrate
+// does the same: a well-formed name it has no table row for gets a derived role name
+// rather than a refusal, because refusing would make substrate the authority on which
+// services exist.
+var iamSLRServiceNamePattern = regexp.MustCompile(`^[\w+=,.@-]+$`)
+
+// iamSLRCustomSuffixPattern is AWS's published pattern for CustomSuffix, identical to
+// AWSServiceName's.
+var iamSLRCustomSuffixPattern = regexp.MustCompile(`^[\w+=,.@-]+$`)
+
+// AWS's published length limits for the three service-linked-role parameters.
+const (
+	iamSLRServiceNameMaxLen  = 128
+	iamSLRCustomSuffixMaxLen = 64
+	iamSLRDescriptionMaxLen  = 1000
+	iamSLRRoleNameMaxLen     = 64
+)
+
+// iamSLRInvalidInputCode is the refusal every malformed service-linked-role request
+// gets.
+//
+// CreateServiceLinkedRole publishes exactly four errors — InvalidInput 400,
+// LimitExceeded 409, NoSuchEntity 404 and ServiceFailure 500 — and notably **not**
+// EntityAlreadyExists, which is what CreateRole answers for a duplicate name. So the
+// duplicate-suffix refusal cannot be a copy of createRole's: substrate answers
+// InvalidInput, which is its reading of AWS's "if a role with that name already exists,
+// the request fails with a duplicate role name error" against the four codes the
+// operation actually publishes.
+const iamSLRInvalidInputCode = "InvalidInput"
+
+// createServiceLinkedRole handles CreateServiceLinkedRole.
+//
+// AWS: "Creates an IAM role that is linked to a specific AWS service. The service
+// controls the permissions of the role, and the role can only be used by that service."
+// Substrate mints the role under the reserved `/aws-service-role/<principal>/` path with
+// a trust policy naming the linked service, which is what makes it visible to GetRole,
+// ListRoles and the STS trust-policy gate like any other role.
+//
+// The operation exists here principally because eleven of the condition blocks in
+// substrate's bundled managed policies condition on `iam:AWSServiceName`, and before
+// #747 the operation carrying that parameter answered InvalidAction — so none of the
+// eleven could be evaluated at all, let alone satisfied.
+func (p *IAMPlugin) createServiceLinkedRole(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var params struct {
+		AWSServiceName string `json:"AWSServiceName"`
+		CustomSuffix   string `json:"CustomSuffix"`
+		Description    string `json:"Description"`
+	}
+	if err := parseIAMBody(req.Body, &params); err != nil {
+		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
+	}
+	if params.AWSServiceName == "" {
+		return iamErrorResponse("ValidationError", "AWSServiceName is required", http.StatusBadRequest), nil
+	}
+	if len(params.AWSServiceName) > iamSLRServiceNameMaxLen ||
+		!iamSLRServiceNamePattern.MatchString(params.AWSServiceName) {
+		return iamErrorResponse(iamSLRInvalidInputCode,
+			fmt.Sprintf("The value %q for parameter AWSServiceName is invalid.", params.AWSServiceName),
+			http.StatusBadRequest), nil
+	}
+	if params.CustomSuffix != "" &&
+		(len(params.CustomSuffix) > iamSLRCustomSuffixMaxLen ||
+			!iamSLRCustomSuffixPattern.MatchString(params.CustomSuffix)) {
+		return iamErrorResponse(iamSLRInvalidInputCode,
+			fmt.Sprintf("The value %q for parameter CustomSuffix is invalid.", params.CustomSuffix),
+			http.StatusBadRequest), nil
+	}
+	if len(params.Description) > iamSLRDescriptionMaxLen {
+		return iamErrorResponse(iamSLRInvalidInputCode,
+			fmt.Sprintf("The value for parameter Description exceeds the maximum length of %d.",
+				iamSLRDescriptionMaxLen),
+			http.StatusBadRequest), nil
+	}
+
+	roleName := iamSLRRoleName(params.AWSServiceName, params.CustomSuffix)
+	if len(roleName) > iamSLRRoleNameMaxLen {
+		// A role name is capped at 64 characters everywhere in IAM, and a long derived
+		// name plus a long suffix can exceed it. Refusing here rather than storing a
+		// role no other operation could address is what keeps DeleteServiceLinkedRole
+		// and GetRole able to name what this created.
+		return iamErrorResponse(iamSLRInvalidInputCode,
+			fmt.Sprintf("The combined role name %q exceeds the maximum length of %d characters.",
+				roleName, iamSLRRoleNameMaxLen),
+			http.StatusBadRequest), nil
+	}
+
+	goCtx := context.Background()
+
+	// The resource is the ARN this is about to mint, not "*", and the context carries
+	// iam:AWSServiceName — both of which the generic gate publishes too
+	// ([iamAuthzResources], [iamAuthzRequestContext]). A statement scoped to
+	// `arn:aws:iam::*:role/aws-service-role/lambda.amazonaws.com/AWSServiceRoleForLambda`
+	// with a StringLike on the service name is the exact shape five of the bundled
+	// policies use, and it has to reach the same verdict at both doors (#747).
+	slrPath := iamSLRPath(params.AWSServiceName)
+	roleARN := iamRoleARN(ctx.AccountID, slrPath, roleName)
+	if err := p.authorizeWith(goCtx, ctx, "iam:CreateServiceLinkedRole", roleARN,
+		map[string]string{iamSLRAWSServiceNameCondKey: params.AWSServiceName}); err != nil {
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
+	}
+
+	key := iamRoleKey(ctx.AccountID, roleName)
+	existing, err := p.state.Get(goCtx, iamNamespace, key)
+	if err != nil {
+		return nil, fmt.Errorf("get service-linked role: %w", err)
+	}
+	if existing != nil {
+		return iamErrorResponse(iamSLRInvalidInputCode,
+			fmt.Sprintf("Service role name %s has been taken in this account, please try a different suffix.",
+				roleName),
+			http.StatusBadRequest), nil
+	}
+
+	role := &IAMRole{
+		RoleName:                 roleName,
+		RoleID:                   generateIAMID("AROA"),
+		ARN:                      roleARN,
+		Path:                     slrPath,
+		Description:              params.Description,
+		MaxSessionDuration:       3600,
+		CreateDate:               p.now().UTC(),
+		AssumeRolePolicyDocument: iamSLRTrustPolicy(params.AWSServiceName),
+	}
+	raw, err := json.Marshal(role)
+	if err != nil {
+		return nil, fmt.Errorf("marshal service-linked role: %w", err)
+	}
+	if err := p.state.Put(goCtx, iamNamespace, key, raw); err != nil {
+		return nil, fmt.Errorf("put service-linked role: %w", err)
+	}
+
+	return iamXMLResponse(http.StatusOK, "CreateServiceLinkedRole", iamSingleRoleXML(role))
+}
+
+// deleteServiceLinkedRole handles DeleteServiceLinkedRole.
+//
+// AWS: "Submits a service-linked role deletion request and returns a DeletionTaskId,
+// which you can use to check the status of the deletion." The submission is
+// asynchronous, so this returns a task rather than an outcome, and
+// [IAMPlugin.getServiceLinkedRoleDeletionStatus] reports the outcome.
+//
+// Substrate deletes the role record immediately and reports the task SUCCEEDED, because
+// nothing here is using it — the linked service does not run. A test that needs the
+// failure AWS documents ("If you submit a deletion request for a service-linked role
+// whose linked service is still accessing a resource, then the deletion task fails")
+// seeds it through `POST /v1/iam/slr-deletion-status`, which is how a poll loop's
+// failure branch becomes reachable without wall-clock time.
+func (p *IAMPlugin) deleteServiceLinkedRole(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var params struct {
+		RoleName string `json:"RoleName"`
+	}
+	if err := parseIAMBody(req.Body, &params); err != nil {
+		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
+	}
+	if params.RoleName == "" {
+		return iamErrorResponse("ValidationError", "RoleName is required", http.StatusBadRequest), nil
+	}
+
+	goCtx := context.Background()
+
+	role, err := p.loadRole(goCtx, ctx.AccountID, params.RoleName)
+	if err != nil {
+		return nil, err
+	}
+
+	// The role's own path names the service, so authorization can name the same ARN the
+	// gate built — and can publish iam:AWSServiceName for the delete half of the two
+	// bundled statements that condition on it. A role that does not exist yields no path
+	// and authorizes against "*", so the refusal that follows is NoSuchEntity rather than
+	// a denial that would leak whether the role is there.
+	resource, extra := "*", map[string]string(nil)
+	if role != nil && iamIsSLRPath(role.Path) {
+		resource = role.ARN
+		if service := iamSLRServiceFromPath(role.Path); service != "" {
+			extra = map[string]string{iamSLRAWSServiceNameCondKey: service}
+		}
+	}
+	if err := p.authorizeWith(goCtx, ctx, "iam:DeleteServiceLinkedRole", resource, extra); err != nil {
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
+	}
+
+	if role == nil {
+		return iamErrorResponse("NoSuchEntity",
+			fmt.Sprintf("The role with name %s cannot be found.", params.RoleName),
+			http.StatusNotFound), nil
+	}
+	if !iamIsSLRPath(role.Path) {
+		// Not a service-linked role. AWS publishes no InvalidInput on this operation,
+		// and the four codes it does publish leave NoSuchEntity as the only one that
+		// fits: there is no *service-linked* role by that name. The message says which
+		// so a caller is not left hunting a role that plainly exists.
+		return iamErrorResponse("NoSuchEntity",
+			fmt.Sprintf("The role with name %s is not a service-linked role.", params.RoleName),
+			http.StatusNotFound), nil
+	}
+
+	// An incomplete task for the same role is returned again rather than duplicated:
+	// "If the deletion task is not yet complete, the DeletionTaskId of the existing task
+	// is returned." Which is also what keeps a caller's retry from accumulating tasks.
+	if existing, err := p.findIncompleteSLRDeletionTask(goCtx, ctx.AccountID, params.RoleName); err != nil {
+		return nil, err
+	} else if existing != nil {
+		return iamXMLResponse(http.StatusOK, "DeleteServiceLinkedRole",
+			"<DeletionTaskId>"+xmlEsc(existing.DeletionTaskID)+"</DeletionTaskId>")
+	}
+
+	service := iamSLRServiceFromPath(role.Path)
+	task := &IAMSLRDeletionTask{
+		DeletionTaskID: iamSLRDeletionTaskID(service, role.RoleName, iamSLRTaskUUID()),
+		RoleName:       role.RoleName,
+		ServiceName:    service,
+		Status:         iamSLRDeletionSucceeded,
+	}
+	// A seed decides the status, so a consumer's poll loop can be driven to FAILED or
+	// held at IN_PROGRESS. It is read at submission rather than at each status poll
+	// because the deletion itself is conditional on it: a task that fails must leave the
+	// role in place, which is the whole observable difference between the two outcomes.
+	if seed := p.slrDeletionSeed(goCtx, role.RoleName); seed != nil {
+		task.Status, task.Reason, task.RoleUsageList = seed.Status, seed.Reason, seed.RoleUsageList
+	}
+
+	if task.Status == iamSLRDeletionSucceeded {
+		if err := p.state.Delete(goCtx, iamNamespace, iamRoleKey(ctx.AccountID, role.RoleName)); err != nil {
+			return nil, fmt.Errorf("delete service-linked role: %w", err)
+		}
+	}
+
+	raw, err := json.Marshal(task)
+	if err != nil {
+		return nil, fmt.Errorf("marshal service-linked role deletion task: %w", err)
+	}
+	if err := p.state.Put(goCtx, iamNamespace,
+		iamSLRDeletionTaskKey(ctx.AccountID, task.DeletionTaskID), raw); err != nil {
+		return nil, fmt.Errorf("put service-linked role deletion task: %w", err)
+	}
+
+	return iamXMLResponse(http.StatusOK, "DeleteServiceLinkedRole",
+		"<DeletionTaskId>"+xmlEsc(task.DeletionTaskID)+"</DeletionTaskId>")
+}
+
+// getServiceLinkedRoleDeletionStatus handles GetServiceLinkedRoleDeletionStatus.
+//
+// AWS: "Retrieves the status of your service-linked role deletion. After you use
+// DeleteServiceLinkedRole to submit a service-linked role for deletion, you can use the
+// DeletionTaskId parameter … to check the status of the deletion."
+//
+// Status is one of SUCCEEDED, IN_PROGRESS, FAILED or NOT_STARTED, and a FAILED task
+// also reports a Reason naming the resources that must be deleted first — which is the
+// shape a consumer's poll loop branches on and the reason the outcome is seedable.
+func (p *IAMPlugin) getServiceLinkedRoleDeletionStatus(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var params struct {
+		DeletionTaskID string `json:"DeletionTaskId"`
+	}
+	if err := parseIAMBody(req.Body, &params); err != nil {
+		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
+	}
+	if params.DeletionTaskID == "" {
+		return iamErrorResponse("ValidationError", "DeletionTaskId is required", http.StatusBadRequest), nil
+	}
+
+	goCtx := context.Background()
+
+	// The task ID embeds the service and the role, so the resource resolves with no
+	// state read — which matters here, because a SUCCEEDED task's role is gone and a
+	// resource derived from state would fall back to "*" exactly when the poll loop
+	// finally gets its answer.
+	//
+	// No iam:AWSServiceName is published: the reference lists the key on the create and
+	// the delete, not here, and publishing one AWS does not is the permissive direction.
+	// See [iamAuthzRequestContext], which makes the same split at the other door.
+	resource := "*"
+	if service, roleName, ok := iamSLRRoleFromDeletionTaskID(params.DeletionTaskID); ok {
+		resource = iamRoleARN(ctx.AccountID, iamSLRPath(service), roleName)
+	}
+	if err := p.authorize(goCtx, ctx, "iam:GetServiceLinkedRoleDeletionStatus", resource); err != nil {
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
+	}
+
+	raw, err := p.state.Get(goCtx, iamNamespace,
+		iamSLRDeletionTaskKey(ctx.AccountID, params.DeletionTaskID))
+	if err != nil {
+		return nil, fmt.Errorf("get service-linked role deletion task: %w", err)
+	}
+	if raw == nil {
+		return iamErrorResponse("NoSuchEntity",
+			fmt.Sprintf("The deletion task with ID %s cannot be found.", params.DeletionTaskID),
+			http.StatusNotFound), nil
+	}
+	var task IAMSLRDeletionTask
+	if err := json.Unmarshal(raw, &task); err != nil {
+		return nil, fmt.Errorf("unmarshal service-linked role deletion task: %w", err)
+	}
+
+	return iamXMLResponse(http.StatusOK, "GetServiceLinkedRoleDeletionStatus",
+		iamSLRDeletionStatusXML(&task))
+}
+
+// iamSLRDeletionStatusXML renders a deletion task as a
+// GetServiceLinkedRoleDeletionStatus result.
+//
+// Reason is a DeletionTaskFailureReasonType — a Reason string plus a RoleUsageList of
+// {Region, Resources} — and is emitted only when there is one, because AWS reports the
+// member only for a task that failed.
+func iamSLRDeletionStatusXML(task *IAMSLRDeletionTask) string {
+	var b strings.Builder
+	b.WriteString("<Status>")
+	b.WriteString(xmlEsc(task.Status))
+	b.WriteString("</Status>")
+	if task.Reason == "" && len(task.RoleUsageList) == 0 {
+		return b.String()
+	}
+	b.WriteString("<Reason>")
+	if task.Reason != "" {
+		b.WriteString("<Reason>")
+		b.WriteString(xmlEsc(task.Reason))
+		b.WriteString("</Reason>")
+	}
+	b.WriteString("<RoleUsageList>")
+	for _, usage := range task.RoleUsageList {
+		b.WriteString("<member><Region>")
+		b.WriteString(xmlEsc(usage.Region))
+		b.WriteString("</Region>")
+		b.WriteString(iamStringListXML("Resources", usage.Resources))
+		b.WriteString("</member>")
+	}
+	b.WriteString("</RoleUsageList></Reason>")
+	return b.String()
+}
+
+// findIncompleteSLRDeletionTask returns the account's existing unfinished deletion task
+// for a role, or nil when there is none.
+//
+// "Incomplete" is anything that is not SUCCEEDED: a FAILED task is complete in the sense
+// that it has an answer, but AWS's rule is about a task still outstanding, so only
+// IN_PROGRESS and NOT_STARTED hold a resubmission back. A FAILED task must not, or a
+// caller who deleted the blocking resources could never retry.
+func (p *IAMPlugin) findIncompleteSLRDeletionTask(goCtx context.Context, accountID, roleName string) (*IAMSLRDeletionTask, error) {
+	keys, err := p.state.List(goCtx, iamNamespace, iamSLRDeletionTaskPrefix(accountID))
+	if err != nil {
+		return nil, fmt.Errorf("list service-linked role deletion tasks: %w", err)
+	}
+	for _, k := range keys {
+		raw, err := p.state.Get(goCtx, iamNamespace, k)
+		if err != nil || raw == nil {
+			continue
+		}
+		var task IAMSLRDeletionTask
+		if err := json.Unmarshal(raw, &task); err != nil {
+			continue
+		}
+		if task.RoleName != roleName {
+			continue
+		}
+		if task.Status == iamSLRDeletionInProgress || task.Status == iamSLRDeletionNotStarted {
+			return &task, nil
+		}
+	}
+	return nil, nil
+}
+
+// slrDeletionSeed returns the seeded deletion outcome for a role name, preferring an
+// exact match over the "*" wildcard, or nil when nothing is seeded.
+func (p *IAMPlugin) slrDeletionSeed(goCtx context.Context, roleName string) *IAMSLRDeletionTask {
+	for _, name := range []string{roleName, "*"} {
+		raw, err := p.state.Get(goCtx, iamCtrlNamespace, iamCtrlSLRDeletionStatusKey(name))
+		if err != nil || raw == nil {
+			continue
+		}
+		var seed IAMSLRDeletionTask
+		if err := json.Unmarshal(raw, &seed); err != nil {
+			continue
+		}
+		if seed.Status == "" {
+			continue
+		}
+		return &seed
+	}
+	return nil
+}

--- a/emulator/iam_state_keys.go
+++ b/emulator/iam_state_keys.go
@@ -149,6 +149,23 @@ func iamUserGroupsKey(accountID, userName string) string {
 	return iamStateKey("user_groups", accountID, userName)
 }
 
+// iamSLRDeletionTaskKey returns the state key for a service-linked-role deletion
+// task, whose ID is what GetServiceLinkedRoleDeletionStatus is given.
+//
+// The task ID contains "/" — AWS's format is
+// `task/aws-service-role/<principal>/<role>/<uuid>` — which is harmless here: nothing
+// prefix-scans within a task ID, and the account still delimits the scan that reaches
+// one account's tasks.
+func iamSLRDeletionTaskKey(accountID, taskID string) string {
+	return iamStateKey("slr_deletion_task", accountID, taskID)
+}
+
+// iamSLRDeletionTaskPrefix returns the List prefix reaching every service-linked-role
+// deletion task in one account.
+func iamSLRDeletionTaskPrefix(accountID string) string {
+	return iamStatePrefix("slr_deletion_task", accountID)
+}
+
 // iamGroupPoliciesKey returns the state key holding the managed policy ARNs
 // attached to one group.
 func iamGroupPoliciesKey(accountID, groupName string) string {

--- a/emulator/server.go
+++ b/emulator/server.go
@@ -358,6 +358,10 @@ func (s *Server) buildRouter() *chi.Mux {
 	r.Post("/v1/ssm/command-invocation", s.handleSSMSeedCommandInvocation)
 	r.Delete("/v1/ssm/command-invocation", s.handleSSMClearCommandInvocation)
 
+	// IAM control-plane endpoints (#747).
+	r.Post("/v1/iam/slr-deletion-status", s.handleIAMSeedSLRDeletionStatus)
+	r.Delete("/v1/iam/slr-deletion-status", s.handleIAMClearSLRDeletionStatus)
+
 	// Organizations control-plane endpoints (#578).
 	r.Post("/v1/organizations/feature-set", s.handleOrganizationsSeedFeatureSet)
 	r.Delete("/v1/organizations/feature-set", s.handleOrganizationsClearFeatureSet)


### PR DESCRIPTION
`CreateServiceLinkedRole`, `DeleteServiceLinkedRole` and
`GetServiceLinkedRoleDeletionStatus` answered `InvalidAction`/400, which made **eleven of the
32 condition blocks** in the bundled managed-policy catalog unevaluatable — the largest single
group in the producerless-key census, all eleven turning on a parameter of an operation that
did not exist.

## Two producers, not one

IAM authorizes through two doors that would otherwise disagree — the one-ARN-two-answers class
of #411 — so this closes both:

- **The condition key.** `iamAuthzRequestContext` publishes `iam:AWSServiceName` at the generic
  gate; `authorizeWith` carries it at the handler. It reads either wire form (the query
  protocol's `Params` and the JSON protocol's `Body`), so a decision does not depend on which a
  caller chose.
- **The request resource.** Four of the eleven statements scope `Resource` to
  `arn:aws:iam::*:role/aws-service-role/…`, two of those to an exact ARN with no trailing `*`,
  none of which the flat `arn:aws:iam::<account>:*` every IAM request carried can match. All
  three operations now name a real ARN — including the status poll, whose `DeletionTaskId`
  embeds the service and the role, so its resource resolves with no state read and therefore
  still resolves after the role is gone.

Both halves are load-bearing, verified by disabling each in turn:

```
# gate arm off:   ... on resource: arn:aws:iam::123456789012:*
# key producer off: ... on resource: arn:aws:iam::123456789012:role/aws-service-role/lambda.amazonaws.com/AWSServiceRoleForLambda
```

`TestIAM_BundledPolicyGrantsCreateServiceLinkedRole` asserts both doors reach the same verdict
under AWSLambda_FullAccess, which is the only bundled statement granting the action — so the
allow is genuinely earned by the ARN *and* the condition.

The key is published for the create and the delete and **not** for the status operation,
matching where the Service Authorization Reference lists it. Publishing a key AWS does not is
the permissive direction.

## Refusals, none of them the obvious one

- A duplicate name is `InvalidInput`/400, not `EntityAlreadyExists` — the operation publishes
  four errors and that is not among them, so it cannot be a copy of `CreateRole`'s.
- A role that exists but is not service-linked is `NoSuchEntity`/404 on the delete (no
  `InvalidInput` is published there); the message says which.
- `DeleteRole` refuses a service-linked role with `UnmodifiableEntity` at HTTP **400** — not the
  409 its `DeleteConflict` arms use — without which `DeleteServiceLinkedRole` would be
  decorative.

## Seedable deletion outcome

`POST`/`DELETE /v1/iam/slr-deletion-status`, keyed by role name or `"*"`. The failure AWS
documents is a linked service still using the role, unreachable in an emulator that runs none.
The seed is read at **submission**, not at each poll, because only a `SUCCEEDED` task removes
the role record — the observable difference the two outcomes turn on.

## Provenance

The `AWSServiceRoleFor…` name is **substrate's convention, not AWS's rule**. AWS publishes no
derivation and the User Guide warns against inferring even the principal, so the table holds
exactly the six principals a bundled statement names inside a `Resource` and everything else is
derived (strip `.amazonaws.com`, title-case each segment). It is deliberately not padded with
the other well-known names: a guessed row would be indistinguishable from a cited one. One
bundled statement scopes a `Resource` around an untabled principal — AWSBatchFullAccess's
`arn:aws:iam::*:role/*Batch*` — and the derived `AWSServiceRoleForBatch` satisfies it because
that pattern is a contains-glob. `CustomSuffix` joins with `_`, which is observed behaviour.

## Out of scope, filed

IAM's general per-operation request resource is **#770**. This resolves only the
service-linked-role ARN it needs.

## Verification

`gofmt`/`go build`/`go vet`/`golangci-lint` clean (0 issues); `make test` and `make coverage`
pass with **emulator 83.4%, total 82.9%** (baseline held); `make docs-reference
docs-reference-check docs-versions` clean; vitepress build clean with an empty anchor diff;
`go vet -C test/e2e` and `go test -C test/e2e` pass.

Live fail-before/pass-after through the **AWS CLI** (the query protocol, so `Params` is
exercised): all three operations answered `InvalidAction` and the seed endpoint
`ServiceNotAvailable` on `main`; after, the create returns the role with its trust policy,
`DeleteRole` answers `UnmodifiableEntity`, a seeded `FAILED` reports its `Reason`/`RoleUsageList`
and leaves the role in place, a cleared seed deletes it and reports `SUCCEEDED`, and an unknown
task is `NoSuchEntity`.

Closes #747