### PR TITLE
feat(elb): tagging, and a producer for elasticloadbalancing:CreateAction (#748)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,6 +239,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rule — a verified key has proven the caller holds the secret — and the ARN still resolves
   to no policies. With `verify_signatures: false` the answer stays `…:root`.
 
+- **ELBv2 tagging, and with it the last of the seven bundled condition keys that had no
+  producer** (#748). `AddTags`, `RemoveTags` and `DescribeTags` did not exist, and the
+  `Tags.member.N` on each of the four creates was accepted and silently dropped — a
+  `CreateLoadBalancer` carrying tags answered success and produced an untagged load balancer.
+  The `Tags` field was dead on two of the four records and absent from the other two. All four
+  creates now store what they are given, and the three tagging operations reach all four
+  resource types.
+
+  The limits are the API model's: a key of 1–128 characters, a value of 0–256, both matching
+  `^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$`, 50 tags per resource with `aws:`-prefixed keys excluded
+  from the count — byte-for-byte the rule EC2 already implements, which is also what lets
+  CloudFormation's stamp coexist with a caller's own 50. `DescribeTags` takes at most 20
+  resources and `RemoveTags` at most 128 keys, each its own documented array maximum; the
+  128-key cap is per request and unrelated to the per-resource limit, since a key that is not
+  present is ignored rather than refused.
+
+  Per-operation error sets are followed rather than unified, because AWS's are not uniform.
+  `DuplicateTagKeys` is refused on `AddTags` and `CreateLoadBalancer` only — the two operations
+  that publish it — while `CreateTargetGroup`, `CreateListener` and `CreateRule` resolve a
+  repeated key last-wins, because inventing a code those three do not publish would send a
+  consumer's error branch down a path AWS never takes. An ARN naming nothing answers the code
+  for its type at HTTP **400**, which is ELB's own choice rather than the 404 a reader expects.
+
+  Two readings are substrate's. A call naming several resources applies to all of them or to
+  none — every ARN resolves before any write, so an `AddTags` naming one live and one absent
+  resource leaves the live one untouched; AWS documents no ordering here, and the alternative
+  is a partial write a caller cannot undo from the error alone, which is the same reasoning
+  `TerminateInstances` makes explicit. And a key beginning `aws:` is accepted: the restriction
+  is documented but no reachable page publishes a code for refusing one, so substrate excludes
+  the prefix from the count, as documented, and does not invent the refusal.
+
+  Authorization changes with it, in three ways. Every ELB request naming a resource by ARN —
+  `ResourceArns.member.N`, `LoadBalancerArn`, `TargetGroupArn`, `ListenerArn`, `RuleArn` — is
+  now decided against **that ARN**, where every ELB request was previously decided against the
+  literal string `*`. That is not a wildcard on the request side, so a statement scoped to one
+  load balancer's ARN matched nothing: an ARN-scoped `Allow` denied every call and an
+  ARN-scoped `Deny` was inert. A request naming several resources is denied unless every one is
+  allowed (#660's false-allow class). A resource's tags are reported under
+  `elasticloadbalancing:ResourceTag/<key>` as well as `aws:ResourceTag/<key>`, the guide's
+  "All mutating actions support this condition key" — on reads too, since a read reporting
+  fewer keys than a write could only make a condition on a describe unsatisfiable.
+
+  And a **tagged** create is authorized twice: AWS states that tags specified in a
+  resource-creating action require additional authorization on
+  `elasticloadbalancing:AddTags`, and that the second decision happens only when tags are
+  applied during the create. So each of the four creates carrying `Tags.member.N` is decided a
+  second time against that action with `elasticloadbalancing:CreateAction` set to the bare
+  operation name, and an untagged create needs no tagging grant at all. The second decision's
+  resource is the wildcard for the created type, which is substrate's reading on the same
+  reasoning as EC2's — the resource does not exist yet, and AWS's own examples write that
+  statement's `Resource` as `*` or a type wildcard. It reports no `aws:ResourceTag/*`, because a
+  condition about tags already on a resource that does not exist would otherwise be satisfied
+  by the tags being applied.
+
+  **The plan's provenance for `elasticloadbalancing:CreateAction` was wrong and the correction
+  is worth recording.** The key is absent from the ELB user guide's own list of ELB-specific
+  condition keys, and both Service Authorization Reference pages for ELB render their tables in
+  JavaScript and were unreachable — which made the bundled `AmazonECS_FullAccess` policy look
+  like the only citable source. It is not: the guide's "Tag your Elastic Load Balancing
+  resources during creation" page documents the key, the second `AddTags` authorization, and
+  the bare operation name as the value. Only the four values the bundled statement names come
+  from the policy.
+
+  Two gaps are deliberate and named in `docs/services.md`. `Names.member.N` on
+  `DescribeLoadBalancers` and `DescribeTargetGroups` is not resolved to an ARN, so those two
+  stay at `*` — whether ELB's describes support resource-level permissions is on the
+  unreachable pages, and leaving them alone is the direction that cannot invent a grant. And
+  substrate's listener and rule ARNs nest under the load balancer's where AWS mints flat ones
+  (#774); the tagging code accepts both shapes and the create pass authorizes against AWS's
+  spelling, so a policy written the way AWS writes one behaves correctly either way. The ELB
+  section's hand-written operation table was also five operations out of date and now lists all
+  23.
+
 ### Fixed
 - **A `${aws:username}` in a policy was compared as literal text** (#745). AWS substitutes a
   policy variable before it compares, so `arn:aws:s3:::home/${aws:username}/*` is the documented
@@ -422,6 +495,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no owner". A comment in the catalog claimed nothing rendered the member at all; it did. The
   owner is now omitted and the alias rendered in its place: Amazon's AMI-owning account varies
   by Region and AWS publishes no stable mapping, so it is not inventable.
+- **Six ELBv2 operations made the AWS CLI and boto3 raise `KeyError` on success** (#748).
+  ELBv2 speaks the Query protocol, where every output shape declares a `resultWrapper`, and
+  botocore looks that wrapper up by name in the parsed body. `DeleteLoadBalancer`,
+  `DeleteTargetGroup`, `DeleteListener`, `DeleteRule`, `RegisterTargets` and
+  `DeregisterTargets` answered a bare `<OperationResponse/>` with no result element, so a real
+  client raised `KeyError: 'DeleteLoadBalancerResult'` for a call that had in fact succeeded —
+  the state change landed and the caller saw a crash. Found by the live-CLI proof for this
+  release's ELB tagging work, which is also the only way it could be found: substrate's own
+  ELB tests read the response XML directly rather than through an SDK's parser, so all six
+  were green. The regression test now asserts the wire bytes, and the one place that builds
+  these responses is shared, so a seventh such operation cannot get it wrong.
 - **Four plugins were registered, unit-tested, and unreachable from a real AWS client**
   (#739). Substrate resolves which plugin serves a request by reducing four signals to one
   service name, and `X-Amz-Target` is checked first — so a namespace it does not recognize

--- a/docs/services.md
+++ b/docs/services.md
@@ -1447,7 +1447,7 @@ What has **no** producer, and therefore never matches on the enforcement path:
   would make it stable per-name rather than per-entity; `aws:PrincipalTag/` needs the
   principal's tags read where the credential is resolved, which is the cheaper of the two
   because `TagUser`/`TagRole` already record them.
-- Five of the seven keys the bundled AWS managed policies condition on, each for its own
+- Four of the seven keys the bundled AWS managed policies condition on, each for its own
   reason rather than as one omission:
 
   | Key | Blocks | Why it has no producer |
@@ -1456,15 +1456,25 @@ What has **no** producer, and therefore never matches on the enforcement path:
   | `codestar-notifications:NotificationsForResource` | 6 | No CodeStar Notifications plugin |
   | `aws:CalledViaLast` | 2 | `RequestContext` has no call-chain notion, and there is no service-to-service internal path to record one from |
   | `devops-guru:ServiceNames` | 2 | No DevOps Guru plugin |
-  | `elasticloadbalancing:CreateAction` | 1 | The ELB plugin has no tagging at all — no `AddTags`, and a load balancer's tags are never read or written — so the action the statement conditions does not exist |
 
-  Two now have one: `ec2:ResourceTag/<key>` (see [both
-  prefixes](#ec2-reports-a-resource-s-tags-under-both-prefixes)) and `iam:AWSServiceName`
-  (see [service-linked roles](#service-linked-roles-and-iam-awsservicename)). Between them
-  they were the largest group in the table — 11 of the 32 condition blocks turned on
+  Three now have one: `ec2:ResourceTag/<key>` (see [both
+  prefixes](#ec2-reports-a-resource-s-tags-under-both-prefixes)), `iam:AWSServiceName`
+  (see [service-linked roles](#service-linked-roles-and-iam-awsservicename)) and
+  `elasticloadbalancing:CreateAction` (see [ELB v2](#authorization)). Between them they
+  were the largest group in the table — 11 of the 32 condition blocks turned on
   `iam:AWSServiceName` alone — and each needed the same two things rather than one: a
   producer for the key, *and* a request resource specific enough for the statement's
-  `Resource` to match.
+  `Resource` to match. The ELB key needed a third: the tagging operations it conditions did
+  not exist, so the statement in `AmazonECS_FullAccess`'s `ELBTaggingPolicy` conditioned an
+  action no request could carry.
+
+  `elasticloadbalancing:CreateAction` was the one whose provenance looked thinnest and turned
+  out not to be. It is **absent** from the ELB user guide's own list of ELB-specific condition
+  keys, and both Service Authorization Reference pages for ELB render their key tables in
+  JavaScript and were unreachable — so the bundled managed policy read like the only citable
+  source. It is not: the guide's "Tag your Elastic Load Balancing resources during creation"
+  page documents the key, the `AddTags` second authorization it belongs to, and the bare
+  operation name as its value.
 
   Each remaining absence is a false deny in the safe direction: all 32 condition blocks in
   the bundled catalog sit on an `Allow`, so such a statement grants nothing rather than a
@@ -6403,21 +6413,160 @@ EC2 instance costs approximate on-demand pricing for the instance type.
 
 | Operation | Notes |
 |-----------|-------|
-| CreateLoadBalancer | ALB and NLB supported |
-| DescribeLoadBalancers | |
+| CreateLoadBalancer | ALB and NLB supported; accepts `Tags.member.N` |
+| DescribeLoadBalancers | `Names.member.N` and `LoadBalancerArns.member.N` |
 | DeleteLoadBalancer | |
-| CreateTargetGroup | |
+| DescribeLoadBalancerAttributes | |
+| ModifyLoadBalancerAttributes | |
+| CreateTargetGroup | Accepts `Tags.member.N` |
 | DescribeTargetGroups | |
 | DeleteTargetGroup | |
+| ModifyTargetGroup | |
 | RegisterTargets | |
 | DeregisterTargets | |
 | DescribeTargetHealth | |
-| CreateListener | |
+| CreateListener | Accepts `Tags.member.N` |
 | DescribeListeners | |
 | DeleteListener | |
-| CreateRule | |
+| ModifyListener | |
+| CreateRule | Accepts `Tags.member.N` |
 | DescribeRules | |
 | DeleteRule | |
+| SetRulePriorities | |
+| AddTags | Up to 50 user tags per resource |
+| RemoveTags | |
+| DescribeTags | At most 20 resources per request |
+
+Every operation whose output shape carries no members answers
+`<OperationResponse><OperationResult/></OperationResponse>`. The empty result element is not
+decoration: ELBv2 speaks the Query protocol, where each output shape declares a
+`resultWrapper`, and botocore looks that wrapper up by name — so a bare
+`<OperationResponse/>` makes the AWS CLI and boto3 raise `KeyError` rather than report
+success. `DeleteLoadBalancer`, `DeleteTargetGroup`, `DeleteListener`, `DeleteRule`,
+`RegisterTargets` and `DeregisterTargets` answered that way and were unusable from a real
+client while substrate's own tests passed, because those tests read the XML directly instead
+of through an SDK's parser.
+
+### Tagging
+
+The four creates above store the `Tags.member.N` they are given, and `AddTags`,
+`RemoveTags` and `DescribeTags` operate on all four resource types. Before this the
+parameter was accepted and silently dropped, and the three tagging operations did not
+exist — a `Tags` on a `CreateLoadBalancer` produced an untagged load balancer with no
+error.
+
+Limits and shapes come from the `Tag` type's API reference: a key is 1–128 characters, a
+value 0–256, both matching `^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$`, and a resource holds at most
+50 tags. **AWS contradicts itself on the lengths and substrate follows the model:** the ELB
+user guide's restrictions list says "Maximum key length—127 Unicode characters" and
+"Maximum value length—255", where the API model says 128 and 256. A caller who trusts the
+user guide's smaller numbers is inside substrate's limits either way. A violated constraint
+answers `ValidationError`/400: the constraints are the model's, but the model publishes no
+error code for breaking one, so the code is the common one a real service answers for a
+member outside its constraints and the message text is substrate's own.
+
+Per-operation error sets are followed rather than unified, because AWS's are not uniform:
+
+- `DuplicateTagKeys` is refused on **`AddTags` and `CreateLoadBalancer` only** — the two
+  operations whose Errors sections list it. On `CreateTargetGroup`, `CreateListener` and
+  `CreateRule` a repeated key resolves last-wins, because inventing a code those three do
+  not publish would send a consumer's error branch down a path AWS never triggers.
+- `TooManyTags` is published by `AddTags` and by all four creates, so every path that can
+  apply a tag can raise it.
+- An ARN naming nothing answers the code for its type — `LoadBalancerNotFound`,
+  `TargetGroupNotFound`, `ListenerNotFound` or `RuleNotFound` — each at **HTTP 400**, which
+  is the ELB API's own choice and not the 404 a reader expects. `TrustStoreNotFound`, the
+  fifth code those operations list, cannot occur: substrate models no trust store.
+- An ARN naming no ELB resource type at all answers `ValidationError`.
+
+Two readings are substrate's rather than AWS's published text, both recorded because a
+consumer can observe them:
+
+- **A tagging call naming several resources applies to all of them or to none.** Every ARN
+  is resolved before any write, so an `AddTags` naming one live load balancer and one absent
+  one leaves the live one untouched. AWS documents no ordering for ELB's multi-resource
+  tagging calls; the alternative is a partial write a caller cannot undo from the error
+  alone. This mirrors `TerminateInstances`, where AWS *does* document the whole-request
+  refusal.
+- **A tag key beginning `aws:` is accepted.** The restrictions list says "You can't edit or
+  delete tag names or values with this prefix", but no reachable page publishes a code for
+  that refusal, so substrate does not invent one. The prefix *is* excluded from the 50-tag
+  count, which the same list states ("Tags with this prefix do not count against your tags
+  per resource limit") and which is byte-for-byte the rule EC2 already implements. This is
+  also what lets CloudFormation's `aws:cloudformation:*` stamp coexist with a caller's own
+  50 tags.
+
+`RemoveTags` ignores a key that is not present — the operation publishes no error for one —
+and refuses more than 128 keys in one request, its own documented array maximum. That cap is
+per request and unrelated to the per-resource limit: a request may legally name more keys
+than any one resource holds.
+
+### Authorization
+
+Every ELB request naming a resource by ARN is now authorized **against that ARN**. The
+members read are `ResourceArns.member.N` (the three tagging operations, up to 20 of them)
+and `LoadBalancerArn`, `TargetGroupArn`, `ListenerArn` and `RuleArn`. Previously every ELB
+request was decided against the literal string `*`, which is not a wildcard on the request
+side: a statement scoped to one load balancer's ARN matched nothing, so an ARN-scoped
+`Allow` denied every call and an ARN-scoped `Deny` was inert. A request naming several
+resources is denied unless every one of them is allowed.
+
+An ARN that resolves to nothing in state is still the resource the decision is about, with
+no tags. Substituting `*` for it would let a bogus ARN reach a statement scoped to `*` that
+the real ARN would not have matched; the handler refuses it afterwards on its own terms.
+
+A resource's tags are reported under **both** `aws:ResourceTag/<key>` and
+`elasticloadbalancing:ResourceTag/<key>`. The service-specific prefix is the ELB user
+guide's: "The `elasticloadbalancing:ResourceTag/{{key}}` condition key is specific to
+Elastic Load Balancing. All mutating actions support this condition key." Substrate reports
+it on reads too, since a read reporting fewer keys than a write could only make a condition
+on a describe unsatisfiable.
+
+`aws:RequestTag/<key>` and `aws:TagKeys` are produced from `Tags.member.N` on `AddTags` and
+on the four creates, and from `TagKeys.member.N` on `RemoveTags`. A removal supplies no
+value, so the key is recorded with an empty one — indistinguishable from absent to every
+condition operator, while still reaching `aws:TagKeys`, which is what a "may only remove
+approved tags" policy is written against.
+
+**A tagged create is authorized twice.** AWS: "If tags are specified in the resource-creating
+action, additional authorization is required on the `elasticloadbalancing:AddTags` action to
+verify if users have permissions to apply tags to the resources being created." So each of
+the four creates, when it carries `Tags.member.N`, is decided a second time against
+`elasticloadbalancing:AddTags` with `elasticloadbalancing:CreateAction` set to the bare
+operation name — and an untagged create needs no tagging grant at all, which is the converse
+AWS states explicitly. The second decision's resource is the wildcard for the created type
+(`…:loadbalancer/*`, `…:targetgroup/*`, `…:listener/*`, `…:listener-rule/*`); **that is
+substrate's reading**, on the same reasoning as EC2's — the resource does not exist yet, and
+AWS's own example policies write the `AddTags` statement's Resource as `*` or as a type
+wildcard. The pass runs after the create's own decision, honours a permission boundary, and
+does not report `aws:ResourceTag/*`: a condition about tags already on a resource that does
+not exist yet is unsatisfiable, and fabricating one would let the tags being applied stand
+in for tags already present.
+
+Provenance for `elasticloadbalancing:CreateAction`: it is documented on the ELB user guide's
+"Tag your Elastic Load Balancing resources during creation" page, which is also where the
+two quotations above come from, and it is **absent** from the same guide's own list of
+ELB-specific condition keys (which names `ListenerProtocol`, `SecurityPolicy`, `Scheme`,
+`SecurityGroup`, `Subnet` and `ResourceTag`). Both Service Authorization Reference pages for
+ELB render their key tables in JavaScript and were unreachable. The value is the bare
+operation name — AWS's examples write `"elasticloadbalancing:CreateAction": "CreateTargetGroup"`
+— not a service-prefixed action. The bundled `AmazonECS_FullAccess` policy's
+`ELBTaggingPolicy` statement names four values: `CreateTargetGroup`, `CreateRule`,
+`CreateListener` and `CreateLoadBalancer`.
+
+Two deliberate gaps:
+
+- **`Names.member.N` on `DescribeLoadBalancers` and `DescribeTargetGroups` is not resolved
+  to an ARN**, so those two requests are still decided against `*`. Whether ELB's describes
+  support resource-level permissions could not be verified — the pages that would say are
+  the unreachable ones above — and leaving them at `*` is the direction that cannot invent a
+  grant.
+- Substrate's listener and rule ARNs nest under the load balancer's
+  (`…:loadbalancer/app/<name>/<id>/listener/<suffix>`) where AWS mints flat
+  `…:listener/app/<name>/<id>/<suffix>` and `…:listener-rule/…` forms. The tagging code
+  accepts **both** shapes, and the tag-on-create pass authorizes against AWS's spelling, so a
+  policy written the way AWS writes one behaves correctly regardless. The ARN shape itself is
+  [#774](https://github.com/scttfrdmn/substrate/issues/774).
 
 ### CloudFormation resource types
 
@@ -6427,6 +6576,9 @@ EC2 instance costs approximate on-demand pricing for the instance type.
 | AWS::ElasticLoadBalancingV2::TargetGroup | TargetGroupArn | |
 | AWS::ElasticLoadBalancingV2::Listener | ListenerArn | |
 | AWS::ElasticLoadBalancingV2::ListenerRule | RuleArn | |
+
+The deployer does not send `Tags` for any of the four, so a template's resource tags are
+still dropped — as is the `aws:cloudformation:*` stamp, whose first cut covers EC2 only.
 
 ### Cost
 

--- a/emulator/authz.go
+++ b/emulator/authz.go
@@ -283,8 +283,14 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 	}
 
 	// The create is allowed. If it also applies tags, AWS authorizes those separately
-	// against ec2:CreateTags, and the caller needs that permission too (#691).
-	return a.checkEC2TagOnCreate(reqCtx, req, docs, boundary, requestTags, deniedCode, now, haveClock)
+	// against the service's tagging action, and the caller needs that permission too —
+	// ec2:CreateTags (#691) and elasticloadbalancing:AddTags (#748). Each pass answers nil
+	// for a request of the other's service, so the two are chained rather than switched on
+	// here, and a third service arriving adds a line rather than a branch.
+	if err := a.checkEC2TagOnCreate(reqCtx, req, docs, boundary, requestTags, deniedCode, now, haveClock); err != nil {
+		return err
+	}
+	return a.checkELBTagOnCreate(reqCtx, req, docs, boundary, requestTags, deniedCode, now, haveClock)
 }
 
 // checkEC2TagOnCreate runs the second authorization pass AWS performs on
@@ -377,6 +383,82 @@ func (a *AuthController) checkEC2TagOnCreate(reqCtx *RequestContext, req *AWSReq
 					reqCtx.Principal.ARN, ec2CreateTagsAction),
 				HTTPStatus: http.StatusForbidden,
 			}
+		}
+	}
+	return nil
+}
+
+// checkELBTagOnCreate runs the second authorization pass AWS performs on
+// elasticloadbalancing:AddTags when an ELBv2 create applies tags, returning nil when the
+// request applies none or when the caller is permitted to apply them.
+//
+// AWS: "If tags are specified in the resource-creating action, additional authorization is
+// required on the elasticloadbalancing:AddTags action to verify if users have permissions
+// to apply tags to the resources being created." Substrate authorized a tagged ELB create
+// as the creating action alone, so the bundled ELBTaggingPolicy — whose whole content is a
+// separate AddTags statement conditioned on elasticloadbalancing:CreateAction — permitted
+// more than it says.
+//
+// It mirrors [AuthController.checkEC2TagOnCreate] deliberately, because AWS documents the
+// two mechanisms in the same terms, but it is a copy rather than a shared helper: the
+// action, the condition key, the request member the tags arrive under and the resource ARN
+// are all service-specific, and folding them into one function would take four parameters
+// to express two behaviors. The two differences that are not cosmetic are that an ELB
+// create makes one resource rather than a list, and that ELB has no launch-template
+// equivalent — every tag it evaluates is in the request, so requestTags is the whole set.
+func (a *AuthController) checkELBTagOnCreate(reqCtx *RequestContext, req *AWSRequest,
+	docs []PolicyDocument, boundary *PolicyDocument, requestTags map[string]string, deniedCode string,
+	now time.Time, haveClock bool) error {
+	if req.Service != elbServiceName {
+		return nil
+	}
+	arn := elbAuthzCreateTagsPass(reqCtx, req)
+	if arn == "" {
+		return nil
+	}
+
+	condCtx := make(map[string]string, len(requestTags)+1)
+	for k, v := range requestTags {
+		condCtx[k] = v
+	}
+	// The key that separates tagging during a create from standalone tagging, set only
+	// here — which is what makes the bundled policy's StringEquals mean what it says, and
+	// what keeps a direct AddTags from satisfying it.
+	condCtx[elbCreateActionCondKey] = req.Operation
+	a.authzTimeContext(condCtx, now, haveClock)
+	// Same request, same caller, so this door must name the same principal as the primary
+	// decision; see checkEC2TagOnCreate (#714).
+	authzPrincipalContext(condCtx, reqCtx.Principal)
+
+	tagKeysMulti := make(map[string][]string, 1)
+	if keys := requestTagKeys(condCtx); len(keys) > 0 {
+		tagKeysMulti["aws:TagKeys"] = keys
+	}
+
+	// No aws:ResourceTag/* or elasticloadbalancing:ResourceTag/*: the resource does not
+	// exist yet, so a condition about tags already on it is unsatisfiable, and fabricating
+	// one would let the tags being applied stand in for tags already present.
+	evalReq := EvaluationRequest{
+		Principal:    reqCtx.Principal.ARN,
+		Action:       elbAddTagsAction,
+		Resource:     arn,
+		Context:      condCtx,
+		MultiContext: tagKeysMulti,
+	}
+	if Evaluate(docs, evalReq).Decision != DecisionAllow {
+		return &AWSError{
+			Code: deniedCode,
+			Message: fmt.Sprintf("User: %s is not authorized to perform: %s on resource: %s",
+				reqCtx.Principal.ARN, elbAddTagsAction, arn),
+			HTTPStatus: http.StatusForbidden,
+		}
+	}
+	if boundary != nil && Evaluate([]PolicyDocument{*boundary}, evalReq).Decision != DecisionAllow {
+		return &AWSError{
+			Code: deniedCode,
+			Message: fmt.Sprintf("User: %s is not authorized to perform: %s (blocked by permission boundary)",
+				reqCtx.Principal.ARN, elbAddTagsAction),
+			HTTPStatus: http.StatusForbidden,
 		}
 	}
 	return nil
@@ -823,6 +905,11 @@ func (a *AuthController) buildResourceARNs(reqCtx *RequestContext, req *AWSReque
 			return multi
 		}
 	}
+	if req.Service == elbServiceName {
+		if multi := elbAuthzResources(a.state, reqCtx, req); len(multi) > 0 {
+			return multi
+		}
+	}
 	return []authzResource{{
 		ARN:  a.buildResourceARN(reqCtx, req),
 		Tags: a.resourceTagsFor(reqCtx, req),
@@ -1016,8 +1103,17 @@ const authzAWSResourceTagPrefix = "aws:ResourceTag/"
 // and a policy that happened to use it would then be honored here and ignored by AWS —
 // a divergence in the more dangerous direction, since it grants.
 func authzResourceTagPrefixes(service string) []string {
-	if service == "ec2" {
+	switch service {
+	case "ec2":
 		return []string{authzAWSResourceTagPrefix, "ec2:ResourceTag/"}
+	case elbServiceName:
+		// ELB is the other: "The elasticloadbalancing:ResourceTag/{{key}} condition key is
+		// specific to Elastic Load Balancing. All mutating actions support this condition
+		// key" (#748). Substrate reports it on every ELB action rather than only the
+		// mutating ones, because a read reporting fewer keys than a write could only make a
+		// condition on a describe unsatisfiable, and AWS's own list of what counts as
+		// mutating is not published operation by operation.
+		return []string{authzAWSResourceTagPrefix, elbResourceTagPrefix}
 	}
 	return []string{authzAWSResourceTagPrefix}
 }
@@ -1245,6 +1341,16 @@ func addRequestTags(condCtx map[string]string, req *AWSRequest) {
 		// Reference, which is what makes a "may only apply approved tags" policy
 		// expressible here.
 		for k, v := range cfgsvcAuthzRequestTags(req) {
+			condCtx["aws:RequestTag/"+k] = v
+		}
+
+	case elbServiceName:
+		// ELB tags arrive as query params — Tags.member.N.Key / .Value on AddTags and on
+		// each of the four creates, TagKeys.member.N on RemoveTags — so one reader serves
+		// all six (#748). Without this, aws:RequestTag/* and aws:TagKeys were empty for
+		// every ELB call, so the tag-on-create pass below could not evaluate the key set
+		// that is the whole point of the second decision.
+		for k, v := range elbAuthzRequestTags(req) {
 			condCtx["aws:RequestTag/"+k] = v
 		}
 

--- a/emulator/elb_authz.go
+++ b/emulator/elb_authz.go
@@ -1,0 +1,251 @@
+package emulator
+
+import (
+	"context"
+	"fmt"
+)
+
+// elbServiceName is the service an ELBv2 request carries, which is [ELBPlugin.Name] and
+// the prefix of every elasticloadbalancing: action.
+//
+// It is deliberately not [elbNamespace]: that is the shorter "elb" the state keys are
+// written under, and using it to switch on req.Service would match nothing.
+const elbServiceName = "elasticloadbalancing"
+
+// elbCreateActionCondKey is the condition key that tells an
+// elasticloadbalancing:AddTags statement which creating operation the tags are being
+// applied by.
+//
+// AWS: "In the IAM policy definition for the elasticloadbalancing:AddTags action, you
+// can use the Condition element with the elasticloadbalancing:CreateAction condition key
+// to give tagging permissions to the action that creates the resource." It is a
+// request-level key, so it lives in the condition context beside aws:RequestTag/* rather
+// than on a resource — and it is **absent** from a direct AddTags, which is what makes
+// the bundled ELBTaggingPolicy mean what it says.
+//
+// Provenance: the key is documented in the ELB user guide's "Tag resources during
+// creation" page and is **not** in the same guide's own list of ELB-specific condition
+// keys (which names ListenerProtocol, SecurityPolicy, Scheme, SecurityGroup, Subnet and
+// ResourceTag). Both Service Authorization Reference pages for ELB render their key table
+// in JavaScript and were unreachable. The value is the bare operation name —
+// AWS's examples write "elasticloadbalancing:CreateAction": "CreateTargetGroup" — not a
+// service-prefixed action.
+const elbCreateActionCondKey = "elasticloadbalancing:CreateAction"
+
+// elbAddTagsAction is the action a tagged create is authorized against a second time.
+const elbAddTagsAction = "elasticloadbalancing:AddTags"
+
+// elbResourceTagPrefix is the service-specific duplicate of aws:ResourceTag/ that ELB
+// publishes.
+//
+// AWS: "The elasticloadbalancing:ResourceTag/{{key}} condition key is specific to Elastic
+// Load Balancing. All mutating actions support this condition key." A policy written the
+// way AWS writes it sees nothing unless a resource's tags are reported under this prefix
+// too; see [authzResourceTagPrefixes].
+const elbResourceTagPrefix = "elasticloadbalancing:ResourceTag/"
+
+// elbAuthzARNParams are the request members that name an ELB resource by ARN, in the
+// order they are resolved.
+//
+// ResourceArns.member.N is first because it is the plural one — the three tagging
+// operations name up to 20 resources through it, and each must be allowed. The four
+// singular members follow; no ELB operation carries two of them, so their relative order
+// is inert today and fixed anyway, so a denial names the same resource on every run.
+//
+// Deliberately absent: `Names.member.N` on DescribeLoadBalancers and
+// DescribeTargetGroups, which names resources by name rather than ARN. Resolving those
+// would put the two describes on a resource-scoped path, and whether ELB's describes
+// support resource-level permissions could not be verified — the Service Authorization
+// Reference pages that would say are JavaScript-rendered and unreachable. Leaving them
+// at "*" is the direction that cannot invent a grant.
+var elbAuthzARNParams = []string{
+	"LoadBalancerArn",
+	"TargetGroupArn",
+	"ListenerArn",
+	"RuleArn",
+}
+
+// elbAuthzResources returns every ELB resource the request names by ARN, each paired
+// with its own tags, or nil when it names none.
+//
+// Before this, every ELB request was authorized against `*` — the default arm of
+// [AuthController.buildResourceARN] — so a policy scoped to one load balancer's ARN
+// matched nothing at all ([resourceMatches] compares a statement's Resource against the
+// request's resource string, and `*` is a literal there). A caller holding
+// `elasticloadbalancing:DeleteLoadBalancer` on one ARN was refused on every ARN, and a
+// tag-scoped condition had no tags to read. Both are fixed by naming the resource the
+// request actually names, which is the same correction #744 made for EC2 and #660 for
+// Organizations.
+//
+// A named ARN that resolves to nothing in state is still returned, with no tags: the
+// resource the request names is the resource the decision is about, and substituting `*`
+// for an unknown ARN would let a bogus ARN reach a statement scoped to `*` that the real
+// one would not have matched. The handler refuses it afterwards on its own terms.
+func elbAuthzResources(state StateManager, reqCtx *RequestContext, req *AWSRequest) []authzResource {
+	arns := extractIndexedParams(req.Params, "ResourceArns.member")
+	for _, param := range elbAuthzARNParams {
+		if arn := req.Params[param]; arn != "" {
+			arns = append(arns, arn)
+		}
+	}
+	if len(arns) == 0 {
+		return nil
+	}
+
+	scope := reqCtx.AccountID + "/" + reqCtx.Region
+	out := make([]authzResource, 0, len(arns))
+	for _, arn := range arns {
+		out = append(out, authzResource{ARN: arn, Tags: elbAuthzTagsFor(state, scope, arn)})
+	}
+	return out
+}
+
+// elbAuthzTagsFor reads the tags on one ELB resource, or nil when the ARN names nothing
+// or the read fails.
+//
+// A failed read is nil rather than an error for the same reason the tag readers in
+// [AuthController.resourceTagsFor] are: a condition on a tag that cannot be read is
+// unsatisfied, which denies, and that is the safe direction.
+func elbAuthzTagsFor(state StateManager, scope, arn string) map[string]string {
+	res, awsErr, err := elbResolveTaggedResource(state, scope, arn)
+	if err != nil || awsErr != nil || res == nil {
+		return nil
+	}
+	return elbTagsToMap(res.tags)
+}
+
+// elbTagsToMap converts []ELBTag to a map[string]string.
+func elbTagsToMap(tags []ELBTag) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+	m := make(map[string]string, len(tags))
+	for _, t := range tags {
+		m[t.Key] = t.Value
+	}
+	return m
+}
+
+// elbCreateResourceKinds maps each creating operation to the ARN resource type the tags
+// it applies land on.
+//
+// These are the four operations the bundled ELBTaggingPolicy names in its
+// elasticloadbalancing:CreateAction condition, which is also every ELBv2 operation
+// accepting Tags.member.N. The listener and rule types are AWS's own spellings rather
+// than the ones substrate's ARNs carry; see [elbKindListener] and #774.
+var elbCreateResourceKinds = map[string]string{
+	"CreateLoadBalancer": elbKindLoadBalancer,
+	"CreateTargetGroup":  elbKindTargetGroup,
+	"CreateListener":     elbKindListener,
+	"CreateRule":         elbKindRule,
+}
+
+// elbAuthzCreateTagsPass returns the resource ARN a tagged create must additionally be
+// authorized against on elasticloadbalancing:AddTags, or "" when the request needs no
+// such pass.
+//
+// AWS: "If tags are specified in the resource-creating action, additional authorization
+// is required on the elasticloadbalancing:AddTags action to verify if users have
+// permissions to apply tags to the resources being created." And the converse, which is
+// why this can answer "": "The elasticloadbalancing:AddTags action is only evaluated if
+// tags are applied during the resource-creating action. Therefore, a user that has
+// permissions to create a resource … does not require permissions to use the
+// elasticloadbalancing:AddTags action if no tags are specified in the request."
+//
+// The ARN is the wildcard for the created resource's type —
+// arn:aws:elasticloadbalancing:<region>:<account>:<type>/*. **That is substrate's
+// reading**, on the same reasoning as [ec2CreateTagsPass.resourceARNs]: the resource does
+// not exist yet, and AWS's own example policies for this key write the Resource of the
+// AddTags statement as `*` or as a type wildcard, so resolving it to anything narrower
+// would make those policies mean something else. Unlike EC2 a create here makes one
+// resource of one type, so there is one ARN rather than a list.
+func elbAuthzCreateTagsPass(reqCtx *RequestContext, req *AWSRequest) string {
+	kind, ok := elbCreateResourceKinds[req.Operation]
+	if !ok {
+		return ""
+	}
+	if len(extractELBTags(req.Params, "Tags.member")) == 0 {
+		return ""
+	}
+	return "arn:aws:elasticloadbalancing:" + reqCtx.Region + ":" + reqCtx.AccountID + ":" + kind + "/*"
+}
+
+// elbTagsForCreate validates the Tags.member.N a create carries and returns the tag set
+// to store on the new resource.
+//
+// It is called by each of the four creates before the record is written, so a tag the
+// request cannot legally apply refuses the create rather than leaving a resource behind
+// carrying it — the rollback rule [ec2CheckReservedTagKeys] documents. The tags are
+// returned rather than written, because the create is what writes the record.
+//
+// refuseDuplicateKeys is a parameter rather than a rule because AWS makes it one:
+// DuplicateTagKeys is listed on CreateLoadBalancer and on none of CreateTargetGroup,
+// CreateListener or CreateRule. Passing false is what keeps substrate from inventing a
+// code three of the four do not publish; the duplicate then resolves last-wins through
+// [elbMergeTags], which is the only other thing it can do.
+func elbTagsForCreate(req *AWSRequest, refuseDuplicateKeys bool) ([]ELBTag, *AWSError) {
+	tags := extractELBTags(req.Params, "Tags.member")
+	if len(tags) == 0 {
+		return nil, nil
+	}
+	if refuseDuplicateKeys {
+		if awsErr := elbCheckDuplicateTagKeys(tags); awsErr != nil {
+			return nil, awsErr
+		}
+	}
+	if awsErr := elbCheckCreateTags(tags); awsErr != nil {
+		return nil, awsErr
+	}
+	return elbMergeTags(nil, tags), nil
+}
+
+// elbLoadTagsByARN reads a resource's tags straight from state, for the tests that
+// assert what a create or a tagging call persisted.
+func elbLoadTagsByARN(state StateManager, scope, arn string) ([]ELBTag, error) {
+	kind := elbResourceKindFromARN(arn)
+	if kind == "" {
+		return nil, fmt.Errorf("elb load tags: %q names no ELB resource type", arn)
+	}
+	keys, err := state.List(context.Background(), elbNamespace, elbStateKeyPrefix(kind, scope))
+	if err != nil {
+		return nil, fmt.Errorf("elb load tags list: %w", err)
+	}
+	for _, k := range keys {
+		data, getErr := state.Get(context.Background(), elbNamespace, k)
+		if getErr != nil || data == nil {
+			continue
+		}
+		res := elbDecodeTaggedResource(kind, k, data)
+		if res == nil || res.arn != arn {
+			continue
+		}
+		return res.tags, nil
+	}
+	return nil, fmt.Errorf("elb load tags: %q names nothing in state", arn)
+}
+
+// elbAuthzRequestTags reads the tags a request asks to apply or remove, for
+// [addRequestTags].
+//
+// AddTags and the four creates all spell them Tags.member.N.Key / .Value, so one reader
+// serves all five. RemoveTags names keys under TagKeys.member.N and supplies no values,
+// and those are recorded with an empty value — the same reading substrate already applies
+// to EC2's DeleteTags, and for the same reason: [conditionMatches] reads an absent key as
+// the empty string too, so the two are indistinguishable to every operator, while the key
+// still reaches aws:TagKeys, which is what a "may only remove approved tags" policy is
+// written against.
+func elbAuthzRequestTags(req *AWSRequest) map[string]string {
+	tags := extractELBTags(req.Params, "Tags.member")
+	keys := extractIndexedParams(req.Params, "TagKeys.member")
+	if len(tags) == 0 && len(keys) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(tags)+len(keys))
+	for _, t := range tags {
+		out[t.Key] = t.Value
+	}
+	for _, k := range keys {
+		out[k] = ""
+	}
+	return out
+}

--- a/emulator/elb_authz_test.go
+++ b/emulator/elb_authz_test.go
@@ -1,0 +1,657 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// The authorization decision for ELBv2 (#748), which had two defects at once.
+//
+// Every ELB request was decided against the literal string "*" — the default arm of
+// buildResourceARN — so a policy scoped to one load balancer's ARN matched nothing:
+// resourceMatches passes the *statement's* Resource to globMatch as the pattern, so a
+// request resource of "*" matches only a statement whose Resource itself begins with "*".
+// An ARN-scoped Allow therefore denied every call and an ARN-scoped Deny was inert.
+//
+// And a tagged create was authorized as the creating action alone, so AWS's documented
+// tag-on-create grant — which is what the bundled ELBTaggingPolicy statement *is* —
+// permitted more than it says.
+
+const (
+	elbAuthzAccount = "123456789012"
+	elbAuthzRegion  = "us-east-1"
+)
+
+// The ARNs the fixture's resources carry, in substrate's own shapes. The listener and rule
+// ARNs nest under the load balancer's (#774); the tagging code accepts AWS's flat spelling
+// too, which elb_tags_test.go pins.
+var (
+	elbAuthzLBARN       = "arn:aws:elasticloadbalancing:" + elbAuthzRegion + ":" + elbAuthzAccount + ":loadbalancer/app/web/0abc111"
+	elbAuthzTGARN       = "arn:aws:elasticloadbalancing:" + elbAuthzRegion + ":" + elbAuthzAccount + ":targetgroup/web-tg/0def222"
+	elbAuthzListenerARN = elbAuthzLBARN + "/listener/0aaa333"
+	elbAuthzRuleARN     = elbAuthzListenerARN + "/rule/0bbb444"
+
+	// The type wildcards a tagged create's second pass is authorized against, which are
+	// AWS's ARN resource types rather than substrate's nesting.
+	elbAuthzLBWildcard       = "arn:aws:elasticloadbalancing:" + elbAuthzRegion + ":" + elbAuthzAccount + ":loadbalancer/*"
+	elbAuthzTGWildcard       = "arn:aws:elasticloadbalancing:" + elbAuthzRegion + ":" + elbAuthzAccount + ":targetgroup/*"
+	elbAuthzListenerWildcard = "arn:aws:elasticloadbalancing:" + elbAuthzRegion + ":" + elbAuthzAccount + ":listener/*"
+	elbAuthzRuleWildcard     = "arn:aws:elasticloadbalancing:" + elbAuthzRegion + ":" + elbAuthzAccount + ":listener-rule/*"
+)
+
+// elbAuthzFixture is an ELB state store plus an AuthController over the same store, which
+// is what makes a resource-tag condition testable: the tag has to travel from the elb
+// namespace into the condition context under the ARN it belongs to.
+type elbAuthzFixture struct {
+	state emulator.StateManager
+	auth  *emulator.AuthController
+	user  string
+}
+
+// newELBAuthzFixture builds a user carrying one policy plus a load balancer, target group,
+// listener and rule, each optionally tagged.
+//
+// Records are written directly rather than through the plugin: the decision reads state,
+// and a create call would drag its own authorization into the fixture for it.
+func newELBAuthzFixture(t *testing.T, user string, doc emulator.PolicyDocument) *elbAuthzFixture {
+	t.Helper()
+	policyARN := "arn:aws:iam::" + elbAuthzAccount + ":policy/ELB-" + user
+	state := newAuthTestState(t, user, policyARN, doc)
+	f := &elbAuthzFixture{
+		state: state,
+		auth:  emulator.NewAuthController(state, emulator.NewDefaultLogger(slog.LevelError, false)),
+		user:  user,
+	}
+	f.putLoadBalancer(t, nil)
+	f.putTargetGroup(t, nil)
+	f.putListener(t, nil)
+	f.putRule(t, nil)
+	return f
+}
+
+// elbAuthzScope is the account/region segment every ELB state key carries.
+func elbAuthzScope() string { return elbAuthzAccount + "/" + elbAuthzRegion }
+
+// put writes one ELB record under key.
+func (f *elbAuthzFixture) put(t *testing.T, key string, record any) {
+	t.Helper()
+	raw, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("marshal %s: %v", key, err)
+	}
+	if err := f.state.Put(context.Background(), "elb", key, raw); err != nil { //nolint:contextcheck
+		t.Fatalf("store %s: %v", key, err)
+	}
+}
+
+func (f *elbAuthzFixture) putLoadBalancer(t *testing.T, tags map[string]string) {
+	t.Helper()
+	f.put(t, "lb:"+elbAuthzScope()+"/web", emulator.ELBLoadBalancer{
+		Name:      "web",
+		ARN:       elbAuthzLBARN,
+		Type:      "application",
+		AccountID: elbAuthzAccount,
+		Region:    elbAuthzRegion,
+		Tags:      elbAuthzTags(tags),
+	})
+}
+
+func (f *elbAuthzFixture) putTargetGroup(t *testing.T, tags map[string]string) {
+	t.Helper()
+	f.put(t, "tg:"+elbAuthzScope()+"/web-tg", emulator.ELBTargetGroup{
+		Name:      "web-tg",
+		ARN:       elbAuthzTGARN,
+		Protocol:  "HTTP",
+		Port:      80,
+		AccountID: elbAuthzAccount,
+		Region:    elbAuthzRegion,
+		Tags:      elbAuthzTags(tags),
+	})
+}
+
+func (f *elbAuthzFixture) putListener(t *testing.T, tags map[string]string) {
+	t.Helper()
+	f.put(t, "listener:"+elbAuthzScope()+"/0aaa333", emulator.ELBListener{
+		ARN:             elbAuthzListenerARN,
+		LoadBalancerARN: elbAuthzLBARN,
+		Protocol:        "HTTP",
+		Port:            80,
+		AccountID:       elbAuthzAccount,
+		Region:          elbAuthzRegion,
+		Suffix:          "0aaa333",
+		Tags:            elbAuthzTags(tags),
+	})
+}
+
+func (f *elbAuthzFixture) putRule(t *testing.T, tags map[string]string) {
+	t.Helper()
+	f.put(t, "rule:"+elbAuthzScope()+"/0bbb444", emulator.ELBRule{
+		ARN:         elbAuthzRuleARN,
+		ListenerARN: elbAuthzListenerARN,
+		Priority:    "10",
+		AccountID:   elbAuthzAccount,
+		Region:      elbAuthzRegion,
+		Suffix:      "0bbb444",
+		Tags:        elbAuthzTags(tags),
+	})
+}
+
+// elbAuthzTags converts a map to the []ELBTag shape the records store.
+func elbAuthzTags(tags map[string]string) []emulator.ELBTag {
+	if len(tags) == 0 {
+		return nil
+	}
+	out := make([]emulator.ELBTag, 0, len(tags))
+	for k, v := range tags {
+		out = append(out, emulator.ELBTag{Key: k, Value: v})
+	}
+	return out
+}
+
+// call runs one ELB request through the authorization decision.
+//
+// Params, not Body: ELBv2 is a query-protocol service, so every resource a request names
+// arrives as a form parameter.
+func (f *elbAuthzFixture) call(t *testing.T, operation string, params map[string]string) error {
+	t.Helper()
+	reqCtx := newAuthTestReqCtx("arn:aws:iam::" + elbAuthzAccount + ":user/" + f.user)
+	return f.auth.CheckAccess(reqCtx, &emulator.AWSRequest{
+		Service:   "elasticloadbalancing",
+		Operation: operation,
+		Path:      "/",
+		Params:    params,
+	})
+}
+
+// setPolicy rewrites the user's single attached policy so its statements are exactly those
+// given, which is how a test scopes a decision to a list of ARNs rather than to "*".
+func (f *elbAuthzFixture) setPolicy(t *testing.T, statements ...emulator.PolicyStatement) {
+	t.Helper()
+	arn := "arn:aws:iam::" + elbAuthzAccount + ":policy/ELB-" + f.user
+	pol := emulator.IAMPolicy{
+		PolicyName:       "elb",
+		PolicyID:         "ANPAELB",
+		ARN:              arn,
+		Path:             "/",
+		DefaultVersionID: "v1",
+		IsAttachable:     true,
+		Document:         emulator.PolicyDocument{Version: "2012-10-17", Statement: statements},
+	}
+	raw, err := json.Marshal(pol)
+	if err != nil {
+		t.Fatalf("marshal policy: %v", err)
+	}
+	if err := f.state.Put(context.Background(), "iam", emulator.IAMPolicyKeyForTest(arn), raw); err != nil { //nolint:contextcheck
+		t.Fatalf("store policy: %v", err)
+	}
+}
+
+// attachManagedPolicy points the user's attached-policy list at an AWS-managed ARN, so a
+// test can run one of the policies substrate bundles rather than a hand-written copy of it.
+func (f *elbAuthzFixture) attachManagedPolicy(t *testing.T, arn string) {
+	t.Helper()
+	raw, err := json.Marshal([]string{arn})
+	if err != nil {
+		t.Fatalf("marshal attached policies: %v", err)
+	}
+	key := emulator.IAMAttachedPoliciesKeyForTest(elbAuthzAccount, "user", f.user)
+	if err := f.state.Put(context.Background(), "iam", key, raw); err != nil { //nolint:contextcheck
+		t.Fatalf("store attached policies: %v", err)
+	}
+}
+
+// elbAuthzAllow builds one Allow statement over the given action and resources.
+func elbAuthzAllow(action string, resources ...string) emulator.PolicyStatement {
+	return emulator.PolicyStatement{
+		Effect:   "Allow",
+		Action:   emulator.StringOrSlice{action},
+		Resource: emulator.StringOrSlice(resources),
+	}
+}
+
+// elbAuthzAllowCond is elbAuthzAllow with a condition block.
+func elbAuthzAllowCond(action string, resources []string,
+	cond map[string]map[string]emulator.StringOrSlice) emulator.PolicyStatement {
+	stmt := elbAuthzAllow(action, resources...)
+	stmt.Condition = cond
+	return stmt
+}
+
+// elbCreateActionAllow is AWS's documented tagging grant, and the shape of the bundled
+// ELBTaggingPolicy statement: elasticloadbalancing:AddTags, but only in the context of the
+// named creating action.
+func elbCreateActionAllow(createActions ...string) emulator.PolicyStatement {
+	return elbAuthzAllowCond("elasticloadbalancing:AddTags", []string{"*"},
+		map[string]map[string]emulator.StringOrSlice{
+			"StringEquals": {"elasticloadbalancing:CreateAction": emulator.StringOrSlice(createActions)},
+		})
+}
+
+// elbAuthzTagParams returns the Tags.member.N params carrying kv pairs, in the wire
+// spelling ELB's query protocol uses.
+func elbAuthzTagParams(kv ...string) map[string]string {
+	out := make(map[string]string, len(kv))
+	for i := 0; i+1 < len(kv); i += 2 {
+		n := strconv.Itoa(i/2 + 1)
+		out["Tags.member."+n+".Key"] = kv[i]
+		out["Tags.member."+n+".Value"] = kv[i+1]
+	}
+	return out
+}
+
+// elbAuthzParams merges extra maps into a copy of base.
+func elbAuthzParams(base map[string]string, extra ...map[string]string) map[string]string {
+	out := make(map[string]string, len(base)+4)
+	for k, v := range base {
+		out[k] = v
+	}
+	for _, m := range extra {
+		for k, v := range m {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// TestELB_Authz_ResourceScopedPolicyMatchesTheNamedARN is the first half of #748: a policy
+// naming one resource's ARN now decides the request that names it.
+//
+// Before this the request resource was the literal "*", so each of these rows denied — the
+// Allow never matched the resource it was written about.
+func TestELB_Authz_ResourceScopedPolicyMatchesTheNamedARN(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation string
+		params    map[string]string
+		action    string
+		resource  string
+	}{
+		{
+			name:      "DeleteLoadBalancer on LoadBalancerArn",
+			operation: "DeleteLoadBalancer",
+			params:    map[string]string{"LoadBalancerArn": elbAuthzLBARN},
+			action:    "elasticloadbalancing:DeleteLoadBalancer",
+			resource:  elbAuthzLBARN,
+		},
+		{
+			name:      "RegisterTargets on TargetGroupArn",
+			operation: "RegisterTargets",
+			params:    map[string]string{"TargetGroupArn": elbAuthzTGARN},
+			action:    "elasticloadbalancing:RegisterTargets",
+			resource:  elbAuthzTGARN,
+		},
+		{
+			name:      "ModifyListener on ListenerArn",
+			operation: "ModifyListener",
+			params:    map[string]string{"ListenerArn": elbAuthzListenerARN},
+			action:    "elasticloadbalancing:ModifyListener",
+			resource:  elbAuthzListenerARN,
+		},
+		{
+			name:      "DeleteRule on RuleArn",
+			operation: "DeleteRule",
+			params:    map[string]string{"RuleArn": elbAuthzRuleARN},
+			action:    "elasticloadbalancing:DeleteRule",
+			resource:  elbAuthzRuleARN,
+		},
+		{
+			name:      "DescribeTags on ResourceArns.member.N",
+			operation: "DescribeTags",
+			params:    map[string]string{"ResourceArns.member.1": elbAuthzLBARN},
+			action:    "elasticloadbalancing:DescribeTags",
+			resource:  elbAuthzLBARN,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newELBAuthzFixture(t, "scoped", emulator.PolicyDocument{})
+			f.setPolicy(t, elbAuthzAllow(tt.action, tt.resource))
+			assert.NoError(t, f.call(t, tt.operation, tt.params),
+				"a policy naming %s must permit the request that names it", tt.resource)
+
+			// The other direction: the same grant scoped to a different ARN must not
+			// permit it, which is what proves the resource is the one being compared.
+			f.setPolicy(t, elbAuthzAllow(tt.action, elbAuthzTGARN+"-other"))
+			require.Error(t, f.call(t, tt.operation, tt.params))
+		})
+	}
+}
+
+// TestELB_Authz_DenyOnOneNamedARNRefusesTheWholeRequest pins the multi-resource rule for the
+// three tagging operations, which name up to 20 ARNs: every one must be allowed.
+func TestELB_Authz_DenyOnOneNamedARNRefusesTheWholeRequest(t *testing.T) {
+	f := newELBAuthzFixture(t, "multi", emulator.PolicyDocument{})
+	f.setPolicy(t,
+		elbAuthzAllow("elasticloadbalancing:*", "*"),
+		emulator.PolicyStatement{
+			Effect:   "Deny",
+			Action:   emulator.StringOrSlice{"elasticloadbalancing:RemoveTags"},
+			Resource: emulator.StringOrSlice{elbAuthzTGARN},
+		},
+	)
+
+	// The load balancer alone is permitted.
+	assert.NoError(t, f.call(t, "RemoveTags", map[string]string{
+		"ResourceArns.member.1": elbAuthzLBARN,
+		"TagKeys.member.1":      "env",
+	}))
+
+	// Naming the denied target group alongside it refuses the whole request, and the
+	// denial names the resource that failed.
+	err := f.call(t, "RemoveTags", map[string]string{
+		"ResourceArns.member.1": elbAuthzLBARN,
+		"ResourceArns.member.2": elbAuthzTGARN,
+		"TagKeys.member.1":      "env",
+	})
+	require.Error(t, err)
+	assert.Equal(t, elbAuthzTGARN, deniedResource(t, err))
+}
+
+// TestELB_Authz_UnresolvableARNIsStillTheResourceDecidedAbout pins that a bogus ARN is not
+// silently replaced by "*": substituting it would let it reach a statement scoped to "*"
+// that the real ARN would not have matched.
+func TestELB_Authz_UnresolvableARNIsStillTheResourceDecidedAbout(t *testing.T) {
+	f := newELBAuthzFixture(t, "ghost", emulator.PolicyDocument{})
+	f.setPolicy(t, elbAuthzAllow("elasticloadbalancing:AddTags", elbAuthzLBARN))
+
+	ghost := "arn:aws:elasticloadbalancing:" + elbAuthzRegion + ":" + elbAuthzAccount + ":loadbalancer/app/ghost/0zzz999"
+	err := f.call(t, "AddTags", elbAuthzParams(
+		map[string]string{"ResourceArns.member.1": ghost},
+		elbAuthzTagParams("env", "prod"),
+	))
+	require.Error(t, err)
+	assert.Equal(t, ghost, deniedResource(t, err))
+}
+
+// TestELB_Authz_ResourceTagConditions pins both prefixes a resource's tags are reported
+// under: the global aws:ResourceTag/ and the elasticloadbalancing:ResourceTag/ the ELB user
+// guide publishes ("All mutating actions support this condition key").
+func TestELB_Authz_ResourceTagConditions(t *testing.T) {
+	for _, prefix := range []string{"aws:ResourceTag/", "elasticloadbalancing:ResourceTag/"} {
+		t.Run(prefix, func(t *testing.T) {
+			f := newELBAuthzFixture(t, "tagged", emulator.PolicyDocument{})
+			f.putLoadBalancer(t, map[string]string{"env": "prod"})
+			f.setPolicy(t, elbAuthzAllowCond("elasticloadbalancing:DeleteLoadBalancer",
+				[]string{"*"},
+				map[string]map[string]emulator.StringOrSlice{
+					"StringEquals": {prefix + "env": {"prod"}},
+				}))
+
+			assert.NoError(t, f.call(t, "DeleteLoadBalancer",
+				map[string]string{"LoadBalancerArn": elbAuthzLBARN}),
+				"the resource's own tag must satisfy a condition written under %s", prefix)
+
+			// The target group carries no tags, so the same statement must not permit it —
+			// which is what shows the tags travel with the ARN they belong to.
+			f.setPolicy(t, elbAuthzAllowCond("elasticloadbalancing:DeleteTargetGroup",
+				[]string{"*"},
+				map[string]map[string]emulator.StringOrSlice{
+					"StringEquals": {prefix + "env": {"prod"}},
+				}))
+			require.Error(t, f.call(t, "DeleteTargetGroup",
+				map[string]string{"TargetGroupArn": elbAuthzTGARN}))
+		})
+	}
+}
+
+// TestELB_Authz_TaggedCreateRequiresTheTaggingGrant is the second half of #748. AWS: "If
+// tags are specified in the resource-creating action, additional authorization is required
+// on the elasticloadbalancing:AddTags action to verify if users have permissions to apply
+// tags to the resources being created".
+func TestELB_Authz_TaggedCreateRequiresTheTaggingGrant(t *testing.T) {
+	tests := []struct {
+		operation string
+		wildcard  string
+	}{
+		{operation: "CreateLoadBalancer", wildcard: elbAuthzLBWildcard},
+		{operation: "CreateTargetGroup", wildcard: elbAuthzTGWildcard},
+		{operation: "CreateListener", wildcard: elbAuthzListenerWildcard},
+		{operation: "CreateRule", wildcard: elbAuthzRuleWildcard},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.operation, func(t *testing.T) {
+			f := newELBAuthzFixture(t, "creator", emulator.PolicyDocument{})
+			f.setPolicy(t, elbAuthzAllow("elasticloadbalancing:"+tt.operation, "*"))
+
+			// AWS: "a user that has permissions to create a resource … does not require
+			// permissions to use the elasticloadbalancing:AddTags action if no tags are
+			// specified in the request."
+			assert.NoError(t, f.call(t, tt.operation, map[string]string{"Name": "new"}),
+				"an untagged create must not require the tagging grant")
+
+			// The same create carrying tags is refused, and the denial names the tagging
+			// action against the created type's wildcard — which is how a caller learns
+			// it is the tagging pass that failed rather than the create.
+			err := f.call(t, tt.operation, elbAuthzParams(
+				map[string]string{"Name": "new"}, elbAuthzTagParams("env", "prod")))
+			require.Error(t, err)
+			assert.Equal(t, "elasticloadbalancing:AddTags", deniedActionNamed(t, err))
+			assert.Equal(t, tt.wildcard, deniedResource(t, err))
+
+			// Adding the grant permits it.
+			f.setPolicy(t,
+				elbAuthzAllow("elasticloadbalancing:"+tt.operation, "*"),
+				elbAuthzAllow("elasticloadbalancing:AddTags", "*"),
+			)
+			assert.NoError(t, f.call(t, tt.operation, elbAuthzParams(
+				map[string]string{"Name": "new"}, elbAuthzTagParams("env", "prod"))))
+		})
+	}
+}
+
+// TestELB_Authz_CreateActionScopesTheTaggingGrant runs the bundled ELBTaggingPolicy's own
+// statement shape, which is the reason elasticloadbalancing:CreateAction exists.
+func TestELB_Authz_CreateActionScopesTheTaggingGrant(t *testing.T) {
+	f := newELBAuthzFixture(t, "scoper", emulator.PolicyDocument{})
+	f.setPolicy(t,
+		elbAuthzAllow("elasticloadbalancing:CreateLoadBalancer", "*"),
+		elbAuthzAllow("elasticloadbalancing:CreateTargetGroup", "*"),
+		elbCreateActionAllow("CreateTargetGroup", "CreateRule", "CreateListener", "CreateLoadBalancer"),
+	)
+
+	tagged := elbAuthzTagParams("env", "prod")
+	assert.NoError(t, f.call(t, "CreateLoadBalancer",
+		elbAuthzParams(map[string]string{"Name": "new"}, tagged)),
+		"a create named by the condition must be permitted to tag")
+
+	// The whole point of the key: a standalone AddTags carries no
+	// elasticloadbalancing:CreateAction, so the same grant must not permit it.
+	err := f.call(t, "AddTags", elbAuthzParams(
+		map[string]string{"ResourceArns.member.1": elbAuthzLBARN}, tagged))
+	require.Error(t, err, "a grant conditioned on CreateAction permitted standalone tagging")
+
+	// A create the condition does not name is refused too, which is what makes the four
+	// values in the bundled statement mean something.
+	f.setPolicy(t,
+		elbAuthzAllow("elasticloadbalancing:CreateTargetGroup", "*"),
+		elbCreateActionAllow("CreateLoadBalancer"),
+	)
+	require.Error(t, f.call(t, "CreateTargetGroup",
+		elbAuthzParams(map[string]string{"Name": "new"}, tagged)))
+}
+
+// TestELB_Authz_CreateActionIsAbsentOutsideACreate pins the key's absence, which a Null
+// condition is the only way to observe.
+func TestELB_Authz_CreateActionIsAbsentOutsideACreate(t *testing.T) {
+	nullTrue := func(action string) emulator.PolicyStatement {
+		return elbAuthzAllowCond(action, []string{"*"},
+			map[string]map[string]emulator.StringOrSlice{
+				"Null": {"elasticloadbalancing:CreateAction": {"true"}},
+			})
+	}
+
+	f := newELBAuthzFixture(t, "nuller", emulator.PolicyDocument{})
+
+	// A standalone AddTags carries no CreateAction, so a grant requiring its absence
+	// permits it.
+	f.setPolicy(t, nullTrue("elasticloadbalancing:AddTags"))
+	assert.NoError(t, f.call(t, "AddTags", elbAuthzParams(
+		map[string]string{"ResourceArns.member.1": elbAuthzLBARN},
+		elbAuthzTagParams("env", "prod"))))
+
+	// The tagging pass of a tagged create does carry it, so the same grant refuses that.
+	f.setPolicy(t,
+		elbAuthzAllow("elasticloadbalancing:CreateLoadBalancer", "*"),
+		nullTrue("elasticloadbalancing:AddTags"),
+	)
+	require.Error(t, f.call(t, "CreateLoadBalancer", elbAuthzParams(
+		map[string]string{"Name": "new"}, elbAuthzTagParams("env", "prod"))),
+		"the tagging pass of a tagged create carried no elasticloadbalancing:CreateAction")
+}
+
+// TestELB_Authz_RequestTagAndTagKeys pins the two request-level keys the new addRequestTags
+// arm produces, which a "may only apply approved tags" policy is written against.
+func TestELB_Authz_RequestTagAndTagKeys(t *testing.T) {
+	t.Run("aws:RequestTag on AddTags", func(t *testing.T) {
+		f := newELBAuthzFixture(t, "reqtag", emulator.PolicyDocument{})
+		f.setPolicy(t, elbAuthzAllowCond("elasticloadbalancing:AddTags", []string{"*"},
+			map[string]map[string]emulator.StringOrSlice{
+				"StringEquals": {"aws:RequestTag/env": {"prod"}},
+			}))
+
+		assert.NoError(t, f.call(t, "AddTags", elbAuthzParams(
+			map[string]string{"ResourceArns.member.1": elbAuthzLBARN},
+			elbAuthzTagParams("env", "prod"))))
+		require.Error(t, f.call(t, "AddTags", elbAuthzParams(
+			map[string]string{"ResourceArns.member.1": elbAuthzLBARN},
+			elbAuthzTagParams("env", "dev"))))
+	})
+
+	t.Run("aws:TagKeys on a tagged create", func(t *testing.T) {
+		f := newELBAuthzFixture(t, "tagkeys", emulator.PolicyDocument{})
+		f.setPolicy(t,
+			elbAuthzAllow("elasticloadbalancing:CreateTargetGroup", "*"),
+			elbAuthzAllowCond("elasticloadbalancing:AddTags", []string{"*"},
+				map[string]map[string]emulator.StringOrSlice{
+					"ForAllValues:StringEquals": {"aws:TagKeys": {"env", "team"}},
+				}),
+		)
+
+		assert.NoError(t, f.call(t, "CreateTargetGroup", elbAuthzParams(
+			map[string]string{"Name": "new"}, elbAuthzTagParams("env", "prod", "team", "platform"))))
+		require.Error(t, f.call(t, "CreateTargetGroup", elbAuthzParams(
+			map[string]string{"Name": "new"}, elbAuthzTagParams("env", "prod", "cost-center", "42"))))
+	})
+
+	// RemoveTags names keys and supplies no values, and those keys still reach aws:TagKeys
+	// — the reading that makes a "may only remove approved tags" policy expressible.
+	t.Run("aws:TagKeys on RemoveTags", func(t *testing.T) {
+		f := newELBAuthzFixture(t, "removekeys", emulator.PolicyDocument{})
+		f.setPolicy(t, elbAuthzAllowCond("elasticloadbalancing:RemoveTags", []string{"*"},
+			map[string]map[string]emulator.StringOrSlice{
+				"ForAllValues:StringEquals": {"aws:TagKeys": {"env"}},
+			}))
+
+		assert.NoError(t, f.call(t, "RemoveTags", map[string]string{
+			"ResourceArns.member.1": elbAuthzLBARN,
+			"TagKeys.member.1":      "env",
+		}))
+		require.Error(t, f.call(t, "RemoveTags", map[string]string{
+			"ResourceArns.member.1": elbAuthzLBARN,
+			"TagKeys.member.1":      "env",
+			"TagKeys.member.2":      "owner",
+		}))
+	})
+}
+
+// TestELB_Authz_TaggedCreateHonoursThePermissionBoundary pins that the second pass is
+// bounded like the first: a boundary that does not admit the tagging action refuses a tagged
+// create even when the attached policy grants it.
+func TestELB_Authz_TaggedCreateHonoursThePermissionBoundary(t *testing.T) {
+	f := newELBAuthzFixture(t, "bounded", emulator.PolicyDocument{})
+	f.setPolicy(t,
+		elbAuthzAllow("elasticloadbalancing:CreateLoadBalancer", "*"),
+		elbAuthzAllow("elasticloadbalancing:AddTags", "*"),
+	)
+	elbSetBoundary(t, f, emulator.PolicyDocument{
+		Version:   "2012-10-17",
+		Statement: []emulator.PolicyStatement{elbAuthzAllow("elasticloadbalancing:CreateLoadBalancer", "*")},
+	})
+
+	assert.NoError(t, f.call(t, "CreateLoadBalancer", map[string]string{"Name": "new"}),
+		"the untagged create is inside the boundary")
+
+	err := f.call(t, "CreateLoadBalancer", elbAuthzParams(
+		map[string]string{"Name": "new"}, elbAuthzTagParams("env", "prod")))
+	require.Error(t, err)
+	assert.Equal(t, "elasticloadbalancing:AddTags", deniedActionNamed(t, err))
+}
+
+// elbSetBoundary attaches a permission boundary to the fixture's user, which is how a
+// boundary reaches CheckAccess: it is read off the IAM entity, not from the attached-policy
+// list.
+func elbSetBoundary(t *testing.T, f *elbAuthzFixture, doc emulator.PolicyDocument) {
+	t.Helper()
+	arn := "arn:aws:iam::" + elbAuthzAccount + ":policy/Boundary-" + f.user
+	pol := emulator.IAMPolicy{
+		PolicyName:       "boundary",
+		PolicyID:         "ANPABOUNDELB",
+		ARN:              arn,
+		Path:             "/",
+		DefaultVersionID: "v1",
+		IsAttachable:     true,
+		Document:         doc,
+	}
+	raw, err := json.Marshal(pol)
+	if err != nil {
+		t.Fatalf("marshal boundary: %v", err)
+	}
+	if err := f.state.Put(context.Background(), "iam", emulator.IAMPolicyKeyForTest(arn), raw); err != nil { //nolint:contextcheck
+		t.Fatalf("store boundary: %v", err)
+	}
+	user := emulator.IAMUser{
+		UserName:            f.user,
+		UserID:              "AIDATEST",
+		ARN:                 "arn:aws:iam::" + elbAuthzAccount + ":user/" + f.user,
+		Path:                "/",
+		PermissionsBoundary: &emulator.IAMAttachedPolicy{PolicyARN: arn, PolicyName: "boundary"},
+	}
+	userRaw, err := json.Marshal(user)
+	if err != nil {
+		t.Fatalf("marshal user: %v", err)
+	}
+	key := emulator.IAMUserKeyForTest(elbAuthzAccount, f.user)
+	if err := f.state.Put(context.Background(), "iam", key, userRaw); err != nil { //nolint:contextcheck
+		t.Fatalf("store user: %v", err)
+	}
+}
+
+// TestELB_Authz_BundledPolicyAllowsATaggedCreate runs the AWS-authored policy substrate
+// bundles, whose ELBTaggingPolicy statement is the only citable-in-code source for the
+// condition key. A tagged create under it must succeed end to end.
+func TestELB_Authz_BundledPolicyAllowsATaggedCreate(t *testing.T) {
+	f := newELBAuthzFixture(t, "bundled", emulator.PolicyDocument{})
+	f.attachManagedPolicy(t, "arn:aws:iam::aws:policy/AmazonECS_FullAccess")
+
+	for _, operation := range []string{"CreateLoadBalancer", "CreateTargetGroup", "CreateListener", "CreateRule"} {
+		assert.NoError(t, f.call(t, operation, elbAuthzParams(
+			map[string]string{"Name": "new"}, elbAuthzTagParams("env", "prod"))), operation)
+	}
+}
+
+// TestELB_Authz_DescribesByNameStayAtStar pins the deliberate absence: Names.member.N is not
+// resolved to an ARN, because whether ELB's describes support resource-level permissions
+// could not be verified. Leaving them at "*" is the direction that cannot invent a grant.
+func TestELB_Authz_DescribesByNameStayAtStar(t *testing.T) {
+	f := newELBAuthzFixture(t, "bynames", emulator.PolicyDocument{})
+	f.setPolicy(t, elbAuthzAllow("elasticloadbalancing:DescribeLoadBalancers", "*"))
+
+	assert.NoError(t, f.call(t, "DescribeLoadBalancers", map[string]string{"Names.member.1": "web"}))
+
+	// An ARN-scoped grant does not cover it, because the request resource is "*" and not
+	// the load balancer the name resolves to.
+	f.setPolicy(t, elbAuthzAllow("elasticloadbalancing:DescribeLoadBalancers", elbAuthzLBARN))
+	err := f.call(t, "DescribeLoadBalancers", map[string]string{"Names.member.1": "web"})
+	require.Error(t, err)
+	assert.Equal(t, "*", deniedResource(t, err))
+}

--- a/emulator/elb_plugin.go
+++ b/emulator/elb_plugin.go
@@ -21,7 +21,7 @@ type ELBPlugin struct {
 }
 
 // Name returns the service name "elasticloadbalancing".
-func (p *ELBPlugin) Name() string { return "elasticloadbalancing" }
+func (p *ELBPlugin) Name() string { return elbServiceName }
 
 // Initialize sets up the ELBPlugin with the provided configuration.
 func (p *ELBPlugin) Initialize(_ context.Context, cfg PluginConfig) error {
@@ -85,6 +85,12 @@ func (p *ELBPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 		return p.deleteRule(ctx, req)
 	case "SetRulePriorities":
 		return p.setRulePriorities(ctx, req)
+	case "AddTags":
+		return p.addTags(ctx, req)
+	case "RemoveTags":
+		return p.removeTags(ctx, req)
+	case "DescribeTags":
+		return p.describeTags(ctx, req)
 	default:
 		return nil, unknownActionError(p.Name(), action)
 	}
@@ -121,6 +127,15 @@ func (p *ELBPlugin) createLoadBalancer(reqCtx *RequestContext, req *AWSRequest) 
 		azs = []string{reqCtx.Region + "a"}
 	}
 
+	// Tags are validated before the record is written, so a create carrying a tag it
+	// cannot legally apply leaves no load balancer behind. CreateLoadBalancer is the one
+	// create of the four that publishes DuplicateTagKeys, which is why it is the one
+	// passing true here.
+	tags, tagErr := elbTagsForCreate(req, true)
+	if tagErr != nil {
+		return nil, tagErr
+	}
+
 	lb := ELBLoadBalancer{
 		Name:              name,
 		ARN:               arn,
@@ -131,6 +146,7 @@ func (p *ELBPlugin) createLoadBalancer(reqCtx *RequestContext, req *AWSRequest) 
 		State:             ELBState{Code: "active"},
 		AvailabilityZones: azs,
 		SecurityGroups:    sgs,
+		Tags:              tags,
 		AccountID:         reqCtx.AccountID,
 		Region:            reqCtx.Region,
 		CreatedTime:       p.tc.Now(),
@@ -223,11 +239,7 @@ func (p *ELBPlugin) deleteLoadBalancer(reqCtx *RequestContext, req *AWSRequest) 
 		p.removeFromList(scope, "lb_names", lb.Name)
 		break
 	}
-	type response struct {
-		XMLName xml.Name `xml:"DeleteLoadBalancerResponse"`
-		XMLNS   string   `xml:"xmlns,attr"`
-	}
-	return elbXMLResponse(http.StatusOK, response{XMLNS: elbXMLNS})
+	return elbEmptyOKResponse("DeleteLoadBalancer")
 }
 
 func (p *ELBPlugin) describeLoadBalancerAttributes(_ *RequestContext, _ *AWSRequest) (*AWSResponse, error) {
@@ -276,6 +288,11 @@ func (p *ELBPlugin) createTargetGroup(reqCtx *RequestContext, req *AWSRequest) (
 	suffix := generateELBSuffix()
 	arn := elbTargetGroupARN(reqCtx.Region, reqCtx.AccountID, name, suffix)
 
+	tags, tagErr := elbTagsForCreate(req, false)
+	if tagErr != nil {
+		return nil, tagErr
+	}
+
 	tg := ELBTargetGroup{
 		ARN:                 arn,
 		Name:                name,
@@ -286,6 +303,7 @@ func (p *ELBPlugin) createTargetGroup(reqCtx *RequestContext, req *AWSRequest) (
 		HealthCheckPath:     req.Params["HealthCheckPath"],
 		HealthCheckProtocol: req.Params["HealthCheckProtocol"],
 		HealthCheckPort:     req.Params["HealthCheckPort"],
+		Tags:                tags,
 		AccountID:           reqCtx.AccountID,
 		Region:              reqCtx.Region,
 		Suffix:              suffix,
@@ -376,11 +394,7 @@ func (p *ELBPlugin) deleteTargetGroup(reqCtx *RequestContext, req *AWSRequest) (
 		p.removeFromList(scope, "tg_names", tg.Name)
 		break
 	}
-	type response struct {
-		XMLName xml.Name `xml:"DeleteTargetGroupResponse"`
-		XMLNS   string   `xml:"xmlns,attr"`
-	}
-	return elbXMLResponse(http.StatusOK, response{XMLNS: elbXMLNS})
+	return elbEmptyOKResponse("DeleteTargetGroup")
 }
 
 func (p *ELBPlugin) modifyTargetGroup(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
@@ -457,11 +471,7 @@ func (p *ELBPlugin) registerTargets(reqCtx *RequestContext, req *AWSRequest) (*A
 		break
 	}
 
-	type response struct {
-		XMLName xml.Name `xml:"RegisterTargetsResponse"`
-		XMLNS   string   `xml:"xmlns,attr"`
-	}
-	return elbXMLResponse(http.StatusOK, response{XMLNS: elbXMLNS})
+	return elbEmptyOKResponse("RegisterTargets")
 }
 
 func (p *ELBPlugin) deregisterTargets(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
@@ -503,11 +513,7 @@ func (p *ELBPlugin) deregisterTargets(reqCtx *RequestContext, req *AWSRequest) (
 		break
 	}
 
-	type response struct {
-		XMLName xml.Name `xml:"DeregisterTargetsResponse"`
-		XMLNS   string   `xml:"xmlns,attr"`
-	}
-	return elbXMLResponse(http.StatusOK, response{XMLNS: elbXMLNS})
+	return elbEmptyOKResponse("DeregisterTargets")
 }
 
 func (p *ELBPlugin) describeTargetHealth(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
@@ -577,6 +583,11 @@ func (p *ELBPlugin) createListener(reqCtx *RequestContext, req *AWSRequest) (*AW
 		})
 	}
 
+	tags, tagErr := elbTagsForCreate(req, false)
+	if tagErr != nil {
+		return nil, tagErr
+	}
+
 	suffix := generateELBSuffix()
 	arn := elbListenerARN(lbARN, suffix)
 	listener := ELBListener{
@@ -585,6 +596,7 @@ func (p *ELBPlugin) createListener(reqCtx *RequestContext, req *AWSRequest) (*AW
 		Port:            port,
 		Protocol:        protocol,
 		DefaultActions:  actions,
+		Tags:            tags,
 		AccountID:       reqCtx.AccountID,
 		Region:          reqCtx.Region,
 		Suffix:          suffix,
@@ -676,11 +688,7 @@ func (p *ELBPlugin) deleteListener(reqCtx *RequestContext, req *AWSRequest) (*AW
 		}
 		break
 	}
-	type response struct {
-		XMLName xml.Name `xml:"DeleteListenerResponse"`
-		XMLNS   string   `xml:"xmlns,attr"`
-	}
-	return elbXMLResponse(http.StatusOK, response{XMLNS: elbXMLNS})
+	return elbEmptyOKResponse("DeleteListener")
 }
 
 func (p *ELBPlugin) modifyListener(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
@@ -767,6 +775,11 @@ func (p *ELBPlugin) createRule(reqCtx *RequestContext, req *AWSRequest) (*AWSRes
 		})
 	}
 
+	tags, tagErr := elbTagsForCreate(req, false)
+	if tagErr != nil {
+		return nil, tagErr
+	}
+
 	suffix := generateELBSuffix()
 	arn := elbRuleARN(listenerARN, suffix)
 	rule := ELBRule{
@@ -776,6 +789,7 @@ func (p *ELBPlugin) createRule(reqCtx *RequestContext, req *AWSRequest) (*AWSRes
 		Conditions:  conditions,
 		Actions:     actions,
 		IsDefault:   false,
+		Tags:        tags,
 		AccountID:   reqCtx.AccountID,
 		Region:      reqCtx.Region,
 		Suffix:      suffix,
@@ -867,11 +881,7 @@ func (p *ELBPlugin) deleteRule(reqCtx *RequestContext, req *AWSRequest) (*AWSRes
 		}
 		break
 	}
-	type response struct {
-		XMLName xml.Name `xml:"DeleteRuleResponse"`
-		XMLNS   string   `xml:"xmlns,attr"`
-	}
-	return elbXMLResponse(http.StatusOK, response{XMLNS: elbXMLNS})
+	return elbEmptyOKResponse("DeleteRule")
 }
 
 func (p *ELBPlugin) setRulePriorities(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
@@ -1074,6 +1084,31 @@ func (p *ELBPlugin) removeFromList(scope, listName, id string) {
 }
 
 // elbXMLResponse serializes v to XML and returns an AWSResponse.
+// elbEmptyOKResponse answers an ELBv2 operation whose output shape carries no members,
+// as <OperationResponse><OperationResult/></OperationResponse>.
+//
+// The empty result element is not decoration. ELBv2 speaks the Query protocol, where every
+// output shape declares a resultWrapper, and botocore looks that wrapper up by name in the
+// parsed body — so a bare <OperationResponse/> makes the AWS CLI and boto3 raise
+// KeyError: 'DeleteLoadBalancerResult' instead of reporting success. Six operations answered
+// that way and were unusable from a real client while passing substrate's own tests, which
+// read the XML directly rather than through an SDK's parser (#748).
+func elbEmptyOKResponse(operation string) (*AWSResponse, error) {
+	type result struct {
+		XMLName xml.Name
+	}
+	type response struct {
+		XMLName xml.Name
+		XMLNS   string `xml:"xmlns,attr"`
+		Result  result
+	}
+	return elbXMLResponse(http.StatusOK, response{
+		XMLName: xml.Name{Local: operation + "Response"},
+		XMLNS:   elbXMLNS,
+		Result:  result{XMLName: xml.Name{Local: operation + "Result"}},
+	})
+}
+
 func elbXMLResponse(status int, v interface{}) (*AWSResponse, error) {
 	body, err := xml.Marshal(v)
 	if err != nil {

--- a/emulator/elb_tags.go
+++ b/emulator/elb_tags.go
@@ -1,0 +1,652 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+// ELB resource kinds, which are the ARN resource types the four taggable ELBv2
+// resources use. They are the switch value everywhere a tagging call has to know
+// which of the four it is looking at.
+//
+// The listener and rule types are the ones AWS's ARNs carry —
+// `listener/app/<lb>/<lb-id>/<listener-id>` and
+// `listener-rule/app/<lb>/<lb-id>/<listener-id>/<rule-id>` — which is *not* the shape
+// [elbListenerARN] and [elbRuleARN] mint (they nest the suffix under the load
+// balancer's own ARN). Authorization uses the AWS spelling because that is what a
+// policy is written against; resolution reads substrate's, because that is what state
+// holds. The malformed ARN shape is #774, filed rather than fixed here.
+const (
+	elbKindLoadBalancer = "loadbalancer"
+	elbKindTargetGroup  = "targetgroup"
+	elbKindListener     = "listener"
+	elbKindRule         = "listener-rule"
+)
+
+// elbMaxTagsPerResource is the number of user tags ELB allows on one resource.
+//
+// From the ELB tagging documentation's restrictions: "Maximum number of tags per
+// resource—50". Tags carrying [elbReservedTagPrefix] are excluded from the count, per
+// the same list — "Tags with this prefix do not count against your tags per resource
+// limit" — which is byte-for-byte the rule [ec2CheckTagLimit] already implements.
+const elbMaxTagsPerResource = 50
+
+// elbReservedTagPrefix is the tag-key prefix ELB reserves for AWS's own use.
+//
+// It is used **only** to exclude a reserved key from the count above. ELB's
+// restrictions do say "You can't edit or delete tag names or values with this prefix",
+// but neither the API reference's Errors sections nor any reachable page publishes a
+// code for that refusal, and no real response has been observed — so substrate does not
+// refuse the prefix. Inventing a code here is the #561 failure in a different costume: a
+// consumer's error branch would dispatch on something AWS never sends. The gap is
+// recorded in docs/services.md rather than papered over.
+const elbReservedTagPrefix = "aws:"
+
+// elbMaxTagKeyLength and elbMaxTagValueLength are the tag length limits.
+//
+// **AWS contradicts itself here and substrate follows the API model.** The Tag type's
+// API reference gives "Length Constraints: Minimum length of 1. Maximum length of 128"
+// for Key and "Maximum length of 256" for Value; the ELB user guide's restrictions list
+// says "Maximum key length—127 Unicode characters" and "Maximum value length—255
+// Unicode characters". The model is what an SDK validates against and what the service
+// enforces, so it is the one implemented — a 128-character key is accepted here, and a
+// caller who trusts the user guide's 127 is inside that.
+//
+// The unit is Unicode characters rather than bytes, so the checks count runes; see
+// [ec2MaxTagKeyLength] for why the two are indistinguishable on ASCII.
+const (
+	elbMaxTagKeyLength   = 128
+	elbMaxTagValueLength = 256
+)
+
+// elbDescribeTagsMaxResources is the number of resources one DescribeTags request may
+// name, from the operation's "Array Members: Maximum number of 20 items" on
+// ResourceArns. AddTags and RemoveTags carry no such cap.
+const elbDescribeTagsMaxResources = 20
+
+// elbMaxRemoveTagKeys is the number of keys one RemoveTags request may name, from that
+// operation's "Array Members: Minimum number of 1 item. Maximum number of 128 items" on
+// TagKeys. It is a per-request cap and unrelated to [elbMaxTagsPerResource]: a request may
+// legally name more keys than any one resource holds, because a key that is not present is
+// ignored.
+const elbMaxRemoveTagKeys = 128
+
+// elbTagCharPattern is the character set the Tag type's API reference permits in a key
+// and in a value: `^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$`.
+//
+// The pattern admits the empty string, so it decides characters only — the minimum
+// length of 1 on a key is enforced separately by [elbCheckTagRules]. The user guide
+// spells the same set in prose ("letters, spaces, and numbers representable in UTF-8,
+// plus the following special characters: + - = . _ : / @"), and the two agree except
+// that the prose omits the comma the pattern also omits, so there is nothing to choose
+// between here.
+var elbTagCharPattern = regexp.MustCompile(`^[\p{L}\p{Z}\p{N}_.:/=+\-@]*$`)
+
+// elbTagValidationError returns the refusal for a tag that breaks one of the Tag type's
+// documented constraints.
+//
+// Provenance: the *constraints* are the API model's, but the model publishes no error
+// for violating one, and none of AddTags', RemoveTags' or the four creates' Errors
+// sections names one. A real service answers the common `ValidationError` for a member
+// outside its constraints, which is what this returns; the message text is substrate's
+// own, written to name which constraint and which key, because that is the only place a
+// caller learns it.
+func elbTagValidationError(format string, args ...any) *AWSError {
+	return &AWSError{
+		Code:       "ValidationError",
+		Message:    fmt.Sprintf(format, args...),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// elbDuplicateTagKeysError returns the error AddTags raises when one key appears twice.
+//
+// Both the code and the message are the API reference's own: "DuplicateTagKeys — A tag
+// key was specified more than once. HTTP Status Code: 400". It is listed on **AddTags
+// and on CreateLoadBalancer, and on neither CreateTargetGroup, CreateListener nor
+// CreateRule** — so a duplicate key on those three creates is not refused here either;
+// see [elbCheckCreateTags].
+func elbDuplicateTagKeysError() *AWSError {
+	return &AWSError{
+		Code:       "DuplicateTagKeys",
+		Message:    "A tag key was specified more than once.",
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// elbTooManyTagsError returns the error raised when a resource would exceed
+// [elbMaxTagsPerResource].
+//
+// Code and message are the API reference's own — "TooManyTags — You've reached the limit
+// on the number of tags for this resource. HTTP Status Code: 400" — and it is listed on
+// AddTags and on all four creates, so every path that can apply a tag can raise it.
+func elbTooManyTagsError() *AWSError {
+	return &AWSError{
+		Code:       "TooManyTags",
+		Message:    "You've reached the limit on the number of tags for this resource.",
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// elbNotFoundCodes maps a resource kind to the code the tagging operations answer when
+// an ARN of that kind names nothing.
+//
+// All four appear on AddTags, RemoveTags and DescribeTags alike, each at HTTP 400 — a
+// *400*, not the 404 a reader expects, which is the ELB API's own choice and the reason
+// this table exists rather than one shared NotFound. TrustStoreNotFound is the fifth
+// code those operations list and has no row here because substrate models no trust
+// store, so no ARN can ever name one.
+var elbNotFoundCodes = map[string]string{
+	elbKindLoadBalancer: "LoadBalancerNotFound",
+	elbKindTargetGroup:  "TargetGroupNotFound",
+	elbKindListener:     "ListenerNotFound",
+	elbKindRule:         "RuleNotFound",
+}
+
+// elbNotFoundError returns the refusal for an ARN of a known kind that names nothing.
+//
+// The message names the ARN. AWS's published text for each of these is a one-line
+// description of the code rather than a response body ("The specified load balancer does
+// not exist."), so the wording is substrate's; the code, which is what an SDK dispatches
+// on, is the model's.
+func elbNotFoundError(kind, arn string) *AWSError {
+	code, ok := elbNotFoundCodes[kind]
+	if !ok {
+		return elbTagValidationError("'%s' is not a valid Elastic Load Balancing resource ARN", arn)
+	}
+	return &AWSError{
+		Code:       code,
+		Message:    fmt.Sprintf("The specified resource does not exist: %s", arn),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// elbResourceKindFromARN reports which of the four taggable kinds an ARN names, or ""
+// when it names none.
+//
+// The listener and rule tests come first and match on substrate's own nesting —
+// `…:loadbalancer/app/<name>/<id>/listener/<suffix>` and that plus `/rule/<suffix>` —
+// so they must be tried before the load-balancer test, which their prefix also
+// satisfies. AWS's flat `…:listener/…` and `…:listener-rule/…` are recognized too, so a
+// caller passing an ARN of the real shape is not told it names nothing; that is the
+// forward-compatible half of #774.
+func elbResourceKindFromARN(arn string) string {
+	switch {
+	case strings.Contains(arn, "/rule/") || strings.Contains(arn, ":listener-rule/"):
+		return elbKindRule
+	case strings.Contains(arn, "/listener/") || strings.Contains(arn, ":listener/"):
+		return elbKindListener
+	case strings.Contains(arn, ":loadbalancer/"):
+		return elbKindLoadBalancer
+	case strings.Contains(arn, ":targetgroup/"):
+		return elbKindTargetGroup
+	default:
+		return ""
+	}
+}
+
+// elbStateKeyPrefix returns the state-key prefix records of a kind are stored under.
+func elbStateKeyPrefix(kind, scope string) string {
+	switch kind {
+	case elbKindLoadBalancer:
+		return "lb:" + scope + "/"
+	case elbKindTargetGroup:
+		return "tg:" + scope + "/"
+	case elbKindListener:
+		return "listener:" + scope + "/"
+	case elbKindRule:
+		return "rule:" + scope + "/"
+	default:
+		return ""
+	}
+}
+
+// elbTaggedResource is one ELB resource a tagging call names, resolved from state.
+type elbTaggedResource struct {
+	// arn is the ARN the request named, which is also the one DescribeTags reports.
+	arn string
+
+	// stateKey is the key the record lives under, so a write goes back where it came
+	// from rather than to a key rebuilt from the ARN — the listener and rule keys are
+	// suffix-based and not derivable from the ARN alone.
+	stateKey string
+
+	// tags are the tags currently on the resource.
+	tags []ELBTag
+
+	// withTags re-marshals the record carrying a new tag set. It closes over the
+	// decoded record, which is what keeps every other member intact: rebuilding the
+	// record from the ARN would drop whatever the caller set at create time.
+	withTags func(tags []ELBTag) ([]byte, error)
+}
+
+// elbDecodeTaggedResource decodes one state record of the given kind, or returns nil
+// when the bytes do not parse as that kind.
+func elbDecodeTaggedResource(kind, stateKey string, data []byte) *elbTaggedResource {
+	switch kind {
+	case elbKindLoadBalancer:
+		var lb ELBLoadBalancer
+		if json.Unmarshal(data, &lb) != nil {
+			return nil
+		}
+		return &elbTaggedResource{arn: lb.ARN, stateKey: stateKey, tags: lb.Tags,
+			withTags: func(tags []ELBTag) ([]byte, error) {
+				lb.Tags = tags
+				return json.Marshal(lb)
+			}}
+	case elbKindTargetGroup:
+		var tg ELBTargetGroup
+		if json.Unmarshal(data, &tg) != nil {
+			return nil
+		}
+		return &elbTaggedResource{arn: tg.ARN, stateKey: stateKey, tags: tg.Tags,
+			withTags: func(tags []ELBTag) ([]byte, error) {
+				tg.Tags = tags
+				return json.Marshal(tg)
+			}}
+	case elbKindListener:
+		var l ELBListener
+		if json.Unmarshal(data, &l) != nil {
+			return nil
+		}
+		return &elbTaggedResource{arn: l.ARN, stateKey: stateKey, tags: l.Tags,
+			withTags: func(tags []ELBTag) ([]byte, error) {
+				l.Tags = tags
+				return json.Marshal(l)
+			}}
+	case elbKindRule:
+		var r ELBRule
+		if json.Unmarshal(data, &r) != nil {
+			return nil
+		}
+		return &elbTaggedResource{arn: r.ARN, stateKey: stateKey, tags: r.Tags,
+			withTags: func(tags []ELBTag) ([]byte, error) {
+				r.Tags = tags
+				return json.Marshal(r)
+			}}
+	default:
+		return nil
+	}
+}
+
+// elbResolveTaggedResource finds the record an ARN names, or the refusal for it.
+//
+// A read that genuinely fails is reported as an error rather than as a NotFound: a
+// broken backend is not an absent resource, and answering LoadBalancerNotFound for one
+// would tell a consumer's retry loop the wrong thing.
+func elbResolveTaggedResource(state StateManager, scope, arn string) (*elbTaggedResource, *AWSError, error) {
+	kind := elbResourceKindFromARN(arn)
+	if kind == "" {
+		return nil, elbTagValidationError("'%s' is not a valid Elastic Load Balancing resource ARN", arn), nil
+	}
+	keys, err := state.List(context.Background(), elbNamespace, elbStateKeyPrefix(kind, scope))
+	if err != nil {
+		return nil, nil, fmt.Errorf("elb resolve %s: %w", arn, err)
+	}
+	for _, k := range keys {
+		data, getErr := state.Get(context.Background(), elbNamespace, k)
+		if getErr != nil || data == nil {
+			continue
+		}
+		res := elbDecodeTaggedResource(kind, k, data)
+		if res == nil || res.arn != arn {
+			continue
+		}
+		return res, nil, nil
+	}
+	return nil, elbNotFoundError(kind, arn), nil
+}
+
+// elbResolveAll resolves every ARN a tagging call names, refusing the whole request on
+// the first one that names nothing.
+//
+// Resolving all of them before any write is what makes a partly-unknown AddTags apply
+// nothing at all, the same pre-pass [EC2Plugin.terminateInstances] runs for the same
+// reason: a request that is going to be refused must not have already changed half the
+// resources it named. AWS documents no ordering for ELB's multi-resource tagging calls,
+// so **this is substrate's reading**, chosen because the alternative is a partial write
+// no caller can undo from the error alone.
+func elbResolveAll(state StateManager, scope string, arns []string) ([]*elbTaggedResource, *AWSError, error) {
+	out := make([]*elbTaggedResource, 0, len(arns))
+	for _, arn := range arns {
+		res, awsErr, err := elbResolveTaggedResource(state, scope, arn)
+		if err != nil {
+			return nil, nil, err
+		}
+		if awsErr != nil {
+			return nil, awsErr, nil
+		}
+		out = append(out, res)
+	}
+	return out, nil, nil
+}
+
+// extractELBTags reads an indexed Tags.member.N list of {Key, Value} from query params.
+//
+// The walk ends on an absent or empty Key, which is how the query protocol terminates an
+// indexed list and what [extractEC2Tags] does. A value is optional — the Tag type's
+// Value has a minimum length of 0 — so an empty value is a legal tag, not a terminator.
+func extractELBTags(params map[string]string, prefix string) []ELBTag {
+	var tags []ELBTag
+	for i := 1; ; i++ {
+		key := params[fmt.Sprintf("%s.%d.Key", prefix, i)]
+		if key == "" {
+			break
+		}
+		tags = append(tags, ELBTag{Key: key, Value: params[fmt.Sprintf("%s.%d.Value", prefix, i)]})
+	}
+	return tags
+}
+
+// elbCheckTagKey validates one tag key against the Tag type's constraints.
+func elbCheckTagKey(key string) *AWSError {
+	if n := utf8.RuneCountInString(key); n > elbMaxTagKeyLength {
+		return elbTagValidationError(
+			"Tag key must be no more than %d characters; the supplied key is %d",
+			elbMaxTagKeyLength, n)
+	}
+	if !elbTagCharPattern.MatchString(key) {
+		return elbTagValidationError("Tag key '%s' contains characters that are not permitted", key)
+	}
+	return nil
+}
+
+// elbCheckTagRules validates a tag list against every Tag constraint substrate models:
+// key and value lengths, and the permitted character set.
+//
+// Tags are checked in slice order, so which tag a mixed request is refused on is decided
+// identically on every run — the replay-stability reason [ec2CheckTagLengths] avoids a
+// map. The key's minimum length of 1 is not checked because it is not expressible:
+// [extractELBTags] ends its walk on an empty key.
+func elbCheckTagRules(tags []ELBTag) *AWSError {
+	for _, t := range tags {
+		if awsErr := elbCheckTagKey(t.Key); awsErr != nil {
+			return awsErr
+		}
+		if n := utf8.RuneCountInString(t.Value); n > elbMaxTagValueLength {
+			return elbTagValidationError(
+				"Tag value must be no more than %d characters; the supplied value is %d",
+				elbMaxTagValueLength, n)
+		}
+		if !elbTagCharPattern.MatchString(t.Value) {
+			return elbTagValidationError("Tag value '%s' contains characters that are not permitted", t.Value)
+		}
+	}
+	return nil
+}
+
+// elbCheckDuplicateTagKeys returns [elbDuplicateTagKeysError] when one key appears more
+// than once, or nil.
+func elbCheckDuplicateTagKeys(tags []ELBTag) *AWSError {
+	seen := make(map[string]struct{}, len(tags))
+	for _, t := range tags {
+		if _, dup := seen[t.Key]; dup {
+			return elbDuplicateTagKeysError()
+		}
+		seen[t.Key] = struct{}{}
+	}
+	return nil
+}
+
+// elbCheckTagLimit returns an error if merging incoming into existing would leave a
+// resource with more than [elbMaxTagsPerResource] user tags, or nil.
+//
+// The count is over the post-merge key set with reserved keys excluded, which is the
+// same expression [ec2CheckTagLimit] uses and gets the same two documented rules right:
+// re-tagging an existing key on a resource already at the limit succeeds, and a reserved
+// key neither counts nor consumes room.
+func elbCheckTagLimit(existing, incoming []ELBTag) *AWSError {
+	keys := make(map[string]struct{}, len(existing)+len(incoming))
+	for _, t := range existing {
+		if !strings.HasPrefix(t.Key, elbReservedTagPrefix) {
+			keys[t.Key] = struct{}{}
+		}
+	}
+	for _, t := range incoming {
+		if !strings.HasPrefix(t.Key, elbReservedTagPrefix) {
+			keys[t.Key] = struct{}{}
+		}
+	}
+	if len(keys) > elbMaxTagsPerResource {
+		return elbTooManyTagsError()
+	}
+	return nil
+}
+
+// elbCheckCreateTags validates the Tags.member.N a create carries.
+//
+// It is the create's half of the tagging rules and is deliberately narrower than
+// AddTags': **no duplicate-key refusal**. DuplicateTagKeys is listed on AddTags and on
+// CreateLoadBalancer, and on none of CreateTargetGroup, CreateListener or CreateRule, so
+// refusing a duplicate on all four would invent a code three of them do not publish. A
+// duplicate therefore resolves last-wins through [elbMergeTags], which is the only other
+// thing it can do.
+func elbCheckCreateTags(tags []ELBTag) *AWSError {
+	if awsErr := elbCheckTagRules(tags); awsErr != nil {
+		return awsErr
+	}
+	return elbCheckTagLimit(nil, tags)
+}
+
+// elbMergeTags returns existing with incoming applied, overwriting a key already
+// present and appending one that is not.
+//
+// Existing order is preserved and a new key is appended, so a resource's tag list is a
+// stable, replay-identical sequence rather than a map walk.
+func elbMergeTags(existing, incoming []ELBTag) []ELBTag {
+	merged := make([]ELBTag, len(existing))
+	copy(merged, existing)
+	for _, in := range incoming {
+		replaced := false
+		for i := range merged {
+			if merged[i].Key == in.Key {
+				merged[i].Value = in.Value
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			merged = append(merged, in)
+		}
+	}
+	return merged
+}
+
+// elbRemoveTagKeys returns existing without the named keys.
+//
+// A key that is not present is silently ignored: RemoveTags publishes no error for one,
+// and its own description is "Removes the specified tags from the specified Elastic Load
+// Balancing resources" with no requirement that they be there.
+func elbRemoveTagKeys(existing []ELBTag, keys []string) []ELBTag {
+	if len(existing) == 0 {
+		return existing
+	}
+	remove := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		remove[k] = struct{}{}
+	}
+	kept := make([]ELBTag, 0, len(existing))
+	for _, t := range existing {
+		if _, drop := remove[t.Key]; !drop {
+			kept = append(kept, t)
+		}
+	}
+	return kept
+}
+
+// elbWriteTags persists a resolved resource's new tag set.
+func (p *ELBPlugin) elbWriteTags(res *elbTaggedResource, tags []ELBTag) error {
+	data, err := res.withTags(tags)
+	if err != nil {
+		return fmt.Errorf("elb marshal %s: %w", res.arn, err)
+	}
+	if err := p.state.Put(context.Background(), elbNamespace, res.stateKey, data); err != nil {
+		return fmt.Errorf("elb write tags %s: %w", res.arn, err)
+	}
+	return nil
+}
+
+// --- Tagging operations ---
+
+// addTags adds the given tags to the given resources.
+//
+// AWS: "Adds the specified tags to the specified Elastic Load Balancing resource type.
+// Each tag consists of a key and an optional value. If a tag with the same key is
+// already associated with the resource, AddTags updates its value." Both ResourceArns
+// and Tags are required, and Tags carries a minimum of one item.
+func (p *ELBPlugin) addTags(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	arns := extractIndexedParams(req.Params, "ResourceArns.member")
+	if len(arns) == 0 {
+		return nil, &AWSError{Code: "ValidationError", Message: "ResourceArns is required",
+			HTTPStatus: http.StatusBadRequest}
+	}
+	tags := extractELBTags(req.Params, "Tags.member")
+	if len(tags) == 0 {
+		return nil, &AWSError{Code: "ValidationError", Message: "Tags is required",
+			HTTPStatus: http.StatusBadRequest}
+	}
+	if awsErr := elbCheckDuplicateTagKeys(tags); awsErr != nil {
+		return nil, awsErr
+	}
+	if awsErr := elbCheckTagRules(tags); awsErr != nil {
+		return nil, awsErr
+	}
+
+	scope := reqCtx.AccountID + "/" + reqCtx.Region
+	resolved, awsErr, err := elbResolveAll(p.state, scope, arns)
+	if err != nil {
+		return nil, err
+	}
+	if awsErr != nil {
+		return nil, awsErr
+	}
+	// Every resource is checked against the limit before any is written, for the same
+	// reason resolution is: the request either applies to all of them or to none.
+	for _, res := range resolved {
+		if limitErr := elbCheckTagLimit(res.tags, tags); limitErr != nil {
+			return nil, limitErr
+		}
+	}
+	for _, res := range resolved {
+		if writeErr := p.elbWriteTags(res, elbMergeTags(res.tags, tags)); writeErr != nil {
+			return nil, writeErr
+		}
+	}
+
+	return elbEmptyOKResponse("AddTags")
+}
+
+// removeTags removes the named tag keys from the given resources.
+//
+// TagKeys is required and carries 1–128 items, each under the same key constraints a
+// Tag's own Key has. There is no DuplicateTagKeys here — the code is listed on AddTags
+// and not on RemoveTags, and removing the same key twice removes it once.
+func (p *ELBPlugin) removeTags(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	arns := extractIndexedParams(req.Params, "ResourceArns.member")
+	if len(arns) == 0 {
+		return nil, &AWSError{Code: "ValidationError", Message: "ResourceArns is required",
+			HTTPStatus: http.StatusBadRequest}
+	}
+	keys := extractIndexedParams(req.Params, "TagKeys.member")
+	if len(keys) == 0 {
+		return nil, &AWSError{Code: "ValidationError", Message: "TagKeys is required",
+			HTTPStatus: http.StatusBadRequest}
+	}
+	if len(keys) > elbMaxRemoveTagKeys {
+		return nil, elbTagValidationError(
+			"TagKeys must name no more than %d keys; %d were supplied", elbMaxRemoveTagKeys, len(keys))
+	}
+	for _, k := range keys {
+		if awsErr := elbCheckTagKey(k); awsErr != nil {
+			return nil, awsErr
+		}
+	}
+
+	scope := reqCtx.AccountID + "/" + reqCtx.Region
+	resolved, awsErr, err := elbResolveAll(p.state, scope, arns)
+	if err != nil {
+		return nil, err
+	}
+	if awsErr != nil {
+		return nil, awsErr
+	}
+	for _, res := range resolved {
+		if writeErr := p.elbWriteTags(res, elbRemoveTagKeys(res.tags, keys)); writeErr != nil {
+			return nil, writeErr
+		}
+	}
+
+	return elbEmptyOKResponse("RemoveTags")
+}
+
+// describeTags reports the tags on up to [elbDescribeTagsMaxResources] resources.
+//
+// A resource carrying no tags is still reported, with an empty Tags list: the operation
+// answers about the resources the request named, and omitting an untagged one would make
+// "no tags" indistinguishable from "no such resource" — which the operation has four
+// separate codes to distinguish.
+func (p *ELBPlugin) describeTags(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	arns := extractIndexedParams(req.Params, "ResourceArns.member")
+	if len(arns) == 0 {
+		return nil, &AWSError{Code: "ValidationError", Message: "ResourceArns is required",
+			HTTPStatus: http.StatusBadRequest}
+	}
+	if len(arns) > elbDescribeTagsMaxResources {
+		return nil, elbTagValidationError(
+			"ResourceArns must name no more than %d resources; %d were supplied",
+			elbDescribeTagsMaxResources, len(arns))
+	}
+
+	scope := reqCtx.AccountID + "/" + reqCtx.Region
+	resolved, awsErr, err := elbResolveAll(p.state, scope, arns)
+	if err != nil {
+		return nil, err
+	}
+	if awsErr != nil {
+		return nil, awsErr
+	}
+
+	type tagsResult struct {
+		TagDescriptions []elbTagDescriptionItem `xml:"TagDescriptions>member"`
+	}
+	type response struct {
+		XMLName xml.Name   `xml:"DescribeTagsResponse"`
+		XMLNS   string     `xml:"xmlns,attr"`
+		Result  tagsResult `xml:"DescribeTagsResult"`
+	}
+	resp := response{XMLNS: elbXMLNS}
+	for _, res := range resolved {
+		resp.Result.TagDescriptions = append(resp.Result.TagDescriptions, elbTagDescriptionItem{
+			ResourceArn: res.arn,
+			Tags:        elbTagItems(res.tags),
+		})
+	}
+	return elbXMLResponse(http.StatusOK, resp)
+}
+
+// elbTagItem is the XML representation of one ELB tag.
+type elbTagItem struct {
+	Key   string `xml:"Key"`
+	Value string `xml:"Value"`
+}
+
+// elbTagDescriptionItem is the XML representation of one resource's tags.
+type elbTagDescriptionItem struct {
+	ResourceArn string       `xml:"ResourceArn"`
+	Tags        []elbTagItem `xml:"Tags>member"`
+}
+
+// elbTagItems renders a tag list for the wire.
+func elbTagItems(tags []ELBTag) []elbTagItem {
+	items := make([]elbTagItem, 0, len(tags))
+	for _, t := range tags {
+		items = append(items, elbTagItem(t))
+	}
+	return items
+}

--- a/emulator/elb_tags_test.go
+++ b/emulator/elb_tags_test.go
@@ -1,0 +1,758 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// elbErrorCode decodes the query-protocol error body ELB answers with and returns its
+// Code. It fails the test if the response was not an error.
+func elbErrorCode(t *testing.T, resp *http.Response) string {
+	t.Helper()
+	var body struct {
+		XMLName xml.Name `xml:"ErrorResponse"`
+		Error   struct {
+			Code    string `xml:"Code"`
+			Message string `xml:"Message"`
+		} `xml:"Error"`
+	}
+	if err := xml.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode elb error body: %v", err)
+	}
+	if body.Error.Code == "" {
+		t.Fatalf("expected an error body, got status %d with no Code", resp.StatusCode)
+	}
+	return body.Error.Code
+}
+
+// elbCreateLB creates a load balancer and returns its ARN.
+func elbCreateLB(t *testing.T, ts *httptest.Server, name string, extra map[string]string) string {
+	t.Helper()
+	params := map[string]string{"Action": "CreateLoadBalancer", "Name": name, "Type": "application"}
+	for k, v := range extra {
+		params[k] = v
+	}
+	resp := elbRequest(t, ts, params)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode, "CreateLoadBalancer %s", name)
+
+	var result struct {
+		Result struct {
+			LoadBalancers []struct {
+				LoadBalancerArn string `xml:"LoadBalancerArn"`
+			} `xml:"LoadBalancers>member"`
+		} `xml:"CreateLoadBalancerResult"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&result))
+	require.Len(t, result.Result.LoadBalancers, 1)
+	return result.Result.LoadBalancers[0].LoadBalancerArn
+}
+
+// elbCreateTG creates a target group and returns its ARN.
+func elbCreateTG(t *testing.T, ts *httptest.Server, name string, extra map[string]string) string {
+	t.Helper()
+	params := map[string]string{"Action": "CreateTargetGroup", "Name": name, "Protocol": "HTTP", "Port": "80"}
+	for k, v := range extra {
+		params[k] = v
+	}
+	resp := elbRequest(t, ts, params)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode, "CreateTargetGroup %s", name)
+
+	var result struct {
+		Result struct {
+			TargetGroups []struct {
+				TargetGroupArn string `xml:"TargetGroupArn"`
+			} `xml:"TargetGroups>member"`
+		} `xml:"CreateTargetGroupResult"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&result))
+	require.Len(t, result.Result.TargetGroups, 1)
+	return result.Result.TargetGroups[0].TargetGroupArn
+}
+
+// elbCreateListener creates a listener on lbARN and returns its ARN.
+func elbCreateListener(t *testing.T, ts *httptest.Server, lbARN, tgARN string, extra map[string]string) string {
+	t.Helper()
+	params := map[string]string{
+		"Action":                                 "CreateListener",
+		"LoadBalancerArn":                        lbARN,
+		"Protocol":                               "HTTP",
+		"Port":                                   "80",
+		"DefaultActions.member.1.Type":           "forward",
+		"DefaultActions.member.1.TargetGroupArn": tgARN,
+	}
+	for k, v := range extra {
+		params[k] = v
+	}
+	resp := elbRequest(t, ts, params)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode, "CreateListener")
+
+	var result struct {
+		Result struct {
+			Listeners []struct {
+				ListenerArn string `xml:"ListenerArn"`
+			} `xml:"Listeners>member"`
+		} `xml:"CreateListenerResult"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&result))
+	require.Len(t, result.Result.Listeners, 1)
+	return result.Result.Listeners[0].ListenerArn
+}
+
+// elbCreateRule creates a rule on listenerARN and returns its ARN.
+func elbCreateRule(t *testing.T, ts *httptest.Server, listenerARN, tgARN string, extra map[string]string) string {
+	t.Helper()
+	params := map[string]string{
+		"Action":                              "CreateRule",
+		"ListenerArn":                         listenerARN,
+		"Priority":                            "10",
+		"Conditions.member.1.Field":           "path-pattern",
+		"Conditions.member.1.Values.member.1": "/api/*",
+		"Actions.member.1.Type":               "forward",
+		"Actions.member.1.TargetGroupArn":     tgARN,
+	}
+	for k, v := range extra {
+		params[k] = v
+	}
+	resp := elbRequest(t, ts, params)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode, "CreateRule")
+
+	var result struct {
+		Result struct {
+			Rules []struct {
+				RuleArn string `xml:"RuleArn"`
+			} `xml:"Rules>member"`
+		} `xml:"CreateRuleResult"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&result))
+	require.Len(t, result.Result.Rules, 1)
+	return result.Result.Rules[0].RuleArn
+}
+
+// elbDescribeTags reads the tags on the named resources, keyed by ARN.
+func elbDescribeTags(t *testing.T, ts *httptest.Server, arns ...string) map[string]map[string]string {
+	t.Helper()
+	params := map[string]string{"Action": "DescribeTags"}
+	for i, arn := range arns {
+		params["ResourceArns.member."+strconv.Itoa(i+1)] = arn
+	}
+	resp := elbRequest(t, ts, params)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode, "DescribeTags")
+
+	var result struct {
+		Result struct {
+			TagDescriptions []struct {
+				ResourceArn string `xml:"ResourceArn"`
+				Tags        []struct {
+					Key   string `xml:"Key"`
+					Value string `xml:"Value"`
+				} `xml:"Tags>member"`
+			} `xml:"TagDescriptions>member"`
+		} `xml:"DescribeTagsResult"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&result))
+
+	out := make(map[string]map[string]string, len(result.Result.TagDescriptions))
+	for _, td := range result.Result.TagDescriptions {
+		tags := make(map[string]string, len(td.Tags))
+		for _, tag := range td.Tags {
+			tags[tag.Key] = tag.Value
+		}
+		out[td.ResourceArn] = tags
+	}
+	return out
+}
+
+func TestELB_AddTags_DescribeTags_RoundTrip(t *testing.T) {
+	ts := newELBTestServer(t)
+	arn := elbCreateLB(t, ts, "tagged-alb", nil)
+
+	resp := elbRequest(t, ts, map[string]string{
+		"Action":                "AddTags",
+		"ResourceArns.member.1": arn,
+		"Tags.member.1.Key":     "env",
+		"Tags.member.1.Value":   "prod",
+		"Tags.member.2.Key":     "team",
+		"Tags.member.2.Value":   "",
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	tags := elbDescribeTags(t, ts, arn)
+	// An empty value is a legal tag, not a terminator: Tag.Value has a documented minimum
+	// length of 0, so "team" must be present rather than having ended the walk.
+	assert.Equal(t, map[string]string{"env": "prod", "team": ""}, tags[arn])
+}
+
+func TestELB_AddTags_UpdatesExistingValue(t *testing.T) {
+	ts := newELBTestServer(t)
+	arn := elbCreateLB(t, ts, "retag-alb", map[string]string{
+		"Tags.member.1.Key":   "env",
+		"Tags.member.1.Value": "dev",
+	})
+
+	resp := elbRequest(t, ts, map[string]string{
+		"Action":                "AddTags",
+		"ResourceArns.member.1": arn,
+		"Tags.member.1.Key":     "env",
+		"Tags.member.1.Value":   "prod",
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// AWS: "If a tag with the same key is already associated with the resource, AddTags
+	// updates its value" — one tag, not two.
+	assert.Equal(t, map[string]string{"env": "prod"}, elbDescribeTags(t, ts, arn)[arn])
+}
+
+func TestELB_AddTags_AcrossSeveralResources(t *testing.T) {
+	ts := newELBTestServer(t)
+	lbARN := elbCreateLB(t, ts, "multi-alb", nil)
+	tgARN := elbCreateTG(t, ts, "multi-tg", nil)
+
+	resp := elbRequest(t, ts, map[string]string{
+		"Action":                "AddTags",
+		"ResourceArns.member.1": lbARN,
+		"ResourceArns.member.2": tgARN,
+		"Tags.member.1.Key":     "owner",
+		"Tags.member.1.Value":   "platform",
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	tags := elbDescribeTags(t, ts, lbARN, tgARN)
+	assert.Equal(t, map[string]string{"owner": "platform"}, tags[lbARN])
+	assert.Equal(t, map[string]string{"owner": "platform"}, tags[tgARN])
+}
+
+// TestELB_AddTags_AppliesNothingWhenOneARNIsUnknown pins the resolve-everything pre-pass:
+// a request naming one good and one absent resource must leave the good one untouched.
+func TestELB_AddTags_AppliesNothingWhenOneARNIsUnknown(t *testing.T) {
+	ts := newELBTestServer(t)
+	arn := elbCreateLB(t, ts, "atomic-alb", nil)
+
+	resp := elbRequest(t, ts, map[string]string{
+		"Action":                "AddTags",
+		"ResourceArns.member.1": arn,
+		"ResourceArns.member.2": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/ghost/0abcdef",
+		"Tags.member.1.Key":     "env",
+		"Tags.member.1.Value":   "prod",
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "LoadBalancerNotFound", elbErrorCode(t, resp))
+
+	assert.Empty(t, elbDescribeTags(t, ts, arn)[arn], "the resolvable resource must be untouched")
+}
+
+func TestELB_AddTags_Errors(t *testing.T) {
+	ts := newELBTestServer(t)
+	lbARN := elbCreateLB(t, ts, "err-alb", nil)
+
+	longKey := strings.Repeat("k", 129)
+	longValue := strings.Repeat("v", 257)
+
+	tests := []struct {
+		name   string
+		params map[string]string
+		code   string
+	}{
+		{
+			name:   "no ResourceArns",
+			params: map[string]string{"Tags.member.1.Key": "env"},
+			code:   "ValidationError",
+		},
+		{
+			name:   "no Tags",
+			params: map[string]string{"ResourceArns.member.1": lbARN},
+			code:   "ValidationError",
+		},
+		{
+			name: "duplicate key",
+			params: map[string]string{
+				"ResourceArns.member.1": lbARN,
+				"Tags.member.1.Key":     "env", "Tags.member.1.Value": "a",
+				"Tags.member.2.Key": "env", "Tags.member.2.Value": "b",
+			},
+			code: "DuplicateTagKeys",
+		},
+		{
+			name: "key over 128 characters",
+			params: map[string]string{
+				"ResourceArns.member.1": lbARN,
+				"Tags.member.1.Key":     longKey, "Tags.member.1.Value": "v",
+			},
+			code: "ValidationError",
+		},
+		{
+			name: "value over 256 characters",
+			params: map[string]string{
+				"ResourceArns.member.1": lbARN,
+				"Tags.member.1.Key":     "env", "Tags.member.1.Value": longValue,
+			},
+			code: "ValidationError",
+		},
+		{
+			name: "key outside the permitted character set",
+			params: map[string]string{
+				"ResourceArns.member.1": lbARN,
+				"Tags.member.1.Key":     "env!", "Tags.member.1.Value": "v",
+			},
+			code: "ValidationError",
+		},
+		{
+			name: "value outside the permitted character set",
+			params: map[string]string{
+				"ResourceArns.member.1": lbARN,
+				"Tags.member.1.Key":     "env", "Tags.member.1.Value": "pr#od",
+			},
+			code: "ValidationError",
+		},
+		{
+			name: "ARN naming no ELB resource type",
+			params: map[string]string{
+				"ResourceArns.member.1": "arn:aws:s3:::my-bucket",
+				"Tags.member.1.Key":     "env", "Tags.member.1.Value": "v",
+			},
+			code: "ValidationError",
+		},
+		{
+			name: "absent load balancer",
+			params: map[string]string{
+				"ResourceArns.member.1": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/nope/0aaaaaaa",
+				"Tags.member.1.Key":     "env", "Tags.member.1.Value": "v",
+			},
+			code: "LoadBalancerNotFound",
+		},
+		{
+			name: "absent target group",
+			params: map[string]string{
+				"ResourceArns.member.1": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/nope/0aaaaaaa",
+				"Tags.member.1.Key":     "env", "Tags.member.1.Value": "v",
+			},
+			code: "TargetGroupNotFound",
+		},
+		{
+			name: "absent listener",
+			params: map[string]string{
+				"ResourceArns.member.1": lbARN + "/listener/0aaaaaaa",
+				"Tags.member.1.Key":     "env", "Tags.member.1.Value": "v",
+			},
+			code: "ListenerNotFound",
+		},
+		{
+			name: "absent rule",
+			params: map[string]string{
+				"ResourceArns.member.1": lbARN + "/listener/0aaaaaaa/rule/0bbbbbbb",
+				"Tags.member.1.Key":     "env", "Tags.member.1.Value": "v",
+			},
+			code: "RuleNotFound",
+		},
+		{
+			name: "absent listener under AWS's own flat ARN shape",
+			params: map[string]string{
+				"ResourceArns.member.1": "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/nope/0aaaaaaa/0bbbbbbb",
+				"Tags.member.1.Key":     "env", "Tags.member.1.Value": "v",
+			},
+			code: "ListenerNotFound",
+		},
+		{
+			name: "absent rule under AWS's own flat ARN shape",
+			params: map[string]string{
+				"ResourceArns.member.1": "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener-rule/app/nope/0aaaaaaa/0bbbbbbb/0ccccccc",
+				"Tags.member.1.Key":     "env", "Tags.member.1.Value": "v",
+			},
+			code: "RuleNotFound",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := map[string]string{"Action": "AddTags"}
+			for k, v := range tt.params {
+				params[k] = v
+			}
+			resp := elbRequest(t, ts, params)
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			assert.Equal(t, tt.code, elbErrorCode(t, resp))
+		})
+	}
+}
+
+func TestELB_AddTags_TooManyTags(t *testing.T) {
+	ts := newELBTestServer(t)
+	arn := elbCreateLB(t, ts, "limit-alb", nil)
+
+	params := map[string]string{"Action": "AddTags", "ResourceArns.member.1": arn}
+	for i := 1; i <= 51; i++ {
+		params["Tags.member."+strconv.Itoa(i)+".Key"] = "k" + strconv.Itoa(i)
+		params["Tags.member."+strconv.Itoa(i)+".Value"] = "v"
+	}
+	resp := elbRequest(t, ts, params)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "TooManyTags", elbErrorCode(t, resp))
+}
+
+// TestELB_AddTags_ReservedPrefixDoesNotCountAgainstTheLimit pins the exclusion the ELB
+// restrictions publish — "Tags with this prefix do not count against your tags per resource
+// limit" — and the deliberate absence of a refusal for the prefix itself.
+func TestELB_AddTags_ReservedPrefixDoesNotCountAgainstTheLimit(t *testing.T) {
+	ts := newELBTestServer(t)
+	arn := elbCreateLB(t, ts, "reserved-alb", nil)
+
+	params := map[string]string{"Action": "AddTags", "ResourceArns.member.1": arn}
+	for i := 1; i <= 50; i++ {
+		params["Tags.member."+strconv.Itoa(i)+".Key"] = "k" + strconv.Itoa(i)
+		params["Tags.member."+strconv.Itoa(i)+".Value"] = "v"
+	}
+	params["Tags.member.51.Key"] = "aws:cloudformation:stack-name"
+	params["Tags.member.51.Value"] = "my-stack"
+
+	resp := elbRequest(t, ts, params)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode, "50 user tags plus one aws: tag is within the limit")
+
+	tags := elbDescribeTags(t, ts, arn)[arn]
+	assert.Len(t, tags, 51)
+	assert.Equal(t, "my-stack", tags["aws:cloudformation:stack-name"])
+}
+
+// TestELB_AddTags_ReTaggingAtTheLimitSucceeds pins that the count is over the post-merge key
+// set: a resource already holding 50 tags accepts a new value for one of them.
+func TestELB_AddTags_ReTaggingAtTheLimitSucceeds(t *testing.T) {
+	ts := newELBTestServer(t)
+	arn := elbCreateLB(t, ts, "full-alb", nil)
+
+	params := map[string]string{"Action": "AddTags", "ResourceArns.member.1": arn}
+	for i := 1; i <= 50; i++ {
+		params["Tags.member."+strconv.Itoa(i)+".Key"] = "k" + strconv.Itoa(i)
+		params["Tags.member."+strconv.Itoa(i)+".Value"] = "v"
+	}
+	first := elbRequest(t, ts, params)
+	defer first.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, first.StatusCode)
+
+	resp := elbRequest(t, ts, map[string]string{
+		"Action":                "AddTags",
+		"ResourceArns.member.1": arn,
+		"Tags.member.1.Key":     "k7",
+		"Tags.member.1.Value":   "changed",
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "changed", elbDescribeTags(t, ts, arn)[arn]["k7"])
+}
+
+func TestELB_RemoveTags(t *testing.T) {
+	ts := newELBTestServer(t)
+	arn := elbCreateLB(t, ts, "untag-alb", map[string]string{
+		"Tags.member.1.Key": "env", "Tags.member.1.Value": "prod",
+		"Tags.member.2.Key": "team", "Tags.member.2.Value": "platform",
+	})
+
+	resp := elbRequest(t, ts, map[string]string{
+		"Action":                "RemoveTags",
+		"ResourceArns.member.1": arn,
+		"TagKeys.member.1":      "env",
+		// A key that is not present is silently ignored: RemoveTags publishes no error
+		// for one.
+		"TagKeys.member.2": "absent",
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	assert.Equal(t, map[string]string{"team": "platform"}, elbDescribeTags(t, ts, arn)[arn])
+}
+
+func TestELB_RemoveTags_Errors(t *testing.T) {
+	ts := newELBTestServer(t)
+	arn := elbCreateLB(t, ts, "untag-err-alb", nil)
+
+	tests := []struct {
+		name   string
+		params map[string]string
+		code   string
+	}{
+		{
+			name:   "no ResourceArns",
+			params: map[string]string{"TagKeys.member.1": "env"},
+			code:   "ValidationError",
+		},
+		{
+			name:   "no TagKeys",
+			params: map[string]string{"ResourceArns.member.1": arn},
+			code:   "ValidationError",
+		},
+		{
+			name: "key outside the permitted character set",
+			params: map[string]string{
+				"ResourceArns.member.1": arn,
+				"TagKeys.member.1":      "env!",
+			},
+			code: "ValidationError",
+		},
+		{
+			name: "absent load balancer",
+			params: map[string]string{
+				"ResourceArns.member.1": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/nope/0aaaaaaa",
+				"TagKeys.member.1":      "env",
+			},
+			code: "LoadBalancerNotFound",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := map[string]string{"Action": "RemoveTags"}
+			for k, v := range tt.params {
+				params[k] = v
+			}
+			resp := elbRequest(t, ts, params)
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			assert.Equal(t, tt.code, elbErrorCode(t, resp))
+		})
+	}
+}
+
+// TestELB_RemoveTags_RefusesMoreThan128Keys pins the operation's own array-member maximum,
+// which is a per-request cap and not the per-resource tag limit.
+func TestELB_RemoveTags_RefusesMoreThan128Keys(t *testing.T) {
+	ts := newELBTestServer(t)
+	arn := elbCreateLB(t, ts, "many-keys-alb", nil)
+
+	params := map[string]string{"Action": "RemoveTags", "ResourceArns.member.1": arn}
+	for i := 1; i <= 129; i++ {
+		params["TagKeys.member."+strconv.Itoa(i)] = "k" + strconv.Itoa(i)
+	}
+	resp := elbRequest(t, ts, params)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "ValidationError", elbErrorCode(t, resp))
+}
+
+// TestELB_RemoveTags_DuplicateKeyIsNotRefused pins the per-operation error set:
+// DuplicateTagKeys is listed on AddTags and not on RemoveTags, so naming a key twice
+// removes it once rather than being refused.
+func TestELB_RemoveTags_DuplicateKeyIsNotRefused(t *testing.T) {
+	ts := newELBTestServer(t)
+	arn := elbCreateLB(t, ts, "dup-remove-alb", map[string]string{
+		"Tags.member.1.Key": "env", "Tags.member.1.Value": "prod",
+	})
+
+	resp := elbRequest(t, ts, map[string]string{
+		"Action":                "RemoveTags",
+		"ResourceArns.member.1": arn,
+		"TagKeys.member.1":      "env",
+		"TagKeys.member.2":      "env",
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, elbDescribeTags(t, ts, arn)[arn])
+}
+
+// TestELB_DescribeTags_ReportsAnUntaggedResource pins that a resource with no tags is still
+// reported: omitting it would make "no tags" indistinguishable from "no such resource".
+func TestELB_DescribeTags_ReportsAnUntaggedResource(t *testing.T) {
+	ts := newELBTestServer(t)
+	arn := elbCreateLB(t, ts, "bare-alb", nil)
+
+	tags := elbDescribeTags(t, ts, arn)
+	require.Contains(t, tags, arn)
+	assert.Empty(t, tags[arn])
+}
+
+func TestELB_DescribeTags_Errors(t *testing.T) {
+	ts := newELBTestServer(t)
+	arn := elbCreateLB(t, ts, "desc-tags-alb", nil)
+
+	t.Run("no ResourceArns", func(t *testing.T) {
+		resp := elbRequest(t, ts, map[string]string{"Action": "DescribeTags"})
+		defer resp.Body.Close() //nolint:errcheck
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.Equal(t, "ValidationError", elbErrorCode(t, resp))
+	})
+
+	// The operation's ResourceArns carries "Array Members: Maximum number of 20 items",
+	// which AddTags and RemoveTags do not.
+	t.Run("more than 20 resources", func(t *testing.T) {
+		params := map[string]string{"Action": "DescribeTags"}
+		for i := 1; i <= 21; i++ {
+			params["ResourceArns.member."+strconv.Itoa(i)] = arn
+		}
+		resp := elbRequest(t, ts, params)
+		defer resp.Body.Close() //nolint:errcheck
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.Equal(t, "ValidationError", elbErrorCode(t, resp))
+	})
+
+	t.Run("absent target group", func(t *testing.T) {
+		resp := elbRequest(t, ts, map[string]string{
+			"Action":                "DescribeTags",
+			"ResourceArns.member.1": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/nope/0aaaaaaa",
+		})
+		defer resp.Body.Close() //nolint:errcheck
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.Equal(t, "TargetGroupNotFound", elbErrorCode(t, resp))
+	})
+}
+
+// TestELB_CreatesPersistTags walks the four creates that accept Tags.member.N and asserts
+// each one stored what it was given — the gap #748 opened with, where every create silently
+// dropped its tags.
+func TestELB_CreatesPersistTags(t *testing.T) {
+	ts := newELBTestServer(t)
+	tagged := map[string]string{
+		"Tags.member.1.Key": "env", "Tags.member.1.Value": "prod",
+	}
+
+	lbARN := elbCreateLB(t, ts, "create-tags-alb", tagged)
+	tgARN := elbCreateTG(t, ts, "create-tags-tg", tagged)
+	listenerARN := elbCreateListener(t, ts, lbARN, tgARN, tagged)
+	ruleARN := elbCreateRule(t, ts, listenerARN, tgARN, tagged)
+
+	for _, arn := range []string{lbARN, tgARN, listenerARN, ruleARN} {
+		assert.Equal(t, map[string]string{"env": "prod"}, elbDescribeTags(t, ts, arn)[arn], arn)
+	}
+}
+
+// TestELB_CreateLoadBalancer_DuplicateTagKeys pins the one create of the four that publishes
+// DuplicateTagKeys.
+func TestELB_CreateLoadBalancer_DuplicateTagKeys(t *testing.T) {
+	ts := newELBTestServer(t)
+	resp := elbRequest(t, ts, map[string]string{
+		"Action": "CreateLoadBalancer", "Name": "dup-alb", "Type": "application",
+		"Tags.member.1.Key": "env", "Tags.member.1.Value": "a",
+		"Tags.member.2.Key": "env", "Tags.member.2.Value": "b",
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "DuplicateTagKeys", elbErrorCode(t, resp))
+
+	// The refusal happens before the record is written, so no load balancer is left behind
+	// carrying a tag set the request was refused for.
+	descResp := elbRequest(t, ts, map[string]string{"Action": "DescribeLoadBalancers"})
+	defer descResp.Body.Close() //nolint:errcheck
+	var result struct {
+		Result struct {
+			LoadBalancers []struct{} `xml:"LoadBalancers>member"`
+		} `xml:"DescribeLoadBalancersResult"`
+	}
+	require.NoError(t, xml.NewDecoder(descResp.Body).Decode(&result))
+	assert.Empty(t, result.Result.LoadBalancers)
+}
+
+// TestELB_OtherCreates_DuplicateTagKeysResolvesLastWins is the other half: the API reference
+// lists DuplicateTagKeys on CreateLoadBalancer and on none of the other three creates, so
+// substrate does not invent it there — the duplicate resolves last-wins instead.
+func TestELB_OtherCreates_DuplicateTagKeysResolvesLastWins(t *testing.T) {
+	ts := newELBTestServer(t)
+	dup := map[string]string{
+		"Tags.member.1.Key": "env", "Tags.member.1.Value": "first",
+		"Tags.member.2.Key": "env", "Tags.member.2.Value": "second",
+	}
+
+	lbARN := elbCreateLB(t, ts, "lastwins-alb", nil)
+	tgARN := elbCreateTG(t, ts, "lastwins-tg", dup)
+	listenerARN := elbCreateListener(t, ts, lbARN, tgARN, dup)
+	ruleARN := elbCreateRule(t, ts, listenerARN, tgARN, dup)
+
+	for _, arn := range []string{tgARN, listenerARN, ruleARN} {
+		assert.Equal(t, map[string]string{"env": "second"}, elbDescribeTags(t, ts, arn)[arn], arn)
+	}
+}
+
+// TestELB_CreateTargetGroup_TooManyTags pins TooManyTags on a create, which all four
+// publish, and the rollback: a refused create leaves nothing behind.
+func TestELB_CreateTargetGroup_TooManyTags(t *testing.T) {
+	ts := newELBTestServer(t)
+	params := map[string]string{
+		"Action": "CreateTargetGroup", "Name": "over-limit-tg", "Protocol": "HTTP", "Port": "80",
+	}
+	for i := 1; i <= 51; i++ {
+		params["Tags.member."+strconv.Itoa(i)+".Key"] = "k" + strconv.Itoa(i)
+		params["Tags.member."+strconv.Itoa(i)+".Value"] = "v"
+	}
+	resp := elbRequest(t, ts, params)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "TooManyTags", elbErrorCode(t, resp))
+
+	descResp := elbRequest(t, ts, map[string]string{"Action": "DescribeTargetGroups"})
+	defer descResp.Body.Close() //nolint:errcheck
+	var result struct {
+		Result struct {
+			TargetGroups []struct{} `xml:"TargetGroups>member"`
+		} `xml:"DescribeTargetGroupsResult"`
+	}
+	require.NoError(t, xml.NewDecoder(descResp.Body).Decode(&result))
+	assert.Empty(t, result.Result.TargetGroups)
+}
+
+// TestELB_EmptyOutputOperationsCarryTheirResultElement pins the shape every ELBv2 operation
+// whose output has no members must answer with.
+//
+// ELBv2 speaks the Query protocol, where each output shape declares a resultWrapper, and
+// botocore looks that wrapper up by name — so a bare <OperationResponse/> makes the AWS CLI
+// and boto3 raise KeyError instead of reporting success, while a test that reads the XML
+// directly sees nothing wrong. Six of these answered that way before #748, which is exactly
+// why the assertion is on the wire bytes rather than on a decoded struct.
+func TestELB_EmptyOutputOperationsCarryTheirResultElement(t *testing.T) {
+	ts := newELBTestServer(t)
+	lbARN := elbCreateLB(t, ts, "wrapper-lb", nil)
+	tgARN := elbCreateTG(t, ts, "wrapper-tg", nil)
+	listenerARN := elbCreateListener(t, ts, lbARN, tgARN, nil)
+	ruleARN := elbCreateRule(t, ts, listenerARN, tgARN, nil)
+
+	tests := []struct {
+		name   string
+		params map[string]string
+	}{
+		{"AddTags", map[string]string{
+			"Action": "AddTags", "ResourceArns.member.1": lbARN,
+			"Tags.member.1.Key": "env", "Tags.member.1.Value": "prod",
+		}},
+		{"RemoveTags", map[string]string{
+			"Action": "RemoveTags", "ResourceArns.member.1": lbARN, "TagKeys.member.1": "env",
+		}},
+		{"RegisterTargets", map[string]string{
+			"Action": "RegisterTargets", "TargetGroupArn": tgARN,
+			"Targets.member.1.Id": "i-1234567890abcdef0",
+		}},
+		{"DeregisterTargets", map[string]string{
+			"Action": "DeregisterTargets", "TargetGroupArn": tgARN,
+			"Targets.member.1.Id": "i-1234567890abcdef0",
+		}},
+		{"DeleteRule", map[string]string{"Action": "DeleteRule", "RuleArn": ruleARN}},
+		{"DeleteListener", map[string]string{"Action": "DeleteListener", "ListenerArn": listenerARN}},
+		{"DeleteTargetGroup", map[string]string{"Action": "DeleteTargetGroup", "TargetGroupArn": tgARN}},
+		{"DeleteLoadBalancer", map[string]string{
+			"Action": "DeleteLoadBalancer", "LoadBalancerArn": lbARN,
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := elbRequest(t, ts, tt.params)
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.Contains(t, string(body), "<"+tt.name+"Result></"+tt.name+"Result>")
+			assert.Contains(t, string(body), "<"+tt.name+"Response xmlns=")
+		})
+	}
+}

--- a/emulator/elb_types.go
+++ b/emulator/elb_types.go
@@ -96,6 +96,9 @@ type ELBListener struct {
 	// DefaultActions is the list of default actions.
 	DefaultActions []ELBAction `json:"DefaultActions"`
 
+	// Tags holds key-value metadata.
+	Tags []ELBTag `json:"Tags,omitempty"`
+
 	// AccountID is the AWS account that owns the listener.
 	AccountID string `json:"AccountID"`
 
@@ -188,6 +191,9 @@ type ELBRule struct {
 
 	// IsDefault indicates whether this is the default rule.
 	IsDefault bool `json:"IsDefault"`
+
+	// Tags holds key-value metadata.
+	Tags []ELBTag `json:"Tags,omitempty"`
 
 	// AccountID is the AWS account that owns the rule.
 	AccountID string `json:"AccountID"`

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -876,3 +876,10 @@ func IAMAccessKeyKeyForTest(accessKeyID string) string { return iamAccessKeyKey(
 func IAMInstanceProfileKeyForTest(accountID, name string) string {
 	return iamInstanceProfileKey(accountID, name)
 }
+
+// ELBTagsByARNForTest wraps elbLoadTagsByARN for external tests, so a test can assert what
+// a create or a tagging call actually persisted rather than re-reading it through
+// DescribeTags — which would let a bug in the reader hide a bug in the writer.
+func ELBTagsByARNForTest(state StateManager, accountID, region, arn string) ([]ELBTag, error) {
+	return elbLoadTagsByARN(state, accountID+"/"+region, arn)
+}


### PR DESCRIPTION
Closes #748

`AddTags`, `RemoveTags` and `DescribeTags` did not exist, and the `Tags.member.N` on each of the four ELBv2 creates was accepted and silently dropped — a `CreateLoadBalancer` carrying tags answered success and produced an untagged load balancer. The `Tags` field was dead on two of the four records and absent from the other two.

All four creates now store what they are given, and the three tagging operations reach all four resource types. Limits are the API model's: keys 1–128, values 0–256, 50 tags per resource with `aws:`-prefixed keys excluded from the count, `DescribeTags` capped at 20 resources and `RemoveTags` at 128 keys. Per-operation error sets are followed rather than unified — `DuplicateTagKeys` on `AddTags` and `CreateLoadBalancer` only, since those are the two operations that publish it.

## Authorization

Every ELB request naming a resource by ARN is now decided against **that ARN**. Previously every ELB request was decided against the literal string `*`, which is not a wildcard on the request side — so an ARN-scoped `Allow` denied every call and an ARN-scoped `Deny` was inert. A request naming several resources is denied unless every one is allowed. Tags are reported under `elasticloadbalancing:ResourceTag/<key>` as well as `aws:ResourceTag/<key>`.

A **tagged** create is authorized twice, against `elasticloadbalancing:AddTags` with `elasticloadbalancing:CreateAction` set to the bare operation name. That is the last of the seven bundled managed-policy condition keys to gain a producer; the census in `docs/services.md` drops to four.

## Provenance correction

The plan claimed `elasticloadbalancing:CreateAction`'s only citable source was AWS's own managed policy shipping inside substrate. That is wrong: the ELB user guide's "Tag your Elastic Load Balancing resources during creation" page documents the key, the second `AddTags` authorization, and the bare operation name as its value. It *is* absent from the guide's own condition-key list, and both Service Authorization Reference pages for ELB render their tables in JavaScript and were unreachable — which is how it came to look otherwise. Docs, CHANGELOG and release notes cite the user guide.

## A second bug, found by the live proof

Six pre-existing operations — `DeleteLoadBalancer`, `DeleteTargetGroup`, `DeleteListener`, `DeleteRule`, `RegisterTargets`, `DeregisterTargets` — answered a bare `<OperationResponse/>` with no result wrapper. ELBv2 is a Query-protocol service whose output shapes all declare a `resultWrapper`, so the AWS CLI raised `KeyError: 'DeleteLoadBalancerResult'` for a call that had already succeeded. Substrate's ELB tests read the response XML directly rather than through an SDK parser, so all six were green. Fixed in one shared place with a test that asserts the wire bytes.

## Verification

- `gofmt`/`go build`/`go vet`/`golangci-lint`: 0 issues
- `make test` passes; coverage emulator **83.5%**, total **82.9%** (baseline 83.4% / 82.9%)
- `make docs-reference-check`, `docs-versions`, `npm --prefix docs run build`, anchor diff: clean
- `go vet`/`go test` under `test/e2e`: pass
- Live AWS CLI proof, fail-before against a `main` build: all three tagging operations answered `InvalidAction` and a tagged create dropped its tags; after, the round trip, the multi-resource describe, `DuplicateTagKeys` and `LoadBalancerNotFound` all answer correctly, and the six empty-output operations no longer crash the CLI.

## Deliberate gaps, named in the docs

- `Names.member.N` on `DescribeLoadBalancers`/`DescribeTargetGroups` is not resolved to an ARN — whether ELB describes support resource-level permissions is on the unreachable pages, and leaving them at `*` cannot invent a grant.
- A key beginning `aws:` is accepted: the restriction is documented, no code for refusing one is.
- Substrate's nested listener/rule ARNs (#774) — the tagging code accepts both shapes and the create pass authorizes against AWS's spelling.