### PR TITLE
chore(release): v0.109.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.109.0] - 2026-08-23
 
 ### Added
 - **Service-linked roles, and with them a producer for `iam:AWSServiceName`** (#747).
@@ -9649,7 +9649,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.108.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.109.0...HEAD
+[v0.109.0]: https://github.com/scttfrdmn/substrate/compare/v0.108.0...v0.109.0
 [v0.108.0]: https://github.com/scttfrdmn/substrate/compare/v0.107.0...v0.108.0
 [v0.107.0]: https://github.com/scttfrdmn/substrate/compare/v0.106.0...v0.107.0
 [v0.106.0]: https://github.com/scttfrdmn/substrate/compare/v0.105.0...v0.106.0


### PR DESCRIPTION
Dates the `## [Unreleased]` section as `## [v0.109.0] - 2026-08-23` and adds the comparison links.

v0.109.0 is the twelve follow-ups v0.107.0 and v0.108.0 created by deliberately leaving work out: #630, #736, #737, #738, #739, #744, #745, #746, #747, #748, #749 and #750, all now closed against milestone v0.109.0.

No code changes.